### PR TITLE
ci/ui: remove number of installed nodes from summary

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -282,7 +282,9 @@ jobs:
       - name: Add summary
         run: |
           echo "## General informations" >> $GITHUB_STEP_SUMMARY
-          echo "Number of nodes in the cluster: ${{ inputs.node_number }}" >> $GITHUB_STEP_SUMMARY
+          if ${{ inputs.test_type == 'cli' }}; then
+            echo "Number of nodes in the cluster: ${{ inputs.node_number }}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "Type of certificate for Rancher Manager: ${{ inputs.ca_type }}"  >> $GITHUB_STEP_SUMMARY
           echo "## Versions used" >> $GITHUB_STEP_SUMMARY
           echo "Rancher Manager: ${{ env.RANCHER_CHANNEL }}/${{ env.RANCHER_VERSION }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Because the UI test doesn't use `node_number` variable and thus it will always return the default value (5) as the number of installed nodes, which is false.

See here for an example of a bad output: https://github.com/rancher/elemental/actions/runs/3422527311.