### PR TITLE
Do not enable elemental-system-agent.service

### DIFF
--- a/framework/files/etc/systemd/system/multi-user.target.wants/elemental-system-agent.service
+++ b/framework/files/etc/systemd/system/multi-user.target.wants/elemental-system-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/elemental-system-agent.service

--- a/framework/files/system/oem/99_elemental_system_agent.yaml
+++ b/framework/files/system/oem/99_elemental_system_agent.yaml
@@ -1,7 +1,6 @@
 name: "Elemental system agent bootstarp"
 stages:
   network.after:
-    # run only if on live cd and there is a config file
-    - if: '[ ! -f /run/cos/live_mode ] && [ ! -f /etc/systemd/system/rancher-system-agent.service ]'
+    - if: '[ ! -f /etc/systemd/system/rancher-system-agent.service ] && [ ! -f /run/cos/live_mode ] && [! -f /run/cos/recovery_mode ]'
       commands:
         - systemctl start elemental-system-agent.service

--- a/framework/files/system/oem/99_elemental_system_agent.yaml
+++ b/framework/files/system/oem/99_elemental_system_agent.yaml
@@ -1,0 +1,7 @@
+name: "Elemental system agent bootstarp"
+stages:
+  network.after:
+    # run only if on live cd and there is a config file
+    - if: '[ ! -f /run/cos/live_mode ] && [ ! -f /etc/systemd/system/rancher-system-agent.service ]'
+      commands:
+        - systemctl start elemental-system-agent.service

--- a/framework/files/usr/lib/systemd/system/elemental-system-agent.service
+++ b/framework/files/usr/lib/systemd/system/elemental-system-agent.service
@@ -6,9 +6,6 @@ After=network-online.target
 ConditionPathExists=!/run/cos/live_mode
 ConditionPathExists=!/etc/systemd/system/rancher-system-agent.service
 
-[Install]
-WantedBy=multi-user.target
-
 [Service]
 Type=simple
 Restart=always


### PR DESCRIPTION
We should prevent having enabled services within the image unless we are fully confident we want them to be always enabled and running. Having services enabled just for the bootstrap phase is risky IMHO, as this is written within the immutable filesystem, we should only call the service when needed without enabling it.


Signed-off-by: David Cassany <dcassany@suse.com>