### PR TITLE
ci/e2e: force HTTP1.1 for curl download

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -119,7 +119,7 @@ jobs:
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
           TAG: from-obs
         run: |
-          curl ${ISO_TO_TEST} -fsSL -o elemental-${TAG}.iso
+          curl -fsSL --http1.1 ${ISO_TO_TEST} -o elemental-${TAG}.iso
       - name: Extract iPXE artifacts from ISO
         run: |
           # Extract TAG


### PR DESCRIPTION
This should fix the download issue we see in CI.