### PR TITLE
ci/e2e: use new elemental-operator helm chart

### DIFF
--- a/.github/workflows/e2e-obs-Dev.yaml
+++ b/.github/workflows/e2e-obs-Dev.yaml
@@ -16,6 +16,10 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+        type: string
 
 concurrency:
   group: e2e-tests-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -34,7 +38,7 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}
   rke2:
     if: always()
     needs: k3s
@@ -50,4 +54,4 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-obs-Stable.yaml
+++ b/.github/workflows/e2e-obs-Stable.yaml
@@ -16,6 +16,10 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+        type: string
 
 concurrency:
   group: e2e-tests-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -34,7 +38,7 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}
   rke2:
     if: always()
     needs: k3s
@@ -50,4 +54,4 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-obs-Staging.yaml
+++ b/.github/workflows/e2e-obs-Staging.yaml
@@ -16,6 +16,10 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+        type: string
 
 concurrency:
   group: e2e-tests-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -34,7 +38,7 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}
   rke2:
     if: always()
     needs: k3s
@@ -50,4 +54,4 @@ jobs:
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner: elemental-e2e-ci-runner-spot-x86-64-2
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/elemental/elemental-operator
+      upgrade_operator: ${{ inputs.upgrade_operator }}


### PR DESCRIPTION
The new operator URI is now aligned with other Rancher charts. This PR also allows the value to be overwritten.