### PR TITLE
e2e: don't use a container anymore

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,21 +13,17 @@ jobs:
   e2e-tests:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: kvm-host
-    container:
-      image: opensuse/leap:latest
-      env:
-        TIMEOUT_SCALE: 2
-        CLUSTER_NAME: cluster-k3s
-        CLUSTER_NS: fleet-default
-        INSTALL_K3S_VERSION: v1.23.9+k3s1
-        INSTALL_K3S_SKIP_ENABLE: true
-        KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        ARCH: amd64
-      options: --privileged
+    env:
+      TIMEOUT_SCALE: 2
+      CLUSTER_NAME: cluster-k3s
+      CLUSTER_NS: fleet-default
+      INSTALL_K3S_VERSION: v1.23.9+k3s1
+      INSTALL_K3S_SKIP_ENABLE: true
+      K3S_KUBECONFIG_MODE: 0644
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ARCH: amd64
     steps:
-      - name: Install dependencies
-        run: zypper -n in -l qemu-kvm libvirt virt-install curl helm git-core tar make gcc
       - name: Be sure to remove all previous data from worker ♻
         run: rm -rf ./*
       - name: Checkout
@@ -50,7 +46,7 @@ jobs:
           HELM_REPO=$(helm repo list 2>/dev/null | awk '(NR>1) { print $1 }')
           [[ -n "${HELM_REPO}" ]] && helm repo remove ${HELM_REPO} || true
       - name: E2E - Install Rancher
-        run: cd tests && make e2e-install-rancher
+        run: cd tests && HOSTNAME=$(hostname -f) make e2e-install-rancher
       - name: E2E - Bootstrap node 1 with current build
         env:
           VM_INDEX: 1
@@ -64,5 +60,12 @@ jobs:
     if: always()
     needs: e2e-tests
     steps:
-      - name: Release space from worker ♻
-        run: sudo docker system prune -f -a --volumes
+      - name: Remove all from worker ♻
+        run: |
+          # Remove all VMs
+          for I in {1..10}; do
+            for C in destroy undefine; do
+              sudo virsh ${C} node-${I} >/dev/null 2>&1 || true
+            done
+          done
+          /usr/local/bin/k3s-uninstall.sh || true

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -110,7 +110,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		})
 
 		By("Restarting the VM to add it in the cluster", func() {
-			err := exec.Command("virsh", "start", vmName).Run()
+			err := exec.Command("sudo", "virsh", "start", vmName).Run()
 			Expect(err).To(Not(HaveOccurred()))
 		})
 

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -49,9 +49,7 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 		})
 
 		By("Starting K3s", func() {
-			// Start in background
-			// TODO: use something better to start in background, because this code seems to not write k3s.log file...
-			err := exec.Command("/usr/local/bin/k3s", "server", "--snapshotter=native", ">/tmp/k3s.log", "2>&1").Start()
+			err := exec.Command("sudo", "systemctl", "start", "k3s").Run()
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Delay few seconds before checking
@@ -213,7 +211,7 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 
 		By("Starting HTTP server for network installation", func() {
 			// TODO: improve it to run in background!
-			// err := tools.HTTpShare("../..", 8000)
+			// err := tools.HTTPShare("../..", 8000)
 			// Expect(err).To(Not(HaveOccurred()))
 
 			// Use Python for now...
@@ -221,19 +219,14 @@ var _ = Describe("E2E - Install Rancher", Label("install"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		By("Starting libvirtd", func() {
-			cmds := []string{"libvirtd", "virtlogd"}
-			for _, c := range cmds {
-				err := exec.Command(c, "--daemon").Run()
-				Expect(err).To(Not(HaveOccurred()))
-			}
-		})
-
 		By("Starting default network", func() {
-			err := exec.Command("virsh", "net-undefine", "default").Run()
-			Expect(err).To(Not(HaveOccurred()))
+			// Don't check return code, as the default network could be already removed
+			cmds := []string{"net-destroy", "net-undefine"}
+			for _, c := range cmds {
+				_ = exec.Command("sudo", "virsh", c, "default").Run()
+			}
 
-			err = exec.Command("virsh", "net-create", netDefaultFileName).Run()
+			err := exec.Command("sudo", "virsh", "net-create", netDefaultFileName).Run()
 			Expect(err).To(Not(HaveOccurred()))
 		})
 	})

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -7,7 +7,7 @@ VM_NAME=$1
 MAC=$2
 
 # Create VM
-script -e -c "virt-install \
+script -e -c "sudo virt-install \
   --name ${VM_NAME} \
   --os-type Linux \
   --os-variant opensuse-unknown \


### PR DESCRIPTION
The E2E tests can be run directly on the self-hosted runner without using a container. This will speed up (a little) the run but more importantly will simplify the debugging in case of issue.

Verification run on my local lab: https://github.com/ldevulder/elemental/actions/runs/2911667003