### PR TITLE
Use a dedicated runner for UI test (spot VM)

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       cluster_name: cluster-k3s
       dashboard_version: elemental-dev
       k8s_version_to_provision: v1.23.10+k3s1
-      runner: elemental-e2e-ci-runner-x86-64-1
+      runner: elemental-e2e-ci-runner-spot-x86-64-1
       start_condition: success
       test_type: ui
       zone: us-central1-a


### PR DESCRIPTION
Fix #398 

Verification run:
https://github.com/rancher/elemental/actions/runs/3198051962
This test failed but for a reason (the sporadic issue I got) external to this PR, we can see that the job was executed on the new runner.

This PR changes the runner used for UI testing, actually it is dedicated to UI.
The instance is configured as a spot instance to save money (153$ per month instead of 311$)