### PR TITLE
E2E: add SetTimeout function for slow runner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,6 @@ on:
       - master
     types:
       - completed
-  workflow_dispatch:
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,7 @@ jobs:
     container:
       image: opensuse/leap:latest
       env:
+        TIMEOUT_SCALE: 2
         CLUSTER_NAME: cluster-k3s
         CLUSTER_NS: fleet-default
         INSTALL_K3S_VERSION: v1.23.9+k3s1

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -27,7 +27,7 @@
 - Rebooting the VM and checking that cluster is still healthy after
 
 **NOTE:** the following tests will be rewrite shortly!
-## upgrade_test.go (2E - Upgrading node)
+## upgrade_test.go (E2E - Upgrading node)
 **Upgrade node by:**
 - Checking if VM name is set
 - Checking if upgrade type is set

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -31,7 +31,7 @@ func checkClusterAgent(client *tools.Client) {
 	Eventually(func() string {
 		out, _ := client.RunSSH("kubectl get pod -n cattle-system -l app=cattle-cluster-agent")
 		return out
-	}, "5m", "30s").Should(ContainSubstring("Running"))
+	}, misc.SetTimeout(5*time.Minute), 30*time.Second).Should(ContainSubstring("Running"))
 }
 
 func checkClusterState() {
@@ -41,10 +41,10 @@ func checkClusterState() {
 			"--namespace", clusterNS, clusterName,
 			"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
 		return clusterStatus
-	}, "5m", "10s").Should(Equal("True"))
+	}, misc.SetTimeout(5*time.Minute), 10*time.Second).Should(Equal("True"))
 
 	// Wait a little bit for the cluster to be in a stable state
-	time.Sleep(2 * time.Minute)
+	time.Sleep(misc.SetTimeout(2 * time.Minute))
 
 	// There should be no 'reason' property set in a clean cluster
 	reason, err := kubectl.Run("get", "cluster",
@@ -120,7 +120,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Eventually(func() string {
 				out, _ := client.RunSSH("uname -n")
 				return out
-			}, "5m", "5s").Should(ContainSubstring(vmNameRoot))
+			}, misc.SetTimeout(5*time.Minute), 5*time.Second).Should(ContainSubstring(vmNameRoot))
 			*/
 
 			// Check agent and cluster state
@@ -134,7 +134,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Wait a little bit for the cluster to be in an unstable state (yes!)
-			time.Sleep(2 * time.Minute)
+			time.Sleep(misc.SetTimeout(2 * time.Minute))
 
 			// Check agent and cluster state
 			checkClusterAgent(client)

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
@@ -55,4 +57,22 @@ func ConfigureiPXE() (int, error) {
 
 	// Returns the number of ipxe files found
 	return len(ipxeScript), nil
+}
+
+func SetTimeout(timeout time.Duration) (time.Duration, error) {
+	s, set := os.LookupEnv("TIMEOUT_SCALE")
+
+	// Only if TIMEOUT_SCALE is set
+	if set {
+		scale, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
+
+		// Return the scaled timeout
+		return timeout * time.Duration(scale), nil
+	}
+
+	// Nothing to do
+	return timeout, nil
 }

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -59,20 +59,22 @@ func ConfigureiPXE() (int, error) {
 	return len(ipxeScript), nil
 }
 
-func SetTimeout(timeout time.Duration) (time.Duration, error) {
+// Don't return error, in the worst case return the initial value
+// Otherwise an additional step will be needed for some commands (like Eventually)
+func SetTimeout(timeout time.Duration) time.Duration {
 	s, set := os.LookupEnv("TIMEOUT_SCALE")
 
 	// Only if TIMEOUT_SCALE is set
 	if set {
 		scale, err := strconv.Atoi(s)
 		if err != nil {
-			return 0, err
+			return timeout
 		}
 
 		// Return the scaled timeout
-		return timeout * time.Duration(scale), nil
+		return timeout * time.Duration(scale)
 	}
 
 	// Nothing to do
-	return timeout, nil
+	return timeout
 }

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	"github.com/rancher/elemental/tests/e2e/helpers/misc"
 )
 
 var _ = Describe("E2E - Install Rancher", Label("install"), func() {
@@ -30,7 +31,7 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 	// Default timeout is too small, so New() cannot be used
 	k := &kubectl.Kubectl{
 		Namespace:    "",
-		PollTimeout:  300 * time.Second,
+		PollTimeout:  misc.SetTimeout(300 * time.Second),
 		PollInterval: 500 * time.Millisecond,
 	}
 
@@ -54,7 +55,7 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Delay few seconds before checking
-			time.Sleep(20 * time.Second)
+			time.Sleep(misc.SetTimeout(20 * time.Second))
 		})
 
 		By("Waiting for K3s to be started", func() {
@@ -178,7 +179,7 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out
-			}, "5m", "5s").Should(ContainSubstring("selector-" + clusterName))
+			}, misc.SetTimeout(5*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + clusterName))
 		})
 
 		By("Adding MachineRegistration", func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -54,7 +54,7 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	k8sVersion = os.Getenv("INSTALL_K8S_VERSION")
+	k8sVersion = os.Getenv("INSTALL_K3S_VERSION")
 	clusterName = os.Getenv("CLUSTER_NAME")
 	clusterNS = os.Getenv("CLUSTER_NS")
 	osImage = os.Getenv("CONTAINER_IMAGE")

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -16,11 +16,13 @@ package e2e_test
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	"github.com/rancher/elemental/tests/e2e/helpers/misc"
 )
 
 var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
@@ -101,7 +103,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 				out, _ := client.RunSSH("eval $(grep -v ^# /usr/lib/os-release) && echo ${VERSION}")
 				out = strings.Trim(out, "\n")
 				return out
-			}, "30m", "30s").Should(Equal(osVersion))
+			}, misc.SetTimeout(30*time.Minute), 30*time.Second).Should(Equal(osVersion))
 		})
 
 		if upgradeType != "manual" {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -89,8 +89,9 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 				Expect(err).To(Not(HaveOccurred()), out)
 				Expect(out).To((ContainSubstring("Upgrade completed")))
 
-				// Simply reboot, no check as an ssh error will be throwned anyway
-				_, _ = client.RunSSH("reboot")
+				// Execute 'reboot' in background, to avoid ssh locking
+				_, err = client.RunSSH("setsid -f reboot")
+				Expect(err).To(Not(HaveOccurred()))
 			})
 		}
 


### PR DESCRIPTION
Our self-hosted runner can be slow sometimes (SSD might be needed!), this PR adds a funciton to increase the timeout easily based on a env variable (`TIMEOUT_SCALE`). Set it to 2, should be enough (but will see after testing).

This PR also fixes small issues.