### PR TITLE
Use machine reg created in UI instead of the one in test assets

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -292,7 +292,7 @@ jobs:
         if: always()
         run: |
           # Remove all VMs
-          for I in $(sudo virsh list | awk '/node-/ { print $2 }'); do
+          for I in $(sudo virsh list --all| awk '/node-/ { print $2 }'); do
             for C in destroy undefine; do
               [[ "${C}" == "undefine" ]] && OPT="--nvram" || unset OPT
               sudo virsh ${C} ${OPT} ${I} >/dev/null 2>&1 || true

--- a/cypress/e2e/unit_tests/machine_registration.spec.ts
+++ b/cypress/e2e/unit_tests/machine_registration.spec.ts
@@ -45,10 +45,6 @@ describe('Machine registration testing', () => {
     cy.createMachReg({machRegName: 'labels-annotations-test', checkLabels: true, checkAnnotations: true});
   });
 
-  it.skip('Create machine registration with custom cloud-config', () => {
-      // Cannot be tested yet due to https://github.com/rancher/dashboard/issues/6458
-  });
-
   it('Delete machine registration', () => {
     cy.createMachReg({machRegName: 'delete-test'});
     cy.deleteMachReg({machRegName: 'delete-test'});
@@ -98,4 +94,10 @@ describe('Machine registration testing', () => {
     cy.verifyDownload('download-yaml-test.yaml');
   });
 
+  // This test must stay the last one because we use this machine registration when we test adding a node.
+  // It also tests using a custom cloud config by using read from file button.
+  it('Create Machine registration we will use to test adding a node', () => {
+    cy.createMachReg({machRegName: 'machine-registration', checkInventoryLabels: true, checkInventoryAnnotations: true, customCloudConfig: 'custom_cloud-config.yaml'});
+    cy.checkMachInvLabel({machRegName: 'machine-registration', labelName: 'myInvLabel1', labelValue: 'myInvLabelValue1'});
+  });
 });

--- a/cypress/e2e/unit_tests/machine_selector.spec.ts
+++ b/cypress/e2e/unit_tests/machine_selector.spec.ts
@@ -42,8 +42,8 @@ describe('Machine selector testing', () => {
     // TODO: Cannot use the clickButton here, I do not know why yet 
     cy.get('.mt-20 > .btn').contains('Add Rule').click();
     cy.get('#vs6__combobox').click()
-    cy.contains('cypress').click();
-    cy.get('[data-testid="input-match-expression-values-0"] > input').click().type('uitesting');
+    cy.contains('myInvLabel1').click();
+    cy.get('[data-testid="input-match-expression-values-0"] > input').click().type('myInvLabelValue1');
     cy.contains('.banner', 'Matches all 1 existing Machine Inventories').should('exist');
   });
 });

--- a/cypress/fixtures/custom_cloud-config.yaml
+++ b/cypress/fixtures/custom_cloud-config.yaml
@@ -1,0 +1,10 @@
+config:
+  cloud-config:
+    users:
+    - name: root
+      passwd: root
+  elemental:
+    install:
+      poweroff: true
+      device: /dev/sda
+      debug: true

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,13 +15,17 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean): Chainable<Element>;
+      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, customCloudConfig?: string): Chainable<Element>;
       deleteMachReg(machRegName: string): Chainable<Element>;
       deleteAllMachReg():Chainable<Element>;
       addMachRegLabel(labelName: string, labelValue: string):Chainable<Element>;
       checkMachRegLabel(machRegName: string, labelName: string, labelValue: string):Chainable<Element>;
       checkMachRegAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;
       addMachRegAnnotation(annotationName: string, annotationValue: string):Chainable<Element>;
+      addMachInvLabel(labelName: string, labelValue: string):Chainable<Element>;
+      checkMachInvLabel(machRegName: string, labelName: string, labelValue: string):Chainable<Element>;
+      checkMachInvAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;
+      addMachInvAnnotation(annotationName: string, annotationValue: string):Chainable<Element>;
       editMachReg(machRegName: string, addLabel?: boolean, addAnnotation?: boolean, withYAML?: boolean): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string,): Chainable<Element>;
     }

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1,3 +1,4 @@
+import 'cypress-file-upload';
 // Generic functions
 
 // Log into Rancher
