### PR TITLE
Add Cypress tests into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 /tests/build
 /tests/.vagrant
 /tests/build-box
+/cypress/videos/*
+/cypress/screenshots/*
+/cypress/downloads/*
+/node_modules
+package-lock.json

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,8 @@
+{
+  "experimentalSessionAndOrigin": true,
+  "defaultCommandTimeout": 10000,
+  "testFiles": [
+    "unit_tests/first_connection.spec.ts",
+    "unit_tests/menu.spec.ts"
+  ]
+}

--- a/cypress/integration/unit_tests/first_connection.spec.ts
+++ b/cypress/integration/unit_tests/first_connection.spec.ts
@@ -1,0 +1,18 @@
+import { Elemental } from '~/cypress/support/elemental';
+
+Cypress.config();
+describe('First login on Rancher', () => {
+  const elemental = new Elemental();
+
+  it('Log in and accept terms and conditions', () => {
+    cy.visit('/auth/login');
+    cy.get("span").then($text => {
+      if ($text.text().includes('your first time visiting Rancher')) {
+        elemental.firstLogin();
+      }
+      else {
+        cy.log('Rancher already initialized, no need to handle first login.')
+      }
+    })
+  });
+});

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -1,0 +1,34 @@
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
+import { Elemental } from '../../support/elemental';
+
+Cypress.config();
+describe('Menu testing', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const elemental = new Elemental();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+  });
+
+  it('Check Elemental logo', () => {
+    topLevelMenu.openIfClosed();
+
+    // Elemental's icon should appear in the side menu
+      elemental.elementalIcon().should('exist');
+  });
+  
+  it('Check Elemental menu', () => {
+    topLevelMenu.openIfClosed();
+
+    // Elemental's icon should appear in the side menu
+      elemental.elementalIcon().should('exist');
+
+      // Click on the Elemental's icon
+      elemental.accessElementalMenu(); 
+
+    // Check Elemental's side menu
+    elemental.checkElementalNav();
+  });
+});

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+require('dotenv').config();
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
+module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+  const url = process.env.RANCHER_URL || 'https://localhost:8005';
+
+  config.baseUrl = url.replace(/\/$/, '');
+
+  config.env.username = process.env.RANCHER_USER;
+  config.env.password = process.env.RANCHER_PASSWORD;
+  config.env.cluster = process.env.CLUSTER_NAME;
+  config.env.cache_session = process.env.CACHE_SESSION || false;
+
+  return config;
+};

--- a/cypress/support/elemental.ts
+++ b/cypress/support/elemental.ts
@@ -1,0 +1,38 @@
+export class Elemental {
+
+  firstLogin() {
+    cy.get('input').type(Cypress.env('password'), {log: false});
+    cy.clickButton('Log in with Local User');
+    cy.contains('I agree').click('left');
+    cy.clickButton('Continue');
+    cy.contains("Getting Started", {timeout: 10000});
+  }
+
+  elementalIcon() {
+    return cy.get('.option .icon.group-icon.icon-gear');
+  } 
+
+  // Go into the Elemental Menu
+  accessElementalMenu() {
+    cy.contains('Elemental').click();
+  }
+
+  checkElementalNav() {
+    // Open Advanced accordion
+    cy.get('div.header > i').eq(0).click()
+    cy.get('div.header').contains('Advanced').should('be.visible')
+
+    // Check all listed options once accordion is opened
+    cy.get('li.child.nav-type').should(($lis) => {
+    expect($lis).to.have.length(8);
+    expect($lis.eq(0)).to.contain('Dashboard');
+    expect($lis.eq(1)).to.contain('Machine Registrations');
+    expect($lis.eq(2)).to.contain('Machine Inventories');
+    expect($lis.eq(3)).to.contain('OS Image Upgrades');
+    expect($lis.eq(4)).to.contain('Mach. Inv. Selectors');
+    expect($lis.eq(5)).to.contain('Mach. Inv. Selec. Templates');
+    expect($lis.eq(6)).to.contain('Managed OS Versions');
+    expect($lis.eq(7)).to.contain('Managed OS Version Channels');
+    })      
+  }
+}

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1,0 +1,76 @@
+// Generic functions
+
+// Log into Rancher
+Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = Cypress.env('cache_session')) => {
+  const login = () => {
+    let loginPath
+    loginPath="/v3-public/localProviders/local*";
+    cy.intercept('POST', loginPath).as('loginReq');
+    
+    cy.visit('/auth/login');
+
+    cy.byLabel('Username')
+      .focus()
+      .type(username, {log: false});
+
+    cy.byLabel('Password')
+      .focus()
+      .type(password, {log: false});
+
+    cy.get('button').click();
+    cy.wait('@loginReq');
+    cy.contains("Getting Started", {timeout: 10000}).should('be.visible');
+    } 
+
+  if (cacheSession) {
+    cy.session([username, password], login);
+  } else {
+    login();
+  }
+});
+
+// Search fields by label
+Cypress.Commands.add('byLabel', (label) => {
+  cy.get('.labeled-input').contains(label).siblings('input');
+});
+
+// Search button by label
+Cypress.Commands.add('clickButton', (label) => {
+  cy.get('.btn').contains(label).click();
+});
+
+// Insert a value in a field *BUT* force a clear before!
+Cypress.Commands.add('typeValue', ({label, value, noLabel, log=true}) => {
+  if (noLabel === true) {
+    cy.get(label).focus().clear().type(value, {log: log});
+  } else {
+    cy.byLabel(label).focus().clear().type(value, {log: log});
+  }
+});
+
+// Insert a key/value pair
+Cypress.Commands.add('typeKeyValue', ({key, value}) => {
+  cy.get(key).clear().type(value);
+});
+
+Cypress.Commands.overwrite('type', (originalFn, subject, text, options = {}) => {
+  options.delay = 100;
+
+  return originalFn(subject, text, options);
+});
+
+// Add a delay between command without using cy.wait()
+// https://github.com/cypress-io/cypress/issues/249#issuecomment-443021084
+const COMMAND_DELAY = 1000;
+
+for (const command of ['visit', 'click', 'trigger', 'type', 'clear', 'reload', 'contains']) {
+    Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+        const origVal = originalFn(...args);
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(origVal);
+            }, COMMAND_DELAY);
+        });
+    });
+}; 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,0 +1,27 @@
+import './functions';
+
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  namespace Cypress {
+    interface Chainable {
+      // Functions declared in functions.ts
+      login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
+      byLabel(label: string,): Chainable<Element>;
+      clickButton(label: string,): Chainable<Element>;
+      clickElementalMenu(label: string,): Chainable<Element>;
+      typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
+      typeKeyValue(key: string, value: string,): Chainable<Element>;
+      getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
+    }
+}}
+
+// TODO handle redirection errors better?
+// we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // returning false here prevents Cypress from failing the test
+  if (err.message.includes('navigation guard')) {
+    return false;
+  }
+});
+
+require('cypress-dark');

--- a/cypress/support/toplevelmenu.ts
+++ b/cypress/support/toplevelmenu.ts
@@ -1,0 +1,29 @@
+export class TopLevelMenu {
+  toggle() {
+    cy.get('[data-testid="top-level-menu"]', {timeout: 12000}).click();
+  }
+
+  openIfClosed() {
+    cy.get('body').then((body) => {
+      if (body.find('.menu.raised').length === 0) {
+        this.toggle();
+      }
+    });
+  }
+
+  categories() {
+    cy.get('.side-menu .body .category');
+  }
+
+  links() {
+    cy.get('.side-menu .option');
+  }
+
+  clusters(clusterName: string) {
+    cy.get('.clusters .cluster.selector.option').contains(clusterName).click();
+  }
+
+  localization() {
+    cy.get('.locale-chooser');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "epinio-end-to-end-tests",
+  "version": "1.0.0",
+  "description": "Cypress tests to test the Epinio UI",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/epinio/epinio-end-to-end-tests.git"
+  },
+  "keywords": [],
+  "author": "Epinio team",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/epinio/epinio-end-to-end-tests/issues"
+  },
+  "homepage": "https://github.com/epinio/epinio-end-to-end-tests#readme",
+  "dependencies": {
+    "cypress": "^9.0.0",
+    "cypress-dark": "^1.8.3",
+    "dotenv": "^10.0.0",
+    "typescript": "^4.5.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": [
+      "ESNext",
+      "ESNext.AsyncIterable",
+      "DOM"
+    ],
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true,
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "./*"
+      ],
+      "@/*": [
+        "./*"
+      ]
+    },
+    "types": [
+      "@types/node",
+      "@nuxt/types",
+      "cypress",
+      "cypress-file-upload"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Fix #184 
Fix #185 

This PR adds Cypress tests but they are not configured in the CI yet (https://github.com/rancher/elemental/issues/199).
You can execute the tests only from your laptop with the right environment.

![image](https://user-images.githubusercontent.com/6025636/180219574-145c749b-ea99-41d9-9e79-df3bf904cb4e.png)

Video of the test:
[menu.spec.ts.zip](https://github.com/rancher/elemental/files/9159527/menu.spec.ts.zip)


