### PR TITLE
Add UI test to check default cloud-config

### DIFF
--- a/cypress/e2e/unit_tests/machine_registration.spec.ts
+++ b/cypress/e2e/unit_tests/machine_registration.spec.ts
@@ -97,7 +97,7 @@ describe('Machine registration testing', () => {
   // This test must stay the last one because we use this machine registration when we test adding a node.
   // It also tests using a custom cloud config by using read from file button.
   it('Create Machine registration we will use to test adding a node', () => {
-    cy.createMachReg({machRegName: 'machine-registration', checkInventoryLabels: true, checkInventoryAnnotations: true, customCloudConfig: 'custom_cloud-config.yaml'});
+    cy.createMachReg({machRegName: 'machine-registration', checkInventoryLabels: true, checkInventoryAnnotations: true, customCloudConfig: 'custom_cloud-config.yaml', checkDefaultCloudConfig: false});
     cy.checkMachInvLabel({machRegName: 'machine-registration', labelName: 'myInvLabel1', labelValue: 'myInvLabelValue1'});
   });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,7 +15,7 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, customCloudConfig?: string): Chainable<Element>;
+      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, customCloudConfig?: string, checkDefaultCloudConfig?: boolean): Chainable<Element>;
       deleteMachReg(machRegName: string): Chainable<Element>;
       deleteAllMachReg():Chainable<Element>;
       addMachRegLabel(labelName: string, labelValue: string):Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -119,7 +119,7 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl, repoType}) => {
 // Machine registration functions
 
 // Create a machine registration
-Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', checkLabels=false, checkAnnotations=false, checkInventoryLabels=false, checkInventoryAnnotations=false, customCloudConfig=''}) => {
+Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', checkLabels=false, checkAnnotations=false, checkInventoryLabels=false, checkInventoryAnnotations=false, customCloudConfig='', checkDefaultCloudConfig=true }) => {
   cy.clickNavMenu(["Dashboard"]);
   cy.clickButton("Create Machine Registration");
   if (namespace != "fleet-default") {
@@ -167,15 +167,27 @@ Cypress.Commands.add('createMachReg', ({machRegName, namespace='fleet-default', 
   cy.verifyDownload(machRegName + '_registrationURL.yaml');
   cy.contains('Saving').should('not.exist');
   
+    // Check Cloud configuration
+  // TODO: Maybe the check may be improved in one line
+  if (checkDefaultCloudConfig) {
+    cy.get('[data-testid="yaml-editor-code-mirror"]')
+      .should('include.text','config:')
+      .should('include.text','cloud-config:')
+      .should('include.text','users:')
+      .should('include.text','- name: root')
+      .should('include.text','passwd: root')
+      .should('include.text','elemental:')
+      .should('include.text','install:')
+      .should('include.text','device: /dev/nvme0n1')
+      .should('include.text','poweroff: true');
+  }
+
   // Check label and annotation in YAML
   // For now, we can only check in YAML because the fields are disabled and we cannot check their content
   // It looks like we can use shadow DOM to catch it but too complicated for now
   cy.contains('Machine Registrations').click();
   if (checkLabels) {cy.checkMachRegLabel({machRegName: machRegName, labelName: 'myLabel1', labelValue: 'myLabelValue1'})};
   if (checkAnnotations) {cy.checkMachRegAnnotation({machRegName: machRegName, annotationName: 'myAnnotation1', annotationValue: 'myAnnotationValue1'});}
-
-  // Check Cloud configuration
-  // Cannot be checked yet due to https://github.com/rancher/dashboard/issues/6458
 });
 
 // Add Label to machine registration


### PR DESCRIPTION
This test makes sure that the default cloud-config exist after creating a machine registration.

Regression test to avoid this bug https://github.com/rancher/elemental-ui/issues/15

![image](https://user-images.githubusercontent.com/6025636/201073805-e164b530-d5ef-4767-91d6-d679b31fe18e.png)

Verification run:
https://github.com/rancher/elemental/actions/runs/3436098148
