### PR TITLE
Bump repo for teal packages

### DIFF
--- a/framework/files/etc/luet/luet.yaml
+++ b/framework/files/etc/luet/luet.yaml
@@ -6,7 +6,7 @@ repositories:
     cached: true
     priority: 1
     arch: "amd64"
-    reference: v0.8.14-22-repository.yaml
+    reference: repository.yaml
     verify: false
     urls:
       - "quay.io/costoolkit/releases-teal"


### PR DESCRIPTION
We cant track a fixed repo on github builds as we would be really far
aways from latest elemental packages

This meant that on github builds, where we install elemental from teal repos instead of OBS, we were reaaaally behind the latest packages

Signed-off-by: Itxaka <igarcia@suse.com>