### PR TITLE
Improve elemental-operator call

### DIFF
--- a/framework/files/system/oem/99_elemental-operator.yaml
+++ b/framework/files/system/oem/99_elemental-operator.yaml
@@ -1,7 +1,7 @@
 name: "Elemental operator bootstrap"
 stages:
-  network:
+  network.after:
     # run only if on live cd and there is a config file
     - if: '[ -f /run/cos/live_mode ] && [ -f /run/initramfs/live/livecd-cloud-config.yaml ]'
       commands:
-        - elemental-operator register --debug /run/initramfs/live/ 2>&1 | systemd-cat -t elemental
+        - systemd-cat -t elemental elemental-operator register --debug /run/initramfs/live/


### PR DESCRIPTION
This commit makes a better use of systemd-cat and it also
makes elemental-operator to be executed on network.after stage.

There is a race condition while calling `elemental install` in
network stage. This is an attempt to avoid it.

Signed-off-by: David Cassany <dcassany@suse.com>