### PR TITLE
ci/e2e: make Rancher version configurable

### DIFF
--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -8,6 +8,14 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: number
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: latest
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: devel
+        type: string
 
 concurrency:
   group: e2e-tests-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -23,6 +31,8 @@ jobs:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.7+k3s1
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator
   rke2:
@@ -37,5 +47,7 @@ jobs:
       k8s_version_to_provision: v1.24.7+rke2r1
       ca_type: private
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator

--- a/.github/workflows/e2e-obs-Stable.yaml
+++ b/.github/workflows/e2e-obs-Stable.yaml
@@ -8,6 +8,14 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: latest
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: devel
+        type: string
 
 concurrency:
   group: e2e-tests-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -23,6 +31,8 @@ jobs:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.7+k3s1
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/elemental/elemental-operator
   rke2:
@@ -37,5 +47,7 @@ jobs:
       k8s_version_to_provision: v1.24.7+rke2r1
       ca_type: private
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/elemental/elemental-operator

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -8,6 +8,14 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: number
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: latest
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: devel
+        type: string
 
 concurrency:
   group: e2e-tests-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -23,6 +31,8 @@ jobs:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.7+k3s1
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator
   rke2:
@@ -37,5 +47,7 @@ jobs:
       k8s_version_to_provision: v1.24.7+rke2r1
       ca_type: private
       node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator


### PR DESCRIPTION
Also set `latest/devel` version as the default one (but this can be changed upon triggered).

Verification run: https://github.com/rancher/elemental/actions/runs/3482867640