### PR TITLE
Improve service unit file

### DIFF
--- a/framework/files/usr/lib/systemd/system/elemental-system-agent.service
+++ b/framework/files/usr/lib/systemd/system/elemental-system-agent.service
@@ -10,7 +10,9 @@ ConditionPathExists=!/etc/systemd/system/rancher-system-agent.service
 WantedBy=multi-user.target
 
 [Service]
-Type=oneshot
+Type=simple
+Restart=always
+RestartSec=5s
 StandardOutput=journal+console
 StandardError=journal+console
 Environment="CATTLE_AGENT_CONFIG=/etc/rancher/elemental/agent/config.yaml"


### PR DESCRIPTION
oneshot service unit type is not active until the executed cmd ends,
however the system agent is a service and polls for plans in an
infinite loop. A simple type is more appropriate, also adding restart
in case something fails contacting to the management cluster.

Signed-off-by: David Cassany <dcassany@suse.com>