### PR TITLE
network: Enable networkmanager on dockerfile

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -48,6 +48,9 @@ COPY --from=elemental-cli /usr/bin/elemental /usr/bin/elemental
 COPY framework/cos/ /
 COPY framework/files/ /
 
+# Enable services
+RUN systemctl enable NetworkManager
+
 ARG IMAGE_TAG=latest
 ARG IMAGE_COMMIT=""
 ARG IMAGE_REPO=norepo

--- a/framework/files/system/oem/99_networking.yaml
+++ b/framework/files/system/oem/99_networking.yaml
@@ -1,7 +1,0 @@
-name: "Enable NetworkManager"
-stages:
-  initramfs:
-    - name: "Enable NetworkManager"
-      systemctl:
-        enable:
-          - NetworkManager


### PR DESCRIPTION
For github ci we need networkmanager enabled as our base image now ships with networkmanager by default, but its not enabled.

On OBS we already ship a packages that enables/disables services so we only need to enable networkmanager for dev and CI builds by setting it into the dockerfile

Fixes #319 

Signed-off-by: Itxaka <igarcia@suse.com>