@@ -118,7 +119,7 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl, repoType}) => {
 // Machine registration functions
 
 // Create a machine registration
-Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', checkLabels=false, checkAnnotations=false}) => {
+Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', checkLabels=false, checkAnnotations=false, checkInventoryLabels=false, checkInventoryAnnotations=false, customCloudConfig=''}) => {
   cy.clickNavMenu(["Dashboard"]);
   cy.clickButton("Create Machine Registration");
   if (namespace != "fleet-default") {
@@ -130,12 +131,24 @@ Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', 
     cy.typeValue({label: 'Name', value: machRegName});
   }
 
+  if (customCloudConfig != '') {
+    cy.get('input[type="file"]').attachFile({filePath: customCloudConfig});
+  }
+
   if (checkLabels) {
     cy.addMachRegLabel({labelName: 'myLabel1', labelValue: 'myLabelValue1'});
     }
 
   if (checkAnnotations) {
     cy.addMachRegAnnotation({annotationName: 'myAnnotation1', annotationValue: 'myAnnotationValue1'});
+  }
+
+  if (checkInventoryLabels) {
+    cy.addMachInvLabel({labelName: 'myInvLabel1', labelValue: 'myInvLabelValue1'});
+  }
+
+  if (checkInventoryAnnotations) {
+    cy.addMachInvAnnotation({annotationName: 'myInvAnnotation1', annotationValue: 'myInvAnnotationValue1'});
   }
 
   cy.clickButton("Create");
@@ -179,6 +192,32 @@ Cypress.Commands.add('addMachRegAnnotation', ({annotationName, annotationValue})
   cy.get('#machine-reg > .mb-10 > .key-value > .footer > .btn').click(); 
   cy.get('#machine-reg > .mb-10 > .key-value > .kv-container > .kv-item.key').type(annotationName);
   cy.get('#machine-reg > .mb-10 > .key-value > .kv-container > .kv-item.value').type(annotationValue);
+});
+
+// Add Label to machine inventory
+Cypress.Commands.add('addMachInvLabel', ({labelName, labelValue}) => {
+  cy.get('#machine-inventory').contains('Machine Inventories').click();
+  cy.clickButton('Add Label');
+  cy.get('#machine-inventory > .mb-30 > .key-value > .kv-container > .kv-item.key').type(labelName);
+  cy.get('#machine-inventory > .mb-30 > .key-value > .kv-container > .kv-item.value').type(labelValue);
+});
+
+// Add Annotation to machine inventory
+Cypress.Commands.add('addMachInvAnnotation', ({annotationName, annotationValue}) => {
+  cy.get('#machine-inventory').contains('Machine Inventories').click();
+  cy.clickButton('Add Annotation');
+  cy.get('#machine-inventory > .mb-10 > .key-value > .kv-container > .kv-item.key').type(annotationName);
+  cy.get('#machine-inventory > .mb-10 > .key-value > .kv-container > .kv-item.value').type(annotationValue);
+});
+
+// Check machine inventory label in YAML
+Cypress.Commands.add('checkMachInvLabel', ({machRegName, labelName, labelValue}) => {
+  cy.contains(machRegName).click();
+  cy.get('div.actions > .role-multi-action').click()
+  cy.contains('li', 'Edit YAML').click();
+  cy.contains('Machine Registration: '+ machRegName).should('exist');
+  cy.contains(labelName + ': ' + labelValue);
+  cy.clickButton('Cancel');
 });
 
 // Check machine registration label in YAML

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -33,24 +33,7 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 	)
 
 	It("Configure libvirt and bootstrap a node", func() {
-		By("Adding MachineRegistration", func() {
-			registrationYaml := "../assets/machineregistration.yaml"
-
-			err := tools.Sed("%VM_NAME%", vmNameRoot, registrationYaml)
-			Expect(err).To(Not(HaveOccurred()))
-
-			err = tools.Sed("%USER%", userName, registrationYaml)
-			Expect(err).To(Not(HaveOccurred()))
-
-			err = tools.Sed("%PASSWORD%", userPassword, registrationYaml)
-			Expect(err).To(Not(HaveOccurred()))
-
-			err = tools.Sed("%CLUSTER_NAME%", clusterName, registrationYaml)
-			Expect(err).To(Not(HaveOccurred()))
-
-			err = kubectl.Apply(clusterNS, registrationYaml)
-			Expect(err).To(Not(HaveOccurred()))
-
+		By("Downloading MachineRegistration", func() {
 			tokenURL, err := kubectl.Run("get", "MachineRegistration",
 				"--namespace", clusterNS,
 				"machine-registration", "-o", "jsonpath={.status.registrationURL}")


### PR DESCRIPTION
Due to a bug with cloud-config, until now, we were using a machine registration not created in the UI but the same as the backend e2e test (https://github.com/rancher/elemental/blob/main/tests/assets/machineregistration.yaml).

It sound more logical to run the test with a machine registration created with the UI.

This PR adds a test in machine registration to create the resource we need to deploy a node.

Actually, it also tests the cloud config block because we have to import our custom cloud config there.
Fix #215 

![image](https://user-images.githubusercontent.com/6025636/200809137-28ccdac0-9664-450c-bf80-fae7af61ede2.png)

Verification run:
https://github.com/rancher/elemental/actions/runs/3427858809
