### PR TITLE
ci/e2e: add retry on curl command

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -119,7 +119,7 @@ jobs:
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
           TAG: from-obs
         run: |
-          curl -fsSL \
+          curl -vfsSL \
                --http1.1 \
                --connect-timeout 30 \
                --retry 100 \

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -119,7 +119,12 @@ jobs:
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
           TAG: from-obs
         run: |
-          curl -fsSL --http1.1 ${ISO_TO_TEST} -o elemental-${TAG}.iso
+          curl -fsSL \
+               --http1.1 \
+               --connect-timeout 30 \
+               --retry 100 \
+               --retry-delay 5 \
+               ${ISO_TO_TEST} -o elemental-${TAG}.iso
       - name: Extract iPXE artifacts from ISO
         run: |
           # Extract TAG


### PR DESCRIPTION
To avoid sporadic failure like this one: https://github.com/rancher/elemental/actions/runs/3312488264/jobs/5477683940

Tested locally, I'm not sure that this will fix the issue TBH, but at least there's no regression.