### PR TITLE
ci/e2e: add Private CA test with Rancher Manager

### DIFF
--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -17,6 +17,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.4+k3s1
+      ca_type: selfsigned
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -34,6 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.4+rke2r1
+      ca_type: private
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e-obs-Stable.yaml
+++ b/.github/workflows/e2e-obs-Stable.yaml
@@ -17,6 +17,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.4+k3s1
+      ca_type: selfsigned
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -34,6 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.4+rke2r1
+      ca_type: private
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -17,6 +17,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.4+k3s1
+      ca_type: selfsigned
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -34,6 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.4+rke2r1
+      ca_type: private
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,6 +22,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.4+k3s1
+      ca_type: selfsigned
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2
@@ -38,6 +39,7 @@ jobs:
     with:
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.4+rke2r1
+      ca_type: private
       rancher_channel: stable
       rancher_version: latest
       runner: elemental-e2e-ci-runner-spot-x86-64-2

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -21,6 +21,10 @@ on:
         description: Name and version of installed K8s distribution
         required: true
         type: string
+      ca_type:
+        description: CA type to use (selfsigned or private)
+        required: true
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         required: true
@@ -138,6 +142,8 @@ jobs:
           [[ -n "${HELM_REPO}" ]] && helm repo remove ${HELM_REPO} || true
       - name: Install Rancher
         id: installation
+        env:
+          CA_TYPE: ${{ inputs.ca_type }}
         run: |
           export MY_HOSTNAME=$(hostname -f)
           echo "MY_HOSTNAME=$MY_HOSTNAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '~1.18'
-      - name: Download default ISO (if needed)
+      - name: Download default ISO
         # NOTE: download the *default* ISO, not the one passed as a parameter
         if: ${{ inputs.iso_to_test == '' }}
         uses: dawidd6/action-download-artifact@v2.24.0
@@ -113,7 +113,7 @@ jobs:
           name: iso-image
           # Force the path, this is a security hint!
           path: ./
-      - name: Download specified ISO (if needed)
+      - name: Download specified ISO
         if: ${{ inputs.iso_to_test != '' }}
         env:
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
@@ -266,7 +266,7 @@ jobs:
       - name: Remove remaining stuff from worker ♻
         if: always()
         uses: colpal/actions-clean@v1
-      - name: Send failed status to slack (if needed)
+      - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.23.0
         with:

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -18,6 +18,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.4+k3s1
+      ca_type: selfsigned
       rancher_channel: latest
       rancher_version: devel
       runner: elemental-e2e-ci-runner-spot-x86-64-1

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -96,7 +96,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Expect(vmName).To(Not(BeEmpty()))
 		})
 
