### PR TITLE
build: remove obsolete elemental.install.* options

### DIFF
--- a/iso/grub.cfg
+++ b/iso/grub.cfg
@@ -30,7 +30,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Elemental Teal Install ${version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable elemental.install.automatic=true elemental.install.config_url=/run/initramfs/live/config
+    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
     echo Loading initrd...
     $initrd ($root)/boot/rootfs.xz
 }


### PR DESCRIPTION
**Note:** iPXE boot script generated in `Makefile` will be fixed in PR #201.