### PR TITLE
Drop machineName from registration.yaml example

### DIFF
--- a/examples/quickstart/registration.yaml
+++ b/examples/quickstart/registration.yaml
@@ -14,7 +14,6 @@ spec:
         reboot: true
         device: /dev/sda
         debug: true
-  machineName: my-machine
   machineInventoryLabels:
     location: "europe"
     manufacturer: "${System Information/Manufacturer}"


### PR DESCRIPTION
to prevent duplicate hostnames in a cluster

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>