### PR TITLE
Use the new registration binary to register

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,5 +1,6 @@
 # ARGS go first if used on FROM
-ARG OPERATOR_IMAGE=quay.io/costoolkit/elemental-operator:latest
+ARG OPERATOR_IMAGE=quay.io/costoolkit/elemental-operator-ci:latest
+ARG REGISTER_IMAGE=quay.io/costoolkit/elemental-register-ci:latest
 ARG SYSTEM_AGENT_IMAGE=rancher/system-agent:v0.2.9
 ARG TOOL_IMAGE=quay.io/costoolkit/elemental-cli:v0.0.15-87f0cb4
 # Binaries and files needed from elemental-toolkit repository
@@ -18,6 +19,9 @@ RUN selinux/rancher
 # elemental-operator
 FROM $OPERATOR_IMAGE as elemental-operator
 
+# elemental-register
+FROM $REGISTER_IMAGE as elemental-register
+
 # rancher-system-agent
 FROM $SYSTEM_AGENT_IMAGE as system-agent
 
@@ -31,6 +35,8 @@ FROM registry.suse.com/suse/sle-micro-rancher/5.2:latest as default
 COPY --from=framework-build /framework /
 # Copy elemental-operator
 COPY --from=elemental-operator /usr/sbin/elemental-operator /usr/sbin/elemental-operator
+# Copy elemental-register
+COPY --from=elemental-register /usr/sbin/elemental-register /usr/sbin/elemental-register
 # Copy rancher-system-agent as elemental-system-agent to avoid clashes
 COPY --from=system-agent /usr/bin/rancher-system-agent /usr/sbin/elemental-system-agent
 # Copy elemental

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ SUDO?=sudo
 FRAMEWORK_PACKAGES?=meta/cos-light
 CLOUD_CONFIG_FILE?="iso/config"
 # This are the default images already in the dockerfile but we want to be able to override them
-OPERATOR_IMAGE?=quay.io/costoolkit/elemental-operator:latest
+OPERATOR_IMAGE?=quay.io/costoolkit/elemental-operator-ci:latest
+REGISTER_IMAGE?=quay.io/costoolkit/elemental-register-ci:latest
 SYSTEM_AGENT_IMAGE?=rancher/system-agent:v0.2.9
 TOOL_IMAGE?=quay.io/costoolkit/elemental-cli:v0.0.15-87f0cb4
 # Used to know if this is a release or just a normal dev build
@@ -35,6 +36,7 @@ build:
 		--build-arg IMAGE_COMMIT=${GIT_COMMIT} \
 		--build-arg IMAGE_REPO=${REPO} \
 		--build-arg OPERATOR_IMAGE=${OPERATOR_IMAGE} \
+		--build-arg REGISTER_IMAGE=${REGISTER_IMAGE} \
 		--build-arg SYSTEM_AGENT_IMAGE=${SYSTEM_AGENT_IMAGE} \
 		--build-arg TOOL_IMAGE=${TOOL_IMAGE} \
 		-t ${REPO}:${FINAL_TAG} \

--- a/framework/files/system/oem/99_elemental-register.yaml
+++ b/framework/files/system/oem/99_elemental-register.yaml
@@ -4,4 +4,4 @@ stages:
     # run only if on live cd and there is a config file
     - if: '[ -f /run/cos/live_mode ] && [ -f /run/initramfs/live/livecd-cloud-config.yaml ]'
       commands:
-        - systemd-cat -t elemental elemental-operator register --debug /run/initramfs/live/
+        - systemd-cat -t elemental elemental-register --debug /run/initramfs/live/


### PR DESCRIPTION
Also introduce for local docker build the REGISTER_IMAGE to be able to
override the wanted register image.

Alos point the operator and register image to the latest master
published images to be on edge so we can catch any issues on changes for
those.

Signed-off-by: Itxaka <igarcia@suse.com>