### PR TITLE
ci/e2e: add K3s cluster provisioning test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,3 +1,4 @@
+# This workflow calls the master E2E workflow with custom variables
 name: Elemental End-To-End tests with Rancher Manager
 
 on:
@@ -14,118 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: kvm-host
-    env:
-      TIMEOUT_SCALE: 2
-      ARCH: amd64
-      CLUSTER_NAME: cluster-rke2
-      CLUSTER_NS: fleet-default
-      # For K3s installation used to host Rancher Manager
-      INSTALL_K3S_VERSION: v1.23.8+k3s2
-      INSTALL_K3S_SKIP_ENABLE: true
-      K3S_KUBECONFIG_MODE: 0644
-      DASHBOARD_VERSION: latest
-      # For K8s cluster to provision with Rancher Manager
-      K8S_VERSION_TO_PROVISION: v1.23.8+rke2r1
-      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-    steps:
-      - name: Be sure to remove all previous data from worker ♻
-        run: rm -rf ./*
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '~1.18'
-      - name: Download iPXE
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
-          name: ipxe-artifacts
-          # Force the path, this is a security hint!
-          path: ./
-      - name: E2E - Clean local Helm repositories
-        run: |
-          # Clean Helm repo
-          HELM_REPO=$(helm repo list 2>/dev/null | awk '(NR>1) { print $1 }')
-          [[ -n "${HELM_REPO}" ]] && helm repo remove ${HELM_REPO} || true
-      - name: E2E - Install Rancher
-        run: cd tests && HOSTNAME=$(hostname -f) make e2e-install-rancher
-      - name: E2E - Configure Rancher & Libvirt
-        run: cd tests && make e2e-configure-rancher
-      - name: E2E - Bootstrap node 1 with current build (use Emulated TPM)
-        env:
-          EMULATE_TPM: true
-          VM_INDEX: 1
-        run: cd tests && make e2e-bootstrap-node
-      - name: E2E - Upgrade node 1 (with osImage method) to latest build
-        env:
-          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
-          UPGRADE_TYPE: osImage
-          VM_INDEX: 1
-        run: cd tests && make e2e-upgrade-node
-      - name: E2E - Bootstrap node 2 with current build
-        env:
-          VM_INDEX: 2
-        run: cd tests && make e2e-bootstrap-node
-      - name: E2E - Bootstrap node 3 with current build
-        env:
-          VM_INDEX: 3
-        run: cd tests && make e2e-bootstrap-node
-      - name: E2E - Upgrade node 2 (with manual method) to latest build
-        env:
-          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
-          UPGRADE_TYPE: manual
-          VM_INDEX: 2
-        run: cd tests && make e2e-upgrade-node
-      - name: E2E - Upgrade node 3 (with managedOSVersionName method) to specified Teal version
-        env:
-          IMAGE_VERSION: teal-5.3
-          UPGRADE_TYPE: managedOSVersionName
-          VM_INDEX: 3
-        run: cd tests && make e2e-upgrade-node
-      - name: Remove VMs and K3s/RancherManager from worker ♻
-        if: always()
-        run: |
-          # Remove all VMs
-          for I in {1..10}; do
-            for C in destroy undefine; do
-              sudo virsh ${C} node-${I} >/dev/null 2>&1 || true
-            done
-          done
-          # Remove K3s and Rancher Manager
-          /usr/local/bin/k3s-uninstall.sh || true
-      - name: Remove remaining stuff from worker ♻
-        if: always()
-        uses: colpal/actions-clean@v1
-      - name: Send failed status to slack (if needed)
-        if: failure()
-        uses: slackapi/slack-github-action@v1.18.0
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "Workflow build-ci ${{ github.job }}"
-                    },
-                    "accessory": {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": ":github:",
-                         "emoji": true
-                        },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    with:
+      runner: kvm-host
+      cluster_name: cluster-k3s
+      k8s_version_to_provision: v1.23.10+k3s1
+  rke2:
+    uses: ./.github/workflows/master-e2e.yaml
+    with:
+      runner: kvm-host
+      cluster_name: cluster-rke2
+      k8s_version_to_provision: v1.23.10+rke2r1

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -1,0 +1,136 @@
+# This workflow is a reusable one called by other workflows
+name: Elemental End-To-End tests with Rancher Manager (template)
+
+on:
+  workflow_call:
+  # Variables to set when calling this reusable workflow
+    inputs:
+      runner:
+        description: Runner on which to execute tests
+        required: true
+        type: string
+      cluster_name:
+        description: Name of the provisioned cluster
+        required: true
+        type: string
+      k8s_version_to_provision:
+        description: Name and version of installed K8s distribution
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ${{ inputs.runner }}
+    env:
+      TIMEOUT_SCALE: 2
+      ARCH: amd64
+      CLUSTER_NAME: ${{ inputs.cluster_name }}
+      CLUSTER_NS: fleet-default
+      # For K3s installation used to host Rancher Manager
+      INSTALL_K3S_VERSION: v1.23.8+k3s2
+      INSTALL_K3S_SKIP_ENABLE: true
+      K3S_KUBECONFIG_MODE: 0644
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      DASHBOARD_VERSION: latest
+      # For K8s cluster to provision with Rancher Manager
+      K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
+    steps:
+      - name: Be sure to remove all previous data from worker ♻
+        run: rm -rf ./*
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '~1.18'
+      - name: Download iPXE
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          name: ipxe-artifacts
+          # Force the path, this is a security hint!
+          path: ./
+      - name: E2E - Clean local Helm repositories
+        run: |
+          # Clean Helm repo
+          HELM_REPO=$(helm repo list 2>/dev/null | awk '(NR>1) { print $1 }')
+          [[ -n "${HELM_REPO}" ]] && helm repo remove ${HELM_REPO} || true
+      - name: E2E - Install Rancher
+        run: cd tests && HOSTNAME=$(hostname -f) make e2e-install-rancher
+      - name: E2E - Configure Rancher & Libvirt
+        run: cd tests && make e2e-configure-rancher
+      - name: E2E - Bootstrap node 1 with current build (use Emulated TPM)
+        env:
+          EMULATE_TPM: true
+          VM_INDEX: 1
+        run: cd tests && make e2e-bootstrap-node
+      - name: E2E - Upgrade node 1 (with osImage method) to latest build
+        env:
+          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
+          UPGRADE_TYPE: osImage
+          VM_INDEX: 1
+        run: cd tests && make e2e-upgrade-node
+      - name: E2E - Bootstrap node 2 with current build
+        env:
+          VM_INDEX: 2
+        run: cd tests && make e2e-bootstrap-node
+      - name: E2E - Bootstrap node 3 with current build
+        env:
+          VM_INDEX: 3
+        run: cd tests && make e2e-bootstrap-node
+      - name: E2E - Upgrade node 2 (with manual method) to latest build
+        env:
+          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
+          UPGRADE_TYPE: manual
+          VM_INDEX: 2
+        run: cd tests && make e2e-upgrade-node
+      - name: E2E - Upgrade node 3 (with managedOSVersionName method) to specified Teal version
+        env:
+          IMAGE_VERSION: teal-5.3
+          UPGRADE_TYPE: managedOSVersionName
+          VM_INDEX: 3
+        run: cd tests && make e2e-upgrade-node
+      - name: Remove VMs and K3s/RancherManager from worker ♻
+        if: always()
+        run: |
+          # Remove all VMs
+          for I in {1..10}; do
+            for C in destroy undefine; do
+              sudo virsh ${C} node-${I} >/dev/null 2>&1 || true
+            done
+          done
+          # Remove K3s and Rancher Manager
+          /usr/local/bin/k3s-uninstall.sh || true
+      - name: Remove remaining stuff from worker ♻
+        if: always()
+        uses: colpal/actions-clean@v1
+      - name: Send failed status to slack (if needed)
+        if: failure()
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Workflow build-ci ${{ github.job }}"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github:",
+                         "emoji": true
+                        },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -27,6 +27,13 @@ import (
 	"github.com/rancher/elemental/tests/e2e/helpers/misc"
 )
 
+func getClusterVersion(client *tools.Client) string {
+	out, err := client.RunSSH("kubectl version")
+	Expect(err).To(Not(HaveOccurred()))
+
+	return out
+}
+
 func checkClusterAgent(client *tools.Client) {
 	// cluster-agent is the pod that communicates to Rancher, wait for it before continuing
 	Eventually(func() string {
@@ -186,6 +193,12 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			// Check agent and cluster state
 			checkClusterAgent(client)
 			checkClusterState()
+		})
+
+		By("Checking cluster version", func() {
+			// Show cluster version, could be useful for debugging purposes
+			version := getClusterVersion(client)
+			GinkgoWriter.Printf("K8s version:\n%s\n", version)
 		})
 
 		By("Rebooting the VM and checking that cluster is still healthy after", func() {


### PR DESCRIPTION
Provisioning nodes with K3s should also be tested (RKE2 is already).

Should fix https://github.com/rancher/elemental/issues/339.

Verification run: https://github.com/ldevulder/elemental/actions/runs/3098196040\
*NOTE:* a renaming of the jobs have been done, but the verification run hasn't been restarted for this.