### PR TITLE
Network: Make NM ignore calico and flannel devices

### DIFF
--- a/framework/files/etc/NetworkManager/conf.d/rke2-canal.conf
+++ b/framework/files/etc/NetworkManager/conf.d/rke2-canal.conf
@@ -1,0 +1,5 @@
+# NM can interfere with CNI routes
+# This config makes networkmanager ignore the interfaces for both calico and flannel
+# https://docs.rke2.io/known_issues/#networkmanager
+[keyfile]
+unmanaged-devices=interface-name:cali*;interface-name:flannel*


### PR DESCRIPTION
According to rke2 docs NM can interfere with CNI routing.

This patch adds a config file so NM ignores devices from both calico and flannel

Fixes #446 

Signed-off-by: Itxaka <igarcia@suse.com>