### PR TITLE
Improve logic for 01_elemental-rootfs.yaml

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -5,6 +5,7 @@ stages:
       commands:
       - |
         if [ ! -e /usr/local/etc/hostname ]; then
+          mkdir -p /usr/local/etc 
           echo rancher-${RANDOM} > /usr/local/etc/hostname
         fi
         ln -sf /usr/local/etc/hostname /etc/hostname


### PR DESCRIPTION
Every time when we want to write configurarion file in /usr/loca/etc
directory has to be checked and created properly.

Otherwise we will see
```
Running stage: initramfs
Executing /system/oem/01_elemental-rootfs.yaml
Applying 'Elemental Rootfs Layout Settings' for stage 'initramfs'. Total stages: 3
Processing stage step ''. ( commands: 1, files: 0, ... )
Command output: sh: line 1: /usr/local/etc/hostname: No such file or directory
Processing stage step 'Persist /etc/machine-id'. ( commands: 1, files: 0, ... )
Command output:
Processing stage step 'Create essential persistent paths'. ( commands: 0, files: >
```

Signed-off-by: Michal Jura <mjura@suse.com>