### PR TITLE
Copy /etc/resolv.conf from host during upgrade

### DIFF
--- a/framework/files/usr/sbin/suc-upgrade
+++ b/framework/files/usr/sbin/suc-upgrade
@@ -35,5 +35,18 @@ config
 mount --rbind $HOST_DIR/dev /dev
 mount --rbind $HOST_DIR/run /run
 elemental upgrade --system.uri dir:/
+
+# After elemental upgrade we have to also copy
+# /etc/resolv.conf from /host filesystem, otherwise 
+# it will be taken from container context
+mount -o remount,rw /run/initramfs/cos-state
+LOOP_DEV=$(losetup -f)
+losetup $LOOP_DEV /run/initramfs/cos-state/cOS/active.img
+mkdir -p /tmp/cOS
+mount $LOOP_DEV /tmp/cOS
+rsync -av $HOST_DIR/etc/resolv.conf /tmp/cOS/etc/resolv.conf
+umount /tmp/cOS
+losetup -d $LOOP_DEV
+
 nsenter -i -m -t 1 -- reboot
 exit 1


### PR DESCRIPTION
After elemental upgrade we have to also copy /etc/resolv.conf
from /host filesystem, otherwise  it will be taken from
container context.

Fixes https://github.com/orgs/rancher/projects/9