### PR TITLE
ci/ui: use a different group than the CLI E2E tests

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -7,7 +7,7 @@ on:
     - cron: '0 4 * * *'
 
 concurrency:
-  group: e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: ui-e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
With current version a running UI E2E test will be canceled if a CLI E2E test starts, which is not good and due to a copy/paste error.