### PR TITLE
Use GCP spot instance for the backend e2e CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-k3s
       dashboard_version: latest
       k8s_version_to_provision: v1.23.10+k3s1
-      runner: elemental-e2e-ci-runner-x86-64-1
+      runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: ${{ github.event.workflow_run.conclusion }}
       test_type: cli
       zone: us-central1-a
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-rke2
       dashboard_version: latest
       k8s_version_to_provision: v1.23.10+rke2r1
-      runner: elemental-e2e-ci-runner-x86-64-1
+      runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: ${{ github.event.workflow_run.conclusion }}
       test_type: cli
       zone: us-central1-a


### PR DESCRIPTION
Same as https://github.com/rancher/elemental/pull/401 but for the backend e2e tests.