### PR TITLE
Add Cypress tests in the CI

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -1,0 +1,70 @@
+name: Elemental UI End-To-End tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  ui-e2e-tests:
+    runs-on: ui-e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install K3s / Helm / Rancher
+        id: installation
+        env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+          HELM_VERSION: 3.7.0
+          K3S_VERSION: v1.23.9+k3s1
+          DASHBOARD_VERSION: elemental-dev
+        run: |
+          ## Export information
+          ETH_DEV=$(ip route | awk '/default via / { print $5 }')
+          MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
+          export MY_HOSTNAME=$(hostname).prairie.suse.net
+          echo '::set-output name=MY_IP::'${MY_IP}
+          echo '::set-output name=MY_HOSTNAME::'${MY_HOSTNAME}
+          make prepare-ui-e2e-ci
+
+      - name: Start Cypress tests
+        env:
+          BROWSER: chrome
+          CYPRESS_DOCKER: 'cypress/included:9.7.0'
+          RANCHER_PASSWORD: rancherpassword
+          RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
+          RANCHER_USER: admin
+          SPEC: |
+            cypress/integration/unit_tests/first_connection.spec.ts
+            cypress/integration/unit_tests/menu.spec.ts
+            cypress/integration/unit_tests/machine_registration.spec.ts
+
+        run: |
+          make start-cypress-tests
+
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          retention-days: 7
+
+      # Test run video was always captured, so this action uses "always()" condition
+      - name: Upload Cypress videos
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          retention-days: 7
+
+      - name: Delete k3s cluster
+        if: always()
+        run: |
+          make clean-k3s
+
+      - name: Clean all
+        if: always()
+        uses: colpal/actions-clean@v1

--- a/scripts/install_rancher.sh
+++ b/scripts/install_rancher.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+# Add stable Rancher Helm chart repo
+helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+
+# Add stable CertManager Helm chart repo
+helm repo add jetstack https://charts.jetstack.io
+
+# Mandatory! Otherwise Helm repos are not seen...
+helm repo update
+
+# Cert Manager has to be installed before Rancher
+kubectl create namespace cattle-system
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set installCRDs=true \
+  --set extraArgs[0]=--enable-certificate-owner-ref=true \
+  --wait
+
+# Wait for cert-manager deployment to be ready
+kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
+
+# Install Rancher
+helm upgrade --install rancher rancher-latest/rancher \
+  --namespace cattle-system \
+  --create-namespace \
+  --set hostname=${MY_HOSTNAME} \
+  --set bootstrapPassword=rancherpassword \
+  --set "extraEnv[0].name=CATTLE_UI_DASHBOARD_INDEX" \
+  --set "extraEnv[0].value=https://releases.rancher.com/dashboard/${DASHBOARD_VERSION}/index.html" \
+  --set "extraEnv[1].name=CATTLE_UI_OFFLINE_PREFERRED" \
+  --set "extraEnv[1].value=Remote" \
+  --set "extraEnv[2].name=CATTLE_SERVER_URL" \
+  --set "extraEnv[2].value=https://${MY_HOSTNAME}" \
+  --wait
+
+# Wait for rancher deployment to be ready
+kubectl rollout status deployment rancher -n cattle-system --timeout=300s

--- a/scripts/start_cypress_tests.sh
+++ b/scripts/start_cypress_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -evx
+
+# Needed to install Cypress plugins
+npm install
+
+# Start Cypress tests with docker
+docker run -v $PWD:/e2e -w /e2e                  \
+    -e RANCHER_USER=$RANCHER_USER                \
+    -e RANCHER_PASSWORD=$RANCHER_PASSWORD        \
+    -e RANCHER_URL=$RANCHER_URL                  \
+    --add-host host.docker.internal:host-gateway \
+    $CYPRESS_DOCKER                              \
+    -b $BROWSER                                  \
+    -s /e2e/$SPEC


### PR DESCRIPTION
Fix #199 

This PR adds our first Cypress test in the CI, I installed a new self hosted runner within our DC.

Verification run:
https://github.com/rancher/elemental/runs/7991424029?check_suite_focus=true

Bash code will be migrated in Golang in a separate PR.