### PR TITLE
Update persistent paths for NetworkManager

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,26 +105,26 @@ One of the characteristics of Elemental OSes is the setup of an immutable root f
 persistent locations are applied on top of it. Elemental Teal default folders structure is listed in the
 matrix below.
 
-| Path              | Read-Only | Ephemeral | Persistent |
-|-------------------|:---------:|:---------:|:----------:|
-| /                 |     x     |           |            |
-| /etc              |           |     x     |            |
-| /etc/cni          |           |           |     x      |
-| /etc/iscsi        |           |           |     x      |
-| /etc/rancher      |           |           |     x      |
-| /etc/ssh          |           |           |     x      |
-| /etc/systemd      |           |           |     x      |
-| /srv              |           |     x     |            |
-| /home             |           |           |     x      |
-| /opt              |           |           |     x      |
-| /root             |           |           |     x      |
-| /var              |           |     x     |            |
-| /usr/libexec      |           |           |     x      |
-| /var/lib/cni      |           |           |     x      |
-| /var/lib/kubelet  |           |           |     x      |
-| /var/lib/longhorn |           |           |     x      |
-| /var/lib/rancher  |           |           |     x      |
-| /var/lib/elemetal |           |           |     x      |
-| /var/lib/wicked   |           |           |     x      |
-| /var/lib/calico   |           |           |     x      |
-| /var/log          |           |           |     x      |
+| Path                    | Read-Only | Ephemeral | Persistent |
+|-------------------------|:---------:|:---------:|:----------:|
+| /                       |     x     |           |            |
+| /etc                    |           |     x     |            |
+| /etc/cni                |           |           |     x      |
+| /etc/iscsi              |           |           |     x      |
+| /etc/rancher            |           |           |     x      |
+| /etc/ssh                |           |           |     x      |
+| /etc/systemd            |           |           |     x      |
+| /srv                    |           |     x     |            |
+| /home                   |           |           |     x      |
+| /opt                    |           |           |     x      |
+| /root                   |           |           |     x      |
+| /var                    |           |     x     |            |
+| /usr/libexec            |           |           |     x      |
+| /var/lib/cni            |           |           |     x      |
+| /var/lib/kubelet        |           |           |     x      |
+| /var/lib/longhorn       |           |           |     x      |
+| /var/lib/rancher        |           |           |     x      |
+| /var/lib/elemetal       |           |           |     x      |
+| /var/lib/NetworkManager |           |           |     x      |
+| /var/lib/calico         |           |           |     x      |
+| /var/log                |           |           |     x      |

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -45,7 +45,7 @@ stages:
           /var/lib/elemental
           /var/lib/rancher
           /var/lib/kubelet
-          /var/lib/wicked
+          /var/lib/NetworkManager
           /var/lib/longhorn
           /var/lib/cni
           /var/lib/calico


### PR DESCRIPTION
SLE Micro 5.3 replaces wicked with NetworkManager.

https://www.suse.com/releasenotes/x86_64/SLE-Micro/5.3/index.html

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>