### PR TITLE
ci: `gcc` is needed on opensuse/leap image

### DIFF
--- a/.github/workflows/bootstrap_with_rancher_test.yaml
+++ b/.github/workflows/bootstrap_with_rancher_test.yaml
@@ -59,7 +59,7 @@ jobs:
       options: --privileged
     steps:
       - name: Install dependencies
-        run: zypper -n in -l qemu-kvm libvirt virt-install curl helm git-core tar make
+        run: zypper -n in -l qemu-kvm libvirt virt-install curl helm git-core tar make gcc
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go


### PR DESCRIPTION
Should fix: https://github.com/rancher-sandbox/os2/runs/6289738991?check_suite_focus=true

On my lab I have to manually install go1.17 and in the CI it's done by the GH actions plugin, but installing go1.17 with zypper forces the installation of gcc... That's why I was unable to see this issue before...