### PR TITLE
Remove fake machine inventories (Cypress tests)

### DIFF
--- a/cypress/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/cypress/e2e/unit_tests/advanced_filtering.spec.ts
@@ -43,4 +43,12 @@ describe('Advanced filtering testing', () => {
     cy.checkFilter({filterName: 'test-bad-filter', testFilterOne: false, testFilterTwo: false, shouldNotMatch: false});
     cy.contains('There are no rows which match your search query.')
   });
+
+  it('Delete all fake machine inventories', () => {
+    cy.clickNavMenu(["Inventory of Machines"]);
+    cy.get('[width="30"] > .checkbox-outer-container > .checkbox-container > .checkbox-custom').click();
+    cy.clickButton('Actions');
+    cy.get('.tooltip-inner > :nth-child(1) > .list-unstyled > :nth-child(3)').click();
+    cy.confirmDelete();
+  });
 });


### PR DESCRIPTION
Fake machine inventories must be removed, otherwise, next tests fail.

![image](https://user-images.githubusercontent.com/6025636/203821889-5f666a7c-ff08-401d-b63f-c155f1f62bd8.png)
Whereas we catch `Matches all 1 existing Inventory of Machines` in the selector test....

![image](https://user-images.githubusercontent.com/6025636/203822029-aecae574-c843-409a-b7fd-428b8eeaef10.png)

Verification run:
https://github.com/rancher/elemental/actions/runs/3541966519
The failure is related to the upgrade issue, nothing linked to this PR.
