### PR TITLE
Make use or purely OBS artifacts to build ISOs

### DIFF
--- a/Dockerfile.iso
+++ b/Dockerfile.iso
@@ -7,7 +7,6 @@ FROM $TOOL_IMAGE as tools
 FROM tools AS default
 WORKDIR /iso
 COPY --from=os / rootfs
-COPY iso/grub.cfg overlay/boot/grub2/grub.cfg
 ARG CLOUD_CONFIG_FILE=iso/config
 COPY $CLOUD_CONFIG_FILE overlay/livecd-cloud-config.yaml
 ARG ELEMENTAL_VERSION=""

--- a/elemental-iso-build
+++ b/elemental-iso-build
@@ -12,7 +12,6 @@ build() {
     cp "$CLOUD_CONFIG_FILE" "$TEMPDIR"/iso/config
   fi
   curl https://raw.githubusercontent.com/rancher/elemental/main/Dockerfile.iso -fsSL -o "$TEMPDIR"/Dockerfile
-  curl https://raw.githubusercontent.com/rancher/elemental/main/iso/grub.cfg -fsSL -o "$TEMPDIR"/iso/grub.cfg
   # Did we copy the custom cloud config? Then no need to download the default one
   if [[ -z "$CLOUD_CONFIG_FILE" ]]; then
     echo "No custom registration set, using default"
@@ -25,7 +24,7 @@ build() {
 
   rm -Rf "$TEMPDIR"
   ISONAME="elemental-$(date "+%FT%TZ")"
-  docker run --rm -v "$PWD":/mnt elemental/iso:latest build-iso -o /mnt --squash-no-compression -n "$ISONAME" --overlay-iso overlay dir:rootfs
+  docker run --rm -v "$PWD":/mnt elemental/iso:latest --config-dir /mnt build-iso -o /mnt --squash-no-compression -n "$ISONAME" --overlay-iso overlay dir:rootfs
   echo "Iso generated at $ISONAME.iso"
 }
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,6 @@
+iso:
+  uefi:
+    - oci:registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-live-grub2-efi-image/5.3
+  image:
+    - oci:registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-live-grub2/5.3
+    - oci:registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-live-grub2-efi-image/5.3


### PR DESCRIPTION
This commit includes a manifest.yaml for `elemental build-iso` command so instead of pulling livecd artifacts from the default community repositories it uses equivalent oci builds in OBS.

Related to #263

Signed-off-by: David Cassany <dcassany@suse.com>