### PR TITLE
Do not overwrite VERSION/VERSION_ID on dockerfile build

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -64,8 +64,6 @@ RUN systemctl enable NetworkManager sshd elemental-populate-node-labels
 ARG IMAGE_TAG=latest
 ARG IMAGE_COMMIT=""
 ARG IMAGE_REPO=norepo
-RUN echo VERSION=\"${IMAGE_TAG}\" >> /etc/os-release
-RUN echo VERSION_ID=\"$(echo ${IMAGE_TAG} | sed s/^v//)\" >> /etc/os-release
 RUN echo COMMIT=\"${IMAGE_COMMIT}\" >> /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\" >> /etc/os-release
 RUN echo IMAGE_TAG=\"${IMAGE_TAG}\" >> /etc/os-release

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -68,6 +68,7 @@ RUN echo COMMIT=\"${IMAGE_COMMIT}\" >> /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\" >> /etc/os-release
 RUN echo IMAGE_TAG=\"${IMAGE_TAG}\" >> /etc/os-release
 RUN echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release
+RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release
 RUN echo GRUB_ENTRY_NAME=\"Elemental\" >> /etc/os-release
 
 # Rebuild initrd to setup dracut with the boot configurations


### PR DESCRIPTION
We are overriding the existing values in the os-release file and we
should not. We already have the IMAGE_TAG and/or COMMIT to check the
versions

Also adds the TIMESTAMP to os-release

Both are done to be more in sync with OBS builds.

Signed-off-by: Itxaka <igarcia@suse.com>