### PR TITLE
Add Cypress tests for Machine Registration

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,6 +3,7 @@
   "defaultCommandTimeout": 10000,
   "testFiles": [
     "unit_tests/first_connection.spec.ts",
-    "unit_tests/menu.spec.ts"
+    "unit_tests/menu.spec.ts",
+    "unit_tests/machine_registration.spec.ts"
   ]
 }

--- a/cypress/integration/unit_tests/machine_registration.spec.ts
+++ b/cypress/integration/unit_tests/machine_registration.spec.ts
@@ -1,0 +1,56 @@
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
+import { Elemental } from '../../support/elemental';
+import cypress from 'cypress';
+
+Cypress.config();
+describe('Machine registration testing', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const elemental = new Elemental();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+
+    // Open the navigation menu
+    topLevelMenu.openIfClosed();
+
+    // Click on the Elemental's icon
+    elemental.accessElementalMenu(); 
+    
+    // Delete all files previously downloaded
+    cy.exec('rm cypress/downloads/*', {failOnNonZeroExit: false});
+
+    // Delete namespace
+    cy.exec('kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml delete ns mynamespace', {failOnNonZeroExit: false});
+    
+    // Delete all existing machine registrations
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('Manage Machine Registrations')) {
+        cy.deleteAllMachReg();
+      };
+    });
+  });
+
+  it('Create machine registration with default options', () => {
+    cy.createMachReg({machRegName: 'default-options-test'});
+  });
+
+  it('Create machine registration in custom namespace', () => {
+    cy.createMachReg({machRegName: 'custom-namespace-test', namespace: 'mynamespace'});
+  });
+
+  it('Create machine registration with labels and annotations', () => {
+    cy.createMachReg({machRegName: 'labels-annotations-test', checkLabels: true, checkAnnotations: true});
+  });
+
+  it.skip('Create machine registration with custom cloud-config', () => {
+      // Cannot be tested yet due to https://github.com/rancher/dashboard/issues/6458
+  });
+
+  it('Delete machine registration', () => {
+    cy.createMachReg({machRegName: 'delete-test'});
+    cy.deleteMachReg({machRegName: 'delete-test'});
+  });
+
+});

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -9,6 +9,8 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   const url = process.env.RANCHER_URL || 'https://localhost:8005';
+  const { isFileExist, findFiles } = require('cy-verify-downloads');
+  on('task', { isFileExist, findFiles })
 
   config.baseUrl = url.replace(/\/$/, '');
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -39,6 +39,18 @@ Cypress.Commands.add('clickButton', (label) => {
   cy.get('.btn').contains(label).click();
 });
 
+// Confirm the delete operation
+Cypress.Commands.add('confirmDelete', () => {
+  cy.get('.card-actions').contains('Delete').click();
+});
+
+// Make sure we are in the desired menu inside a cluster (local by default)
+// You can access submenu by giving submenu name in the array
+// ex:  cy.clickClusterMenu(['Menu', 'Submenu'])
+Cypress.Commands.add('clickNavMenu', (listLabel: string[]) => {
+  listLabel.forEach(label => cy.get('nav').contains(label).click());
+});
+
 // Insert a value in a field *BUT* force a clear before!
 Cypress.Commands.add('typeValue', ({label, value, noLabel, log=true}) => {
   if (noLabel === true) {
@@ -74,3 +86,78 @@ for (const command of ['visit', 'click', 'trigger', 'type', 'clear', 'reload', '
         });
     });
 }; 
