### PR TITLE
docs: Change nodeSelector example

### DIFF
--- a/examples/upgrade/upgrade-node-selector.yaml
+++ b/examples/upgrade/upgrade-node-selector.yaml
@@ -10,4 +10,4 @@ spec:
     - clusterName: my-cluster
   nodeSelector:
     matchLabels:
-      location: "europe"
+      kubernetes.io/hostname: my-machine


### PR DESCRIPTION
The smbios labels are not propagated to the nodes, so `location` cannot be used for nodeSelector in any meaningful way.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>