### PR TITLE
ci/e2e: fix worflow ARCH issue and test name

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload YAML
         uses: actions/upload-artifact@v3
         with:
-          name: YAML
+          name: yaml
           path: |
             dist/artifacts/*.yaml
           if-no-files-found: error
@@ -107,6 +107,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ipxe
+      - name: Download YAML
+        uses: actions/download-artifact@v3
+        with:
+          name: yaml
       - name: Download Kernel
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -133,46 +133,45 @@ jobs:
         run: |
           # Execute test
           cd tests && make e2e-bootstrap-node
-      - name: E2E - Clean current build
-        run: |
-          # Backup *ALL* files from current build
-          mkdir -p keep-current-build
-          mv -f rancheros-${GITHUB_SHA::7}-${ARCH}* keep-current-build/
-          # Download the latest *OFFICIAL* version available
-          OS2_ISO=$(curl -s ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/latest \
-                           | awk "/browser_download_url.*-${ARCH}.iso/ { gsub(\"\\\"\",\"\"); print \$2 }")
-          for I in \.iso \.ipxe \.squashfs -kernel -initrd; do URL=${OS2_ISO/\.iso/${I}}; curl -Ls -o ${URL##*/} ${URL}; done
-      - name: E2E - Bootstrap node 2 with latest released build
+      - name: E2E - Bootstrap node 2 with current build
         env:
           VM_INDEX: 2
         run: |
           # Execute test
           cd tests && make e2e-bootstrap-node
-      - name: E2E - Upgrade node 2 (with osImage method)
+      - name: E2E - Upgrade node 2 (with UpgradeChannel method) to latest released build
         env:
-          UPGRADE_TYPE: osImage
-          REPO: quay.io/costoolkit/os2-ci
+          UPGRADE_TYPE: managedOSVersionName
           VM_INDEX: 2
         run: |
-          # This variable is used to upgrade the OS and check the OS version after upgrade
-          export CONTAINER_IMAGE=${REPO}:${GITHUB_SHA::7}-${ARCH}
+          VERSION=$(curl -s ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/latest \
+                    | awk '/tag_name/ { gsub("\"",""); print $2 }')
+          # This variable is used to check the OS version after upgrade
+          export CONTAINER_IMAGE=:${VERSION%,}-${ARCH}
           # Execute test
           cd tests && make e2e-upgrade-node
