### PR TITLE
ci/e2e: use EFI firmware instead of deprecated BIOS

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -121,7 +121,8 @@ jobs:
           # Remove all VMs
           for I in {1..10}; do
             for C in destroy undefine; do
-              sudo virsh ${C} node-${I} >/dev/null 2>&1 || true
+              [[ "${C}" == "undefine" ]] && OPT="--nvram" || unset OPT
+              sudo virsh ${C} ${OPT} node-${I} >/dev/null 2>&1 || true
             done
           done
           # Remove K3s and Rancher Manager

--- a/tests/assets/net-default.xml
+++ b/tests/assets/net-default.xml
@@ -1,4 +1,4 @@
-<network>
+<network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>
   <name>default</name>
   <forward mode='nat'>
     <nat>
@@ -16,4 +16,9 @@
       <bootp file='http://192.168.122.1:8000/install-elemental.ipxe'/>
     </dhcp>
   </ip>
+  <dnsmasq:options>
+    <dnsmasq:option value='dhcp-match=set:efi-http,option:client-arch,16'/>
+    <dnsmasq:option value='dhcp-boot=tag:efi-http,http://192.168.122.1:8000/ipxe.efi'/>
+    <dnsmasq:option value='dhcp-option-force=tag:efi-http,60,HTTPClient'/>
+  </dnsmasq:options>
 </network>

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -5,20 +5,32 @@ set -e -x
 # Variable(s)
 VM_NAME=$1
 MAC=$2
+ARCH=$(uname -m)
+IPXE_BIN=/usr/share/ipxe/ipxe-${ARCH}.efi
+FW=/usr/share/qemu/ovmf-x86_64-4m
 
 # Don't configure TPM if software emulation (EMULATE_TPM=true) is used
 if [[ ${EMULATE_TPM} != "true" ]]; then
   EMULATED_TPM="--tpm emulator,model=tpm-crb,version=2.0"
 fi
 
+# Exit if iPXE binary is not available
+[[ ! -f ${IPXE_BIN} ]] \
+  && echo "File ${IPXE_BIN} not found! Exiting!" >&2 \
+  && exit 1
+
+# Create symlink for iPXE binary
+pushd ../..
+ln -s ${IPXE_BIN} ipxe.efi
+popd
+
 # Create VM
 script -e -c "sudo virt-install \
   --name ${VM_NAME} \
-  --os-type Linux \
   --os-variant opensuse-unknown \
   --virt-type kvm \
   --machine q35 \
-  --boot bios.useserial=on \
+  --boot loader=${FW}-code.bin,loader.readonly=on,loader.secure=off,loader.type=pflash \
   --ram=4096 \
   --vcpus=4 \
   --cpu host \


### PR DESCRIPTION
Should fix https://github.com/rancher/elemental/issues/340.

Verification run: https://github.com/ldevulder/elemental/actions/runs/3150802958 (only one node, my lab is not powerful enough to test the whole stack).