### PR TITLE
ci/e2e: add boot iso and operator upgrade

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -33,10 +33,6 @@ jobs:
       - name: Build iso
         run: |
           make iso
-      - name: Build ipxe artifacts
-        run: |
-          make extract_kernel_init_squash
-          make ipxe
       - name: Upload docker image
         uses: actions/upload-artifact@v3
         with:
@@ -47,15 +43,6 @@ jobs:
         with:
           name: iso-image
           path: build/*.iso
-      - name: Upload iPXE
-        uses: actions/upload-artifact@v3
-        with:
-          name: ipxe-artifacts
-          path: |
-            build/*-kernel
-            build/*-initrd
-            build/*.squashfs
-            build/*.ipxe
       - name: Send failed status to slack (only on schedule)
         if: failure() && github.event_name == 'schedule'
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -23,6 +23,7 @@ jobs:
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator
       zone: us-central1-a
   rke2:
     if: always()
@@ -40,4 +41,5 @@ jobs:
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator
       zone: us-central1-a

--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -17,7 +17,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-k3s
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+k3s1
+      k8s_version_to_provision: v1.24.4+k3s1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -35,7 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-rke2
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+rke2r1
+      k8s_version_to_provision: v1.24.4+rke2r1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -18,8 +18,8 @@ jobs:
       cluster_name: cluster-k3s
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+k3s1
-      rancher_channel: latest
-      rancher_version: 2.6.9-rc6
+      rancher_channel: stable
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
@@ -36,8 +36,8 @@ jobs:
       cluster_name: cluster-rke2
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+rke2r1
-      rancher_channel: latest
-      rancher_version: 2.6.9-rc6
+      rancher_channel: stable
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -17,7 +17,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-k3s
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+k3s1
+      k8s_version_to_provision: v1.24.4+k3s1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -35,7 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-rke2
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+rke2r1
+      k8s_version_to_provision: v1.24.4+rke2r1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -23,6 +23,7 @@ jobs:
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator
       zone: us-central1-a
   rke2:
     if: always()
@@ -40,4 +41,5 @@ jobs:
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator
       zone: us-central1-a

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -18,8 +18,8 @@ jobs:
       cluster_name: cluster-k3s
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+k3s1
-      rancher_channel: latest
-      rancher_version: 2.6.9-rc6
+      rancher_channel: stable
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli
@@ -36,8 +36,8 @@ jobs:
       cluster_name: cluster-rke2
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+rke2r1
-      rancher_channel: latest
-      rancher_version: 2.6.9-rc6
+      rancher_channel: stable
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: success
       test_type: cli

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+k3s1
+      k8s_version_to_provision: v1.24.4+k3s1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -39,7 +39,7 @@ jobs:
     with:
       cluster_name: cluster-rke2
       dashboard_version: latest
-      k8s_version_to_provision: v1.24.6+rke2r1
+      k8s_version_to_provision: v1.24.4+rke2r1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+k3s1
       rancher_channel: stable
-      rancher_version: 2.6.8
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: ${{ github.event.workflow_run.conclusion }}
       test_type: cli
@@ -41,7 +41,7 @@ jobs:
       dashboard_version: latest
       k8s_version_to_provision: v1.24.6+rke2r1
       rancher_channel: stable
-      rancher_version: 2.6.8
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       start_condition: ${{ github.event.workflow_run.conclusion }}
       test_type: cli

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -83,7 +83,7 @@ jobs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default
       # For K3s installation used to host Rancher Manager
-      INSTALL_K3S_VERSION: v1.24.6+k3s1
+      INSTALL_K3S_VERSION: v1.24.4+k3s1
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -45,6 +45,10 @@ on:
         description: Type of test to run (cli or ui)
         required: true
         type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        required: false
+        type: string
       zone:
         description: GCP zone to host the runner
         required: true
@@ -87,6 +91,7 @@ jobs:
       RANCHER_CHANNEL: ${{ inputs.rancher_channel }}
       RANCHER_VERSION: ${{ inputs.rancher_version }}
       DASHBOARD_VERSION: ${{ inputs.dashboard_version }}
+      UPGRADE_OPERATOR: ${{ inputs.upgrade_operator }}
       # For K8s cluster to provision with Rancher Manager
       K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
     steps:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -98,26 +98,38 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '~1.18'
-      - name: Download iPXE (if needed)
+      - name: Download default ISO (if needed)
+        # NOTE: download the *default* ISO, not the one passed as a parameter
         if: ${{ inputs.iso_to_test == '' }}
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ inputs.workflow_download }}
           workflow_conclusion: success
-          name: ipxe-artifacts
+          name: iso-image
           # Force the path, this is a security hint!
           path: ./
-      - name: Extract iPXE data from ISO (if needed)
+      - name: Download specified ISO (if needed)
         if: ${{ inputs.iso_to_test != '' }}
         env:
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
           TAG: from-obs
         run: |
+          curl ${ISO_TO_TEST} -fsSL -o elemental-${TAG}.iso
+      - name: Extract iPXE artifacts from ISO
+        run: |
+          # Extract TAG
+          ISO=$(ls elemental-*.iso 2>/dev/null)
+          TAG=${ISO#*-}
+          export TAG=${TAG%.iso}
+          # Move ISO to build for next step
           mkdir -p build
-          curl ${ISO_TO_TEST} -fsSL -o build/elemental-${TAG}.iso
+          mv -f ${ISO} build/
+          # Extract iPXE artifacts
           make extract_kernel_init_squash
           make ipxe
-          mv build/* .
+          mv -f build/* .
+          # Looks a little bit weird but we have to keep the ISO in build!
+          mv -f elemental-*.iso build/
       - name: Clean local Helm repositories
         if: ${{ inputs.test_type == 'cli' }}
         run: |
@@ -183,7 +195,7 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: ${{ inputs.test_type == 'cli' }}
         run: cd tests && make e2e-configure-rancher
-      - name: Bootstrap node 1 with current build (use Emulated TPM)
+      - name: Bootstrap node 1 with current build (use Emulated TPM and iPXE)
         if: ${{ inputs.test_type == 'cli' }}
         env:
           EMULATE_TPM: true
@@ -196,14 +208,16 @@ jobs:
           UPGRADE_TYPE: osImage
           VM_INDEX: 1
         run: cd tests && make e2e-upgrade-node
-      - name: Bootstrap node 2 with current build
+      - name: Bootstrap node 2 with current build (use ISO)
         if: ${{ inputs.test_type == 'cli' }}
         env:
+          ISO_BOOT: true
           VM_INDEX: 2
         run: cd tests && make e2e-bootstrap-node
-      - name: Bootstrap node 3 with current build
+      - name: Bootstrap node 3 with current build (use ISO)
         if: ${{ inputs.test_type == 'cli' }}
         env:
+          ISO_BOOT: true
           VM_INDEX: 3
         run: cd tests && make e2e-bootstrap-node
       - name: Upgrade node 2 (with manual method) to latest build
@@ -220,12 +234,12 @@ jobs:
           UPGRADE_TYPE: managedOSVersionName
           VM_INDEX: 3
         run: cd tests && make e2e-upgrade-node
-      - name: Bootstrap node 4 with current build
+      - name: Bootstrap node 4 with current build (use iPXE)
         if: ${{ inputs.test_type == 'cli' }}
         env:
           VM_INDEX: 4
         run: cd tests && make e2e-bootstrap-node
-      - name: Bootstrap node 5 with current build
+      - name: Bootstrap node 5 with current build (use iPXE)
         if: ${{ inputs.test_type == 'cli' }}
         env:
           VM_INDEX: 5

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       dashboard_version: elemental-dev
-      k8s_version_to_provision: v1.24.6+k3s1
+      k8s_version_to_provision: v1.24.4+k3s1
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-1

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -18,7 +18,9 @@ jobs:
     with:
       cluster_name: cluster-k3s
       dashboard_version: elemental-dev
-      k8s_version_to_provision: v1.23.10+k3s1
+      k8s_version_to_provision: v1.24.6+k3s1
+      rancher_channel: stable
+      rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-1
       start_condition: success
       test_type: ui

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -162,6 +162,25 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 			k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")
 			Expect(err).To(Not(HaveOccurred()))
+
+			// Check if an upgrade to a specific version is configured
+			if upgradeOperator != "" {
+				err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator", upgradeOperator,
+					"--namespace", "cattle-elemental-system",
+					"--create-namespace",
+				)
+				Expect(err).To(Not(HaveOccurred()))
+
+				k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			// Check elemental-operator version
+			operatorVersion, err := kubectl.Run("get", "pod",
+				"--namespace", "cattle-elemental-system",
+				"-l", "app=elemental-operator", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+			Expect(err).To(Not(HaveOccurred()))
+			GinkgoWriter.Printf("Operator Version:\n%s\n", operatorVersion)
 		})
 	})
 })

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -142,6 +142,13 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 			err = k.WaitForNamespaceWithPod("cattle-system", "app=rancher-webhook")
 			Expect(err).To(Not(HaveOccurred()))
+
+			// Check Rancher version
+			operatorVersion, err := kubectl.Run("get", "pod",
+				"--namespace", "cattle-system",
+				"-l", "app=rancher", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+			Expect(err).To(Not(HaveOccurred()))
+			GinkgoWriter.Printf("Rancher Version:\n%s\n", operatorVersion)
 		})
 
 		By("Installing Elemental Operator", func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -36,18 +36,19 @@ const (
 )
 
 var (
-	k8sVersion     string
+	arch           string
 	clusterName    string
 	clusterNS      string
-	osImage        string
-	vmName         string
-	upgradeType    string
-	arch           string
 	emulateTPM     string
 	imageVersion   string
+	isoBoot        string
+	k8sVersion     string
+	osImage        string
 	rancherChannel string
 	rancherVersion string
+	upgradeType    string
 	vmIndex        int
+	vmName         string
 )
 
 func FailWithReport(message string, callerSkip ...int) {
@@ -61,17 +62,18 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
+	arch = os.Getenv("ARCH")
 	clusterName = os.Getenv("CLUSTER_NAME")
 	clusterNS = os.Getenv("CLUSTER_NS")
-	osImage = os.Getenv("CONTAINER_IMAGE")
-	upgradeType = os.Getenv("UPGRADE_TYPE")
-	arch = os.Getenv("ARCH")
 	emulateTPM = os.Getenv("EMULATE_TPM")
 	imageVersion = os.Getenv("IMAGE_VERSION")
+	index, set := os.LookupEnv("VM_INDEX")
+	isoBoot = os.Getenv("ISO_BOOT")
+	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
+	osImage = os.Getenv("CONTAINER_IMAGE")
 	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
-	index, set := os.LookupEnv("VM_INDEX")
+	upgradeType = os.Getenv("UPGRADE_TYPE")
 
 	// Only if VM_INDEX is set
 	if set {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -36,19 +36,20 @@ const (
 )
 
 var (
-	arch           string
-	clusterName    string
-	clusterNS      string
-	emulateTPM     string
-	imageVersion   string
-	isoBoot        string
-	k8sVersion     string
-	osImage        string
-	rancherChannel string
-	rancherVersion string
-	upgradeType    string
-	vmIndex        int
-	vmName         string
+	arch            string
+	clusterName     string
+	clusterNS       string
+	emulateTPM      string
+	imageVersion    string
+	isoBoot         string
+	k8sVersion      string
+	osImage         string
+	rancherChannel  string
+	rancherVersion  string
+	upgradeType     string
+	upgradeOperator string
+	vmIndex         int
+	vmName          string
 )
 
 func FailWithReport(message string, callerSkip ...int) {
@@ -74,6 +75,7 @@ var _ = BeforeSuite(func() {
 	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
 	upgradeType = os.Getenv("UPGRADE_TYPE")
+	upgradeOperator = os.Getenv("UPGRADE_OPERATOR")
 
 	// Only if VM_INDEX is set
 	if set {

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -14,16 +14,34 @@ if [[ ${EMULATE_TPM} != "true" ]]; then
   EMULATED_TPM="--tpm emulator,model=tpm-crb,version=2.0"
 fi
 
-# Exit if iPXE binary is not available
-[[ ! -f ${IPXE_BIN} ]] \
-  && echo "File ${IPXE_BIN} not found! Exiting!" >&2 \
-  && exit 1
+# iPXE stuff will not be used if ISO is set
+if [[ ${ISO_BOOT} == "true" ]]; then
+  pushd ../..
+  ISO=$(ls ${PWD}/elemental-*.iso 2>/dev/null)
+  popd
 
-# Create symlink for iPXE binary
-pushd ../..
-rm -f ipxe.efi  # Force remove, to avoid issue with 'ln'
-ln -s ${IPXE_BIN} ipxe.efi
-popd
+  # Exit if ISO is not available
+  [[ ! -f ${ISO} ]] \
+    && echo "File ${ISO} not found! Exiting!" >&2 \
+    && exit 1
+
+  # Force ISO boot
+  INSTALL_FLAG="--cdrom ${ISO}"
+else
+  # Exit if iPXE binary is not available
+  [[ ! -f ${IPXE_BIN} ]] \
+    && echo "File ${IPXE_BIN} not found! Exiting!" >&2 \
+    && exit 1
+
+  # Create symlink for iPXE binary
+  pushd ../..
+  rm -f ipxe.efi  # Force remove, to avoid issue with 'ln'
+  ln -s ${IPXE_BIN} ipxe.efi
+  popd
+
+  # Force PXE boot
+  INSTALL_FLAG="--pxe"
+fi
 
 # Create VM
 script -e -c "sudo virt-install \
@@ -43,5 +61,5 @@ script -e -c "sudo virt-install \
   --rng random \
   ${EMULATED_TPM} \
   --noreboot \
-  --pxe \
+  ${INSTALL_FLAG} \
   --network network=default,bridge=virbr0,model=virtio,mac=${MAC}"


### PR DESCRIPTION
Should fix https://github.com/rancher/elemental/issues/147 and https://github.com/rancher/elemental/issues/412.

Verification runs:
- with [OBS artifacts on K3s](https://github.com/ldevulder/elemental/actions/runs/3275150151/jobs/5389624884)
- with [OBS artifacts on RKE2](https://github.com/ldevulder/elemental/actions/runs/3276459166/jobs/5392588725)
- with [GH artifacts on K3s](https://github.com/ldevulder/elemental/actions/runs/3275646007/jobs/5392027192)
- with [GH artifacts on RKE2](https://github.com/ldevulder/elemental/actions/runs/3277034771/jobs/5393798476)

**NOTE:** no UI verification run, as the UI-E2E tests are already broken...