### PR TITLE
Use a dedicated group for UI tests

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -7,7 +7,7 @@ on:
     - cron: '0 4 * * *'
 
 concurrency:
-  group: e2e-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: ui-e2e-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Different runner for UI tests so we need to use a different group.