### PR TITLE
Update upgrade docs

### DIFF
--- a/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/examples/upgrade/managed-os-version-channel-json.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: fleet-default
 spec:
   options:
-    URI: "https://raw.githubusercontent.com/rancher-sandbox/upgradechannel-discovery-test-repo/main/sub/beta.json"
+    URI: "https://raw.githubusercontent.com/rancher-sandbox/upgradechannel-discovery-test-repo/main/several.json"
     Timeout: "1m"
   type: json


### PR DESCRIPTION
- Make them more consistent
 - Mark the different paths in upgrading nodes
 - Explain what the managedosversions are
 - Explain what the managedosversionchannels are
 - Add examples for everything
 - Explain the types of syncers for managedosversions
 - Add the discovery plugin for managedosversionchannels

Signed-off-by: Itxaka <igarcia@suse.com>