### PR TITLE
ci/e2e: fix wrong K3s version

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default
       # For K3s installation used to host Rancher Manager
-      INSTALL_K3S_VERSION: v1.23.10+k3s2
+      INSTALL_K3S_VERSION: v1.23.10+k3s1
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
v1.23.10+k3s1 should be used instead of v1.23.10+k3s2...