+
+// Machine registration functions
+
+// Create a machine registration
+Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', checkLabels=false, checkAnnotations=false}) => {
+  cy.clickNavMenu(["Dashboard"]);
+  cy.clickButton("Create Machine Registration");
+  if (namespace != "fleet-default") {
+    cy.get('div.vs__selected-options').eq(0).click()
+    cy.get('li.vs__dropdown-option').contains('Create a New Namespace').click()
+    cy.get(':nth-child(1) > .labeled-input').type(namespace);
+    cy.focused().tab().tab().type(machRegName);
+  } else {
+    cy.typeValue({label: 'Name', value: machRegName});
+  }
+
+  if (checkLabels) {
+    cy.clickButton('Add Label');
+    cy.contains('.row', 'Labels').within(() => {
+      cy.get('.kv-item.key').type('myLabel1');
+      cy.get('.kv-item.value').type('myLabelValue1');
+    })
+  }
+
+  if (checkAnnotations) {
+    cy.clickButton('Add Annotation')
+    cy.contains('.row', 'Annotations').within(() => {
+      cy.get('.kv-item.key').type('myAnnot1');
+      cy.get('.kv-item.value').type('myAnnotValue1');
+    })
+  }
+
+  cy.clickButton("Create");
+
+  // Make sure the machine registration is created and active
+  cy.contains('.masthead', 'Machine Registration: '+ machRegName + ' Active').should('exist');
+
+  // Check the namespace
+  cy.contains('.masthead', 'Namespace: '+ namespace).should('exist');
+
+  // Make sure there is an URL registration in the Registration URL block
+  cy.contains('.mt-40 > .col', /https:\/\/.*elemental\/registration/);
+
+  // Try to download the registration file and check it
+  cy.clickButton("Download");
+  cy.verifyDownload('generate_iso_image.zip');
+  
+  // Check labels
+  // The field is disabled so we cannot check its content...
+  // It looks like we can use shadow DOM to catch it but too complicated for now
+
+  // Check annotations
+  // Same reason as labels
+
+  // Check Cloud configuration
+  // Cannot be checked yet due to https://github.com/rancher/dashboard/issues/6458
+});
+
+// Delete a machine registration
+Cypress.Commands.add('deleteMachReg', ({machRegName}) => {
+  cy.contains('Machine Registrations').click();
+  cy.contains(machRegName).parent().parent().click();
+  cy.clickButton('Delete');
+  cy.confirmDelete();
+  cy.contains(machRegName).should('not.exist')
+});
+
+// Delete all machine registrations
+Cypress.Commands.add('deleteAllMachReg', () => {  
+  cy.clickButton('Manage Machine Registrations');
+  cy.get('[width="30"] > .checkbox-outer-container').click();
+  cy.clickButton('Delete');
+  cy.confirmDelete();
+  cy.contains('There are no rows to show');
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -8,10 +8,15 @@ declare global {
       login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;
+      confirmDelete(): Chainable<Element>;
+      clickNavMenu(listLabel: string[],): Chainable<Element>;
       clickElementalMenu(label: string,): Chainable<Element>;
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
+      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean): Chainable<Element>;
+      deleteMachReg(machRegName: string): Chainable<Element>;
+      deleteAllMachReg():Chainable<Element>;
     }
 }}
 
@@ -25,3 +30,6 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 });
 
 require('cypress-dark');
+require('cy-verify-downloads').addCustomCommand();
+require('cypress-plugin-tab');
+

--- a/package.json
+++ b/package.json
@@ -21,9 +21,13 @@
   },
   "homepage": "https://github.com/epinio/epinio-end-to-end-tests#readme",
   "dependencies": {
+    "cy-verify-downloads": "^0.1.8",
     "cypress": "^9.0.0",
     "cypress-dark": "^1.8.3",
     "dotenv": "^10.0.0",
     "typescript": "^4.5.2"
+  },
+  "devDependencies": {
+    "cypress-plugin-tab": "^1.0.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@types/node",
       "@nuxt/types",
       "cypress",
+      "cy-verify-downloads",
       "cypress-file-upload"
     ]
   },


### PR DESCRIPTION
Fix #196 

- [x] Write before each to clean resources :heavy_check_mark: 
- [x] Write a function to create machine registration :heavy_check_mark: 
- [x] Test with default options :heavy_check_mark: 
- [x] Test with custom namespace :heavy_check_mark: 
- [x] Test with labels and annotations :heavy_check_mark: 
I can create a machine registration but I cannot check that they appear in the UI because they are with the attribute `disabled`
- [x] Test with custom cloud config ❌
Stuck due to this bug anyway https://github.com/rancher/dashboard/issues/6458
- [x] Delete machine registration (done in the [before each section](https://github.com/rancher/elemental/pull/209/files#diff-ccb1eaaaff414b180bf5b60953380addcd7fa4440bfb2c0a1b9cd7ad4cd005d7R27-R34), don't know if it need a dedicated test though