### PR TITLE
Fix e2e tests group

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,8 +11,8 @@ on:
       - completed
 
 concurrency:
-  group: e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+  group: e2e-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   k3s:

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -7,7 +7,7 @@ on:
     - cron: '0 4 * * *'
 
 concurrency:
-  group: ui-e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -7,8 +7,8 @@ on:
     - cron: '0 4 * * *'
 
 concurrency:
-  group: e2e-test-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+  group: e2e-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   ui-e2e-tests:


### PR DESCRIPTION
Finally it's better to keep UI+CLI E2E tests in the same group, to avoid weird kill of running/pending tests.

The new behaviour will be this one:
- if nothing is running in the group then the submitted job will be scheduled and started
- if a job is already running then the submitted job will scheduled and set in pending state
- if a job is already running AND if there is already a scheduled test in pending test then the new submitted job will be scheduled, set in pending state and the former pending one will be canceled.
So only a running test and a pending one will be allowed for the same group.

This is mainly to protect the tests in `main` branch, to be able to have E2E CLI tests and UI at the same time. PR should not be too impacted as there is no UI test automatically scheduled, but this will help UI debugging in individual PR.