-		By("Configuring emulated TPM if needed", func() {
+		By("Setting emulated TPM to "+emulateTPM, func() {
 			// Set correct value for TPM emulation
 			value := "false"
 			if emulateTPM == "true" {
@@ -112,7 +112,9 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 				"--type", "merge", "--patch-file", emulatedTPMYaml,
 			)
 			Expect(err).To(Not(HaveOccurred()), out)
+		})
 
+		By("Downloading installation config file", func() {
 			// Download the new YAML installation config file
 			tokenURL, err := kubectl.Run("get", "MachineRegistration",
 				"--namespace", clusterNS,
@@ -124,16 +126,16 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		By("Configuring iPXE boot script for network installation (if needed)", func() {
-			if isoBoot != "true" {
+		if isoBoot != "true" {
+			By("Configuring iPXE boot script for network installation", func() {
 				numberOfFile, err := misc.ConfigureiPXE()
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(numberOfFile).To(BeNumerically(">=", 1))
-			}
-		})
+			})
+		}
 
-		By("Adding registration file to ISO (if needed)", func() {
-			if isoBoot == "true" {
+		if isoBoot == "true" {
+			By("Adding registration file to ISO", func() {
 				// Check if generated ISO is already here
 				isIso, _ := exec.Command("bash", "-c", "ls ../../elemental-*.iso").Output()
 
@@ -151,8 +153,8 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					err = exec.Command("bash", "-c", "mv -f elemental-*.iso ../..").Run()
 					Expect(err).To(Not(HaveOccurred()))
 				}
-			}
-		})
+			})
+		}
 
 		By("Creating and installing VM", func() {
 			cmd := exec.Command("../scripts/install-vm", vmName, macAdrs)

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -74,29 +74,38 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		By("Installing CertManager", func() {
-			err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", "jetstack", "https://charts.jetstack.io")
-			Expect(err).To(Not(HaveOccurred()))
+		if caType == "private" {
+			By("Configuring Private CA", func() {
+				cmd := exec.Command("../scripts/config-private-ca")
+				out, err := cmd.CombinedOutput()
+				GinkgoWriter.Printf("%s\n", out)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+		} else {
+			By("Installing CertManager", func() {
+				err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", "jetstack", "https://charts.jetstack.io")
+				Expect(err).To(Not(HaveOccurred()))
 
-			err = kubectl.RunHelmBinaryWithCustomErr("repo", "update")
-			Expect(err).To(Not(HaveOccurred()))
+				err = kubectl.RunHelmBinaryWithCustomErr("repo", "update")
+				Expect(err).To(Not(HaveOccurred()))
 
-			err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "cert-manager", "jetstack/cert-manager",
-				"--namespace", "cert-manager",
-				"--create-namespace",
-				"--set", "installCRDs=true",
-			)
-			Expect(err).To(Not(HaveOccurred()))
+				err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "cert-manager", "jetstack/cert-manager",
+					"--namespace", "cert-manager",
+					"--create-namespace",
+					"--set", "installCRDs=true",
+				)
+				Expect(err).To(Not(HaveOccurred()))
 
-			err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=controller")
-			Expect(err).To(Not(HaveOccurred()))
+				err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=controller")
+				Expect(err).To(Not(HaveOccurred()))
 
-			err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=webhook")
-			Expect(err).To(Not(HaveOccurred()))
+				err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=webhook")
+				Expect(err).To(Not(HaveOccurred()))
 
-			err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=cainjector")
-			Expect(err).To(Not(HaveOccurred()))
-		})
+				err = k.WaitForNamespaceWithPod("cert-manager", "app.kubernetes.io/component=cainjector")
+				Expect(err).To(Not(HaveOccurred()))
+			})
+		}
 
 		By("Installing Rancher", func() {
 			err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", "rancher",
@@ -130,8 +139,34 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				}
 			}
 
+			// For Private CA
+			if caType == "private" {
+				flags = append(flags,
+					"--set", "ingress.tls.source=secret",
+					"--set", "privateCA=true",
+				)
+			}
+
 			err = kubectl.RunHelmBinaryWithCustomErr(flags...)
 			Expect(err).To(Not(HaveOccurred()))
+
+			// Inject secret for Private CA
+			if caType == "private" {
+				_, err := kubectl.Run("create", "secret",
+					"--namespace", "cattle-system",
+					"tls", "tls-rancher-ingress",
+					"--cert=tls.crt",
+					"--key=tls.key",
+				)
+				Expect(err).To(Not(HaveOccurred()))
+
+				_, err = kubectl.Run("create", "secret",
+					"--namespace", "cattle-system",
+					"generic", "tls-ca",
+					"--from-file=cacerts.pem=./cacerts.pem",
+				)
+				Expect(err).To(Not(HaveOccurred()))
+			}
 
 			err = k.WaitForNamespaceWithPod("cattle-system", "app=rancher")
 			Expect(err).To(Not(HaveOccurred()))
@@ -142,10 +177,19 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			err = k.WaitForNamespaceWithPod("cattle-system", "app=rancher-webhook")
 			Expect(err).To(Not(HaveOccurred()))
 
+			// Check issuer for Private CA
+			if caType == "private" {
+				out, err := exec.Command("bash", "-c", "curl -vk https://$(hostname -f)").CombinedOutput()
+				GinkgoWriter.Printf("%s\n", out)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
 			// Check Rancher version
 			operatorVersion, err := kubectl.Run("get", "pod",
 				"--namespace", "cattle-system",
-				"-l", "app=rancher", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+				"-l", "app=rancher",
+				"-o", "jsonpath={.items[*].status.containerStatuses[*].image}",
+			)
 			Expect(err).To(Not(HaveOccurred()))
 			GinkgoWriter.Printf("Rancher Version:\n%s\n", operatorVersion)
 		})
@@ -160,7 +204,8 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			err = kubectl.RunHelmBinaryWithCustomErr("repo", "update")
 			Expect(err).To(Not(HaveOccurred()))
 
-			err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator", "elemental-operator/elemental-operator",
+			err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator",
+				"elemental-operator/elemental-operator",
 				"--namespace", "cattle-elemental-system",
 				"--create-namespace",
 			)
@@ -171,7 +216,8 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 			// Check if an upgrade to a specific version is configured
 			if upgradeOperator != "" {
-				err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator", upgradeOperator,
+				err = kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator",
+					upgradeOperator,
 					"--namespace", "cattle-elemental-system",
 					"--create-namespace",
 				)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	clusterNS = os.Getenv("CLUSTER_NS")
 	emulateTPM = os.Getenv("EMULATE_TPM")
 	imageVersion = os.Getenv("IMAGE_VERSION")
-	index, set := os.LookupEnv("VM_INDEX")
+	index := os.Getenv("VM_INDEX")
 	isoBoot = os.Getenv("ISO_BOOT")
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	caType = os.Getenv("CA_TYPE")
@@ -80,12 +80,17 @@ var _ = BeforeSuite(func() {
 	upgradeOperator = os.Getenv("UPGRADE_OPERATOR")
 
 	// Only if VM_INDEX is set
-	if set {
+	if index != "" {
 		var err error
 		vmIndex, err = strconv.Atoi(index)
 		Expect(err).To(Not(HaveOccurred()))
 
 		// Now we can set the VM name
 		vmName = vmNameRoot + "-" + fmt.Sprint(vmIndex)
+	}
+
+	// Force a correct value
+	if emulateTPM != "true" {
+		emulateTPM = "false"
 	}
 })

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -43,6 +43,7 @@ var (
 	imageVersion    string
 	isoBoot         string
 	k8sVersion      string
+	caType          string
 	osImage         string
 	rancherChannel  string
 	rancherVersion  string
@@ -71,6 +72,7 @@ var _ = BeforeSuite(func() {
 	index, set := os.LookupEnv("VM_INDEX")
 	isoBoot = os.Getenv("ISO_BOOT")
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
+	caType = os.Getenv("CA_TYPE")
 	osImage = os.Getenv("CONTAINER_IMAGE")
 	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherVersion = os.Getenv("RANCHER_VERSION")

--- a/tests/scripts/config-private-ca
+++ b/tests/scripts/config-private-ca
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -e -x
+
+# Variable(s)
+EMAIL=elemental@suse.de
+CA_NAME=elementalCA
+DOMAIN=$(hostname -d)
+FQDN=$(hostname -f)
+VALUE=Elemental
+
+# Generate CA private key
+openssl genrsa -des3 -passout pass:${VALUE} -out ${CA_NAME}.key 2048
+
+# Create CA config file
+cat > ${CA_NAME}.config <<EOF
+[req]
+distinguished_name = dn
+prompt = no
+
+[dn]
+CN = ${CA_NAME}
+C = DE
+L = Nuremberg
+O = ${VALUE}
+OU = ${VALUE} Team
+emailAddress = ${EMAIL}
+EOF
+
+# Generate the Root CA
+openssl req -x509 -new -nodes -sha256 -days 1 \
+  -passin pass:${VALUE} \
+  -key ${CA_NAME}.key \
+  -config ${CA_NAME}.config \
+  -out ${CA_NAME}.pem
+
+# Generate private key for FQDN certificate
+openssl genrsa -out ${FQDN}.key 2048
+
+# Create FQDN certificate config file
+cat > ${FQDN}.config <<EOF
+[req]
+req_extensions = v3_req
+distinguished_name = dn
+prompt = no
+
+[dn]
+CN = *.${DOMAIN}
+C = DE
+L = Nuremberg
+O = ${VALUE}
+OU = ${VALUE} Team
+emailAddress = ${EMAIL}
+
+[v3_req]
+subjectAltName = DNS:${FQDN}
+EOF
+
+# Generate Certificate Signing Request (CSR)
+openssl req -new -key ${FQDN}.key -config ${FQDN}.config -out ${FQDN}.csr
+
+# Create Certificate Extension file
+cat > ${FQDN}.ext <<EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${FQDN}
+EOF
+
+# Generate the final certificate
+openssl x509 -req -sha256 -days 1 -CAcreateserial \
+  -passin pass:${VALUE} \
+  -CAkey ${CA_NAME}.key \
+  -CA ${CA_NAME}.pem \
+  -extfile ${FQDN}.ext \
+  -in ${FQDN}.csr \
+  -out ${FQDN}.crt
+
+# Check certificate
+openssl verify -CAfile ${CA_NAME}.pem ${FQDN}.crt
+openssl x509 -noout -subject -issuer -in ${FQDN}.crt
+
+# Create links
+for I in crt key; do
+  ln -s ${FQDN}.${I} tls.${I}
+done
+ln -s ${CA_NAME}.pem cacerts.pem


### PR DESCRIPTION
Add a test that use private CA instead of selfsigned in RKE2 E2E test.
Should fix #429

Verification run: https://github.com/rancher/elemental/actions/runs/3336651585
Verification run for the refactoring commit: https://github.com/ldevulder/elemental/actions/runs/3337939442