### PR TITLE
ci/e2e: re-add upgrade with managedOSVersionName

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -81,6 +81,12 @@ jobs:
           UPGRADE_TYPE: manual
           VM_INDEX: 2
         run: cd tests && make e2e-upgrade-node
+      - name: E2E - Upgrade node 3 (with managedOSVersionName method) to specified Teal version
+        env:
+          IMAGE_VERSION: teal-5.3
+          UPGRADE_TYPE: managedOSVersionName
+          VM_INDEX: 3
+        run: cd tests && make e2e-upgrade-node
       - name: Remove VMs and K3s/RancherManager from worker ♻
         if: always()
         run: |

--- a/examples/upgrade/upgrade-node-selector.yaml
+++ b/examples/upgrade/upgrade-node-selector.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   # Set to the new Elemental version you would like to upgrade to
   osImage: "registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-node-image/5.2:latest"
+  clusterTargets:
+    - clusterName: my-cluster
   nodeSelector:
     matchLabels:
       location: "europe"

--- a/tests/assets/managedOSVersionChannel.yaml
+++ b/tests/assets/managedOSVersionChannel.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: os-versions
+  # The namespace must match the namespace of the cluster
+  # assigned to the clusters.provisioning.cattle.io resource
+  # namespace: fleet-default
+spec:
+  options:
+    URI: http://192.168.122.1:8000/tests/assets/osVersions.json
+    Timeout: 1m
+  type: json

--- a/tests/assets/osVersions.json
+++ b/tests/assets/osVersions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "metadata": {
+      "name": "teal-5.3"
+    },
+    "spec": {
+      "version": "teal-5.3",
+      "type": "container",
+      "metadata": {
+        "upgradeImage": "registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-node-image/5.3:latest"
+      }
+    }
+  },
+  {
+    "metadata": {
+      "name": "teal-5.2"
+    },
+    "spec": {
+      "version": "teal-5.2",
+      "type": "container",
+      "metadata": {
+        "upgradeImage": "registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-node-image/5.2:latest"
+      }
+    }
+  }
+]

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -32,7 +32,7 @@ func checkClusterAgent(client *tools.Client) {
 	Eventually(func() string {
 		out, _ := client.RunSSH("kubectl get pod -n cattle-system -l app=cattle-cluster-agent")
 		return out
-	}, misc.SetTimeout(2*time.Minute), 30*time.Second).Should(ContainSubstring("Running"))
+	}, misc.SetTimeout(3*time.Minute), 10*time.Second).Should(ContainSubstring("Running"))
 }
 
 func checkClusterState() {

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -59,7 +59,7 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out
-			}, misc.SetTimeout(2*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + clusterName))
+			}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + clusterName))
 		})
 
 		By("Adding MachineRegistration", func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -36,15 +36,16 @@ const (
 )
 
 var (
-	k8sVersion  string
-	clusterName string
-	clusterNS   string
-	osImage     string
-	vmName      string
-	upgradeType string
-	arch        string
-	emulateTPM  string
-	vmIndex     int
+	k8sVersion   string
+	clusterName  string
+	clusterNS    string
+	osImage      string
+	vmName       string
+	upgradeType  string
+	arch         string
+	emulateTPM   string
+	imageVersion string
+	vmIndex      int
 )
 
 func FailWithReport(message string, callerSkip ...int) {
@@ -65,6 +66,7 @@ var _ = BeforeSuite(func() {
 	upgradeType = os.Getenv("UPGRADE_TYPE")
 	arch = os.Getenv("ARCH")
 	emulateTPM = os.Getenv("EMULATE_TPM")
+	imageVersion = os.Getenv("IMAGE_VERSION")
 	index, set := os.LookupEnv("VM_INDEX")
 
 	// Only if VM_INDEX is set


### PR DESCRIPTION
This test will also use nodeSelector to restrict the upgrade to a specified node.

Should fix https://github.com/rancher/elemental/issues/298.

Verification run on my lab: https://github.com/ldevulder/elemental/actions/runs/3084596304