### PR TITLE
Added Algolia search bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Elemental - Immutable Linux for Rancher',
-  url: 'https://rancher.github.io/elemental',
+  url: 'https://rancher.github.io',
   baseUrl: '/elemental/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -48,6 +48,12 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      algolia: {
+        appId: 'QLF01IU46G',
+        apiKey: '68a970916bcccd030e13eb07260af56f',
+        indexName: 'elemental',
+        contextualSearch: true,
+      },
       navbar: {
         title: 'Elemental',
         logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
     ({
       algolia: {
         appId: 'QLF01IU46G',
-        apiKey: '68a970916bcccd030e13eb07260af56f',
+        apiKey: '6399abce2893cd405e6b53acf2667f51',
         indexName: 'elemental',
         contextualSearch: true,
       },


### PR DESCRIPTION
The Algolia search crawler has been configured and the search bar can now be used.

Another small change to the configuration was also done for the URL and baseURL settings to avoid a warning when building the docs website.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>