+      - name: E2E - Clean current build
+        run: |
+          # Remove *ALL* files from current build
+          rm -f rancheros-${GITHUB_SHA::7}-${ARCH}*
+          # Download the latest *OFFICIAL* version available
+          OS2_ISO=$(curl -s ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/latest \
+                    | awk "/browser_download_url.*-${ARCH}.iso/ { gsub(\"\\\"\",\"\"); print \$2 }")
+          for I in \.iso \.ipxe \.squashfs -kernel -initrd; do URL=${OS2_ISO/\.iso/${I}}; curl -Ls -o ${URL##*/} ${URL}; done
       - name: E2E - Bootstrap node 3 with latest released build
         env:
           VM_INDEX: 3
         run: |
           # Execute test
           cd tests && make e2e-bootstrap-node
-      - name: E2E - Upgrade node 3 (with UpgradeChannel method)
+      - name: E2E - Upgrade node 3 (with osImage method) to current build
         env:
-          UPGRADE_TYPE: managedOSVersionName
+          UPGRADE_TYPE: osImage
+          REPO: quay.io/costoolkit/os2-ci
           VM_INDEX: 3
         run: |
-          # Restore upgradechannel yaml file
-          cp -a keep-current-build/rancheros-${GITHUB_SHA::7}-${ARCH}.upgradechannel-${ARCH}.yaml .
-          # This variable is used to check the OS version after upgrade
-          export CONTAINER_IMAGE=:${GITHUB_SHA::7}-${ARCH}
+          # This variable is used to upgrade the OS and check the OS version after upgrade
+          export CONTAINER_IMAGE=${REPO}:${GITHUB_SHA::7}-${ARCH}
           # Execute test
           cd tests && make e2e-upgrade-node
       - name: Upload logs

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -150,12 +150,13 @@ jobs:
           cd tests && make e2e-bootstrap-node
       - name: E2E - Upgrade node 2 (with osImage method)
         env:
-          UPGRADE_TYPE: osimage
+          UPGRADE_TYPE: osImage
           REPO: quay.io/costoolkit/os2-ci
           VM_INDEX: 2
         run: |
-          # Execute test
+          # This variable is used to upgrade the OS and check the OS version after upgrade
           export CONTAINER_IMAGE=${REPO}:${GITHUB_SHA::7}-${ARCH}
+          # Execute test
           cd tests && make e2e-upgrade-node
       - name: E2E - Bootstrap node 3 with latest released build
         env:
@@ -165,11 +166,13 @@ jobs:
           cd tests && make e2e-bootstrap-node
       - name: E2E - Upgrade node 3 (with UpgradeChannel method)
         env:
-          UPGRADE_TYPE: upgradechannel
+          UPGRADE_TYPE: managedOSVersionName
           VM_INDEX: 3
         run: |
           # Restore upgradechannel yaml file
           cp -a keep-current-build/rancheros-${GITHUB_SHA::7}-${ARCH}.upgradechannel-${ARCH}.yaml .
+          # This variable is used to check the OS version after upgrade
+          export CONTAINER_IMAGE=:${GITHUB_SHA::7}-${ARCH}
           # Execute test
           cd tests && make e2e-upgrade-node
       - name: Upload logs

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: Bootstrap RancherOS on a VM with Rancher
+name: Elemental End-To-End tests with Rancher
 
 on:
   push:
@@ -84,6 +84,7 @@ jobs:
         INSTALL_K3S_SKIP_ENABLE: true
         KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        ARCH: amd64
       options: --privileged
     steps:
       - name: Install dependencies
@@ -148,10 +149,9 @@ jobs:
           UPGRADE_TYPE: osimage
           REPO: quay.io/costoolkit/os2-ci
           VM_INDEX: 2
-          ARCH: amd64
         run: |
           # Execute test
-          export CONTAINER_IMAGE=${REPO}:${GITHUB_SHA::7}
+          export CONTAINER_IMAGE=${REPO}:${GITHUB_SHA::7}-${ARCH}
           cd tests && make e2e-upgrade-node
       - name: E2E - Bootstrap node 3 with latest released build
         env:
@@ -163,7 +163,6 @@ jobs:
         env:
           UPGRADE_TYPE: upgradechannel
           VM_INDEX: 3
-          ARCH: amd64
         run: |
           # Restore upgradechannel yaml file
           cp -a keep-current-build/rancheros-${GITHUB_SHA::7}-${ARCH}.upgradechannel-${ARCH}.yaml .

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -105,6 +105,12 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 				out, _ := client.RunSSH("uname -n")
 				return out
 			}, "5m", "5s").Should(ContainSubstring(vmNameRoot))
+
+			// fleet-agent is the last pod that start, wait for it before continuing
+			Eventually(func() string {
+				out, _ := client.RunSSH("kubectl get pod -n cattle-fleet-system -l app=fleet-agent")
+				return out
+			}, "10m", "30s").Should(ContainSubstring("Running"))
 		})
 	})
 })

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -80,7 +80,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 				out, _ := client.RunSSH("eval $(grep -v ^# /usr/lib/os-release) && echo ${VERSION}")
 				out = strings.Trim(out, "\n")
 				return out
-			}, "20m", "30s").Should(Equal(osVersion))
+			}, "30m", "30s").Should(Equal(osVersion))
 		})
 
 		By("Cleaning upgrade orders", func() {


### PR DESCRIPTION
It's not RancherOS nor OS2.

This PR also fix the missing yaml file for UpgradeChannel test.

Verification run: https://github.com/rancher/elemental/actions/runs/2457512116