### PR TITLE
Updated baseUrl to match the docs sub-directory

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Elemental - Immutable Linux for Rancher',
   url: 'https://rancher.github.io/elemental',
-  baseUrl: '/',
+  baseUrl: '/elemental/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Due to the docs being a sub-directory, the Docusaurus configuration needs to update the `baseUrl`.