### PR TITLE
Do not use cdrom provider datasource

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -71,7 +71,7 @@ stages:
     - if: '[ ! -f /oem/userdata ]'
       name: "Pull data from provider"
       datasource:
-        providers: ["cdrom", "gcp", "openstack", "aws", "azure", "hetzner", "packet", "scaleway", "vultr", "digitalocean", "metaldata" ]
+        providers: ["gcp", "openstack", "aws", "azure", "hetzner", "packet", "scaleway", "vultr", "digitalocean", "metaldata" ]
         path: "/oem"
       files:
       - path: /oem/userdata_load

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -63,24 +63,3 @@ stages:
           label: COS_PERSISTENT
         expand_partition:
           size: 0
-  # XXX:
-  # Fetch datasources ONLY when network is present
-  # This prevents network configuration via cloud-init from datasources.
-  # See: https://github.com/rancher-sandbox/cOS-toolkit/issues/1140
-  network:
-    - if: '[ ! -f /oem/userdata ]'
-      name: "Pull data from provider"
-      datasource:
-        providers: ["gcp", "openstack", "aws", "azure", "hetzner", "packet", "scaleway", "vultr", "digitalocean", "metaldata" ]
-        path: "/oem"
-      files:
-      - path: /oem/userdata_load
-    - if: '[ -f /oem/userdata ] && [ -f /oem/userdata_load ]'
-      commands:
-      - elemental cloud-init -s initramfs /oem/userdata
-      - elemental cloud-init -s boot /oem/userdata
-      - rm -rf /oem/userdata_load
-    - if: '[ -f oem/userdata_load ]'
-      name: Clear any userdata leftovers
-      commands:
-      - rm -rf /oem/userdata_load


### PR DESCRIPTION
Avoid the use of 'cdrom' provider for datasource plugin. This provider
opens all available block devices to probe them, however an `lsof` call
shows they are not closed afterwards. This might cause issues if within
the same process we pretend to repartition a disk for installation.

This is a workaround for rancher/elemental-operator#50

Signed-off-by: David Cassany <dcassany@suse.com>