### PR TITLE
Fix rke2 deployments on restart

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -47,6 +47,7 @@ stages:
           /var/lib/wicked
           /var/lib/longhorn
           /var/lib/cni
+          /var/lib/calico
         PERSISTENT_STATE_BIND: "true"
     - if: '[ -f "/run/cos/recovery_mode" ]'
       # omit the persistent partition on recovery mode


### PR DESCRIPTION
calico pods were looking for some data in /var/lib/calico but that is
not a persistent path, so it was failing to start.

Fixes https://github.com/rancher/elemental/issues/218

Signed-off-by: Itxaka <igarcia@suse.com>