### PR TITLE
Add script to inject registration yaml into ISO

### DIFF
--- a/.github/elemental-iso-add-registration
+++ b/.github/elemental-iso-add-registration
@@ -2,8 +2,25 @@
 
 set -e
 
+usage() {
+me=$(basename "$0")
+cat << EOF
+
+usage: 
+   $me REGISTRATION_CONFIG_FILE [ISO_URL]
+
+REGISTRATION_CONFIG_FILE is the yaml file required by elemental-register in
+order to self register against the elemental-operator.
+
+ISO_URL is the URL of an elemental ISO, defaults to community Elemental Teal
+ISO releases if not set. I can also be a local path.
+
+EOF
+}
+
 abort() {
-    >&2 echo "$@"
+    >&2 echo "Error: $@"
+    usage
     exit 1
 }
 


### PR DESCRIPTION
This commit adds a script that downloads the ISO from Dev, Staging or Stable projects and the associated builder image and then injects a given registration yaml file into the ISO.

Results with a new ISO into the current directory.

Fixes #376

Signed-off-by: David Cassany <dcassany@suse.com>