### PR TITLE
Test advanced filtering in Elemental UI

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -169,6 +169,7 @@ jobs:
             cypress/e2e/unit_tests/user.spec.ts
             cypress/e2e/unit_tests/menu.spec.ts
             cypress/e2e/unit_tests/machine_registration.spec.ts
+            cypress/e2e/unit_tests/advanced_filtering.spec.ts
         run: make -f tests/Makefile start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure()

--- a/cypress/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/cypress/e2e/unit_tests/advanced_filtering.spec.ts
@@ -1,0 +1,46 @@
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
+import { Elemental } from '../../support/elemental';
+import { contains } from 'cypress/types/jquery';
+
+Cypress.config();
+describe('Advanced filtering testing', () => {
+  const topLevelMenu   = new TopLevelMenu();
+  const elemental      = new Elemental();
+  const ui_account     = Cypress.env('ui_account');
+  const elemental_user = "elemental-user"
+  const ui_password    = "rancherpassword"
+
+  beforeEach(() => {
+    (ui_account == "user") ? cy.login(elemental_user, ui_password) : cy.login();
+    cy.visit('/');
+
+    // Open the navigation menu
+    topLevelMenu.openIfClosed();
+
+    // Click on the Elemental's icon
+    elemental.accessElementalMenu(); 
+  });
+
+  it('Create fake machine inventories', () => {
+    cy.importMachineInventory({machineInventoryFile: 'machine_inventory_1.yaml', machineInventoryName: 'test-filter-one'});
+    cy.importMachineInventory({machineInventoryFile: 'machine_inventory_2.yaml', machineInventoryName: 'test-filter-two'});
+    cy.importMachineInventory({machineInventoryFile: 'machine_inventory_3.yaml', machineInventoryName: 'shouldnotmatch'});
+  });
+
+  it('Two machine inventories should appear by filtering on test-filter', () => {
+    // Only test-filter-one and test-filter-two should appear with test-filter as filter
+    cy.checkFilter({filterName: 'test-filter', testFilterOne: true, testFilterTwo: true, shouldNotMatch: false});
+  });
+
+  it('One machine inventory should appear by filtering on test-filter-one', () => {
+    // Only test-filter-one should appear with test-filter-one as filter
+    cy.checkFilter({filterName: 'test-filter-one', testFilterOne: true, testFilterTwo: false, shouldNotMatch: false});
+  });
+
+  it('No machine inventory should appear by filtering on test-bad-filter', () => {
+    // This test will also serve as no regression test for https://github.com/rancher/elemental-ui/issues/41
+    cy.checkFilter({filterName: 'test-bad-filter', testFilterOne: false, testFilterTwo: false, shouldNotMatch: false});
+    cy.contains('There are no rows which match your search query.')
+  });
+});

--- a/cypress/fixtures/machine_inventory_1.yaml
+++ b/cypress/fixtures/machine_inventory_1.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventory
+metadata:
+  annotations:
+    myInvAnnotation1: myInvAnnotationValue1
+  labels:
+    testfilter: test-filter-one
+  name: test-filter-one
+  namespace: fleet-default
+spec:
+  tpmHash: 725d98e34a6d05336f1c8f3e1b468449b6952f91439df6f2b1b704efe87fe811
+

--- a/cypress/fixtures/machine_inventory_2.yaml
+++ b/cypress/fixtures/machine_inventory_2.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventory
+metadata:
+  annotations:
+    myInvAnnotation1: myInvAnnotationValue1
+  labels:
+    testfilter: test-filter-two
+  name: test-filter-two
+  namespace: fleet-default
+spec:
+  tpmHash: 725d98e34a6d05336f1c8f3e1b468449b6952f91439df6f2b1b704efe87fe812
+

--- a/cypress/fixtures/machine_inventory_3.yaml
+++ b/cypress/fixtures/machine_inventory_3.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventory
+metadata:
+  annotations:
+    myInvAnnotation1: myInvAnnotationValue1
+  name: shouldnotmatch
+  namespace: fleet-default
+spec:
+  tpmHash: 725d98e34a6d05336f1c8f3e1b468449b6952f91439df6f2b1b704efe87fe813
+

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -28,6 +28,8 @@ declare global {
       addMachInvAnnotation(annotationName: string, annotationValue: string):Chainable<Element>;
       editMachReg(machRegName: string, addLabel?: boolean, addAnnotation?: boolean, withYAML?: boolean): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string,): Chainable<Element>;
+      importMachineInventory(machineInventoryFile: string, machineInventoryName: string): Chainable<Element>;
+      checkFilter(filterName: string, testFilterOne: boolean, testFilterTwo: boolean, shouldNotMatch: boolean): Chainable<Element>;
     }
 }}
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -285,3 +285,26 @@ Cypress.Commands.add('deleteAllMachReg', () => {
   cy.confirmDelete();
   cy.contains('There are no rows to show');
 });
+
+// Machine Inventory functions
+
+// Import machine inventory
+Cypress.Commands.add('importMachineInventory', ({machineInventoryFile, machineInventoryName}) => {
+  cy.clickNavMenu(["Inventory of Machines"]);
+  cy.clickButton('Create from YAML');
+  cy.clickButton('Read from File');
+  cy.get('input[type="file"]').attachFile({filePath: machineInventoryFile});
+  cy.clickButton('Create');
+  cy.contains('Creating').should('not.exist');
+  cy.contains(machineInventoryName).should('exist');
+});
+
+Cypress.Commands.add('checkFilter', ({filterName, testFilterOne, testFilterTwo, shouldNotMatch}) => {
+  cy.clickNavMenu(["Inventory of Machines"]);
+  cy.clickButton("Add Filter");
+  cy.get('.advanced-search-box').type(filterName);
+  cy.get('.bottom-block > .role-primary').click();
+  (testFilterOne) ? cy.contains('test-filter-one').should('exist') : cy.contains('test-filter-one').should('not.exist');
+  (testFilterTwo) ? cy.contains('test-filter-two').should('exist') : cy.contains('test-filter-two').should('not.exist');
+  (shouldNotMatch) ? cy.contains('shouldnotmatch').should('exist') : cy.contains('shouldnotmatch').should('not.exist');
+});


### PR DESCRIPTION
Fix #514

![image](https://user-images.githubusercontent.com/6025636/203757658-9a31871a-694a-4c96-80c5-b8b1a2f04199.png)

Details of the new tests:

1. Create 3 machine inventories with different labels to play with.
2. Filtering on `test-filter`, two items should match.
3. Filtering on `test-filter-one`, one item should match.
4. Filtering on `test-wrong-filter`, no item should match and UI should not crash ( regression test to catch https://github.com/rancher/elemental-ui/issues/41)

Verification run:
https://github.com/rancher/elemental/actions/runs/3541232883/jobs/5945256342
The failure is related to the upgrade issue, nothing linked to this PR.
![image](https://user-images.githubusercontent.com/6025636/203807047-aeaa49ec-0105-4732-9934-720c37cccef3.png)
