### PR TITLE
Pick elemental from the docker image and set grub name

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -49,7 +49,7 @@ RUN echo COMMIT=\"${IMAGE_COMMIT}\" >> /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\" >> /etc/os-release
 RUN echo IMAGE_TAG=\"${IMAGE_TAG}\" >> /etc/os-release
 RUN echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release
-RUN echo GRUB_ENTRY_NAME=\"Elemental ${IMAGE_TAG}\" >> /etc/os-release
+RUN echo GRUB_ENTRY_NAME=\"Elemental\" >> /etc/os-release
 
 # Rebuild initrd to setup dracut with the boot configurations
 RUN mkinitrd && \

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,6 +1,7 @@
 # ARGS go first if used on FROM
 ARG OPERATOR_IMAGE=quay.io/costoolkit/elemental-operator:latest
 ARG SYSTEM_AGENT_IMAGE=rancher/system-agent:v0.2.9
+ARG TOOL_IMAGE=quay.io/costoolkit/elemental-cli:v0.0.15-87f0cb4
 # Binaries and files needed from elemental-toolkit repository
 ARG LUET_VERSION=0.32.5
 FROM quay.io/luet/base:$LUET_VERSION AS framework-build
@@ -10,7 +11,6 @@ SHELL ["/usr/bin/luet", "install", "-y", "--system-target", "/framework"]
 
 RUN utils/k9s
 RUN utils/nerdctl
-RUN toolchain/elemental-cli
 RUN toolchain/cosign
 RUN selinux/rancher
 
@@ -20,6 +20,8 @@ FROM $OPERATOR_IMAGE as elemental-operator
 
 # rancher-system-agent
 FROM $SYSTEM_AGENT_IMAGE as system-agent
+
+FROM $TOOL_IMAGE as elemental-cli
 
 
 # Base os
@@ -31,6 +33,8 @@ COPY --from=framework-build /framework /
 COPY --from=elemental-operator /usr/sbin/elemental-operator /usr/sbin/elemental-operator
 # Copy rancher-system-agent as elemental-system-agent to avoid clashes
 COPY --from=system-agent /usr/bin/rancher-system-agent /usr/sbin/elemental-system-agent
+# Copy elemental
+COPY --from=elemental-cli /usr/bin/elemental /usr/bin/elemental
 
 # Copy local framework files
 COPY framework/cos/ /
@@ -45,6 +49,7 @@ RUN echo COMMIT=\"${IMAGE_COMMIT}\" >> /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\" >> /etc/os-release
 RUN echo IMAGE_TAG=\"${IMAGE_TAG}\" >> /etc/os-release
 RUN echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release
+RUN echo GRUB_ENTRY_NAME=\"Elemental ${IMAGE_TAG}\" >> /etc/os-release
 
 # Rebuild initrd to setup dracut with the boot configurations
 RUN mkinitrd && \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CLOUD_CONFIG_FILE?="iso/config"
 # This are the default images already in the dockerfile but we want to be able to override them
 OPERATOR_IMAGE?=quay.io/costoolkit/elemental-operator:latest
 SYSTEM_AGENT_IMAGE?=rancher/system-agent:v0.2.9
-TOOL_IMAGE?=quay.io/costoolkit/elemental-cli:v0.0.15-f1fabd4
+TOOL_IMAGE?=quay.io/costoolkit/elemental-cli:v0.0.15-87f0cb4
 # Used to know if this is a release or just a normal dev build
 RELEASE_TAG?=false
 
@@ -36,6 +36,7 @@ build:
 		--build-arg IMAGE_REPO=${REPO} \
 		--build-arg OPERATOR_IMAGE=${OPERATOR_IMAGE} \
 		--build-arg SYSTEM_AGENT_IMAGE=${SYSTEM_AGENT_IMAGE} \
+		--build-arg TOOL_IMAGE=${TOOL_IMAGE} \
 		-t ${REPO}:${FINAL_TAG} \
 		.
 


### PR DESCRIPTION
For building the image locally/dev/github ci just use a fixed
elemental-cli image to get the elemental-cli binary instead of having to
wait for elemental-toolkit to publsih the packages so we can easily
change versions and test unpublished versions

Also add the GRUB_ENTRY_NAME to os-release so grub looks nicer

Fixes https://github.com/rancher/elemental/issues/176

Signed-off-by: Itxaka <igarcia@suse.com>