### PR TITLE
Push master images to elemental-ci

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: docker-images-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,8 +32,8 @@ jobs:
           images: |
             ${{ env.REPO }}
           tags: |
-            type=semver,pattern=v{{version}}
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
+            type=raw,value=latest
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -34,6 +34,12 @@ jobs:
           tags: |
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
             type=raw,value=latest
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,16 +1,14 @@
-name: Build elemental docker image
+name: Build and push elemental docker image
 
 on:
   push:
     branches:
       - master
-  pull_request:
-
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      REPO: ttl.sh/elemental-ci
+      REPO: quay.io/costoolkit/elemental-ci
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Push the created images from master to the
quay.io/costoolkit/elemental-ci repo to have dev images published so we
can easily build isos from them to test them

Signed-off-by: Itxaka <igarcia@suse.com>