### PR TITLE
Add RBAC tests in the UI

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -162,6 +162,7 @@ jobs:
             cypress/e2e/unit_tests/elemental_plugin.spec.ts
             cypress/e2e/unit_tests/menu.spec.ts
             cypress/e2e/unit_tests/machine_registration.spec.ts
+            cypress/e2e/unit_tests/user.spec.ts
         run: make -f tests/Makefile start-cypress-tests
       - name: Deploy a node to join Rancher manager
         if: ${{ inputs.test_type == 'ui' }}

--- a/cypress/e2e/unit_tests/user.spec.ts
+++ b/cypress/e2e/unit_tests/user.spec.ts
@@ -1,0 +1,60 @@
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
+import { Elemental } from '../../support/elemental';
+
+Cypress.config();
+describe('User role testing', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const elemental = new Elemental();
+  const std_user = "std-user"
+  const elemental_user = "elemental-user"
+  const ui_password = "rancherpassword"
+
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('Create elemental user', () => {
+    // User with the elemental-administrator role
+    cy.login();
+    topLevelMenu.openIfClosed();
+    cy.contains('Users & Authentication').click();
+    cy.contains('.title', 'Users').should('exist');
+    cy.clickButton('Create');
+    cy.typeValue({label: 'Username', value: std_user});
+    cy.typeValue({label: 'New Password', value: ui_password});
+    cy.typeValue({label: 'Confirm Password', value: ui_password});
+    cy.clickButton('Create');
+  });
+
+  it('Create standard user', () => {
+    // User without the elemental-administrator role
+    cy.login();
+    topLevelMenu.openIfClosed();
+    cy.contains('Users & Authentication').click();
+    cy.contains('.title', 'Users').should('exist');
+    cy.clickButton('Create');
+    cy.typeValue({label: 'Username', value: elemental_user});
+    cy.typeValue({label: 'New Password', value: ui_password});
+    cy.typeValue({label: 'Confirm Password', value: ui_password});
+    cy.contains('Elemental Administrator').click();
+    cy.clickButton('Create');
+  });
+
+  it('Elemental user should access the OS management menu', () => {
+    cy.login(elemental_user, ui_password);
+    cy.get('[data-testid="banner-title"]').contains('Welcome to Rancher');
+    topLevelMenu.openIfClosed();
+    elemental.elementalIcon().should('exist');
+    // Waiting a fix to continue
+    //elemental.accessElementalMenu();
+    //elemental.checkElementalNav();
+  });
+
+  it('Standard user should not access the OS management menu', () => {
+    cy.login(std_user, ui_password);
+    cy.get('[data-testid="banner-title"]').contains('Welcome to Rancher');
+    topLevelMenu.openIfClosed();
+    elemental.elementalIcon().should('not.exist');
+  });
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6025636/199550300-5409a58f-b744-44a9-a751-f543b3faead2.png)

Regarding RBAC tests, I don't know how deep they have to be, I mean, with the existing tests, I only test that a user with the elemental-administrator can access the OS management menu. I also test the opposite, a user without the elemental-administrator role should not access the OS management menu.

By deeper, I mean, we can test that a user with the elemental-administrator role can create machine registration etc
May I ask what do you think @kkaempf @ldevulder 