### PR TITLE
elemental-system-agent: delay the service stop of few seconds

### DIFF
--- a/framework/files/usr/lib/systemd/system/elemental-system-agent.service
+++ b/framework/files/usr/lib/systemd/system/elemental-system-agent.service
@@ -15,3 +15,4 @@ StandardError=journal+console
 Environment="CATTLE_AGENT_CONFIG=/etc/rancher/elemental/agent/config.yaml"
 Environment="CATTLE_LOGLEVEL=debug"
 ExecStart=/usr/sbin/elemental-system-agent sentinel
+ExecStop=sleep 10


### PR DESCRIPTION
This is a workaround for #374: when stopping the elemental-system-agent service, we will wait 10 seconds to tear down the service (which will likely be performed by the newly spawned rancher-system-agent). Let's elemental-system-agent have a bit of seconds more to mark completed the rancher-system-agent startup plan.