### PR TITLE
Also trigger Dev rebuild on tag push

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,4 +1,4 @@
-dev_workflow:
+push_workflow:
   steps:
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
@@ -9,10 +9,13 @@ dev_workflow:
         - main
     event: push
 
-staging_workflow:
+tag_workflow:
   steps:
     - trigger_services:
         project: isv:Rancher:Elemental:Staging
+        package: elemental
+    - trigger_services:
+        project: isv:Rancher:Elemental:Dev
         package: elemental
   filters:
     branches:


### PR DESCRIPTION
This commit sets the OBS workflow to also rebuild Dev environment when a tag is pushed to main branch. This is relevant to ensure the latest Dev build is also taking the correct package version.

Signed-off-by: David Cassany <dcassany@suse.com>