### PR TITLE
Delete OS version and channel in e2e UI tests

### DIFF
--- a/cypress/e2e/unit_tests/machine_registration.spec.ts
+++ b/cypress/e2e/unit_tests/machine_registration.spec.ts
@@ -31,7 +31,7 @@ describe('Machine registration testing', () => {
     cy.get('.outlet > header').contains('Registration Endpoints');
     cy.get('body').then(($body) => {
       if (!$body.text().includes('There are no rows to show.')) {
-        cy.deleteAllMachReg();
+        cy.deleteAllResources();
       };
     });
   });

--- a/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -20,7 +20,6 @@ describe('Upgrade tests', () => {
 
     // Click on the Elemental's icon
     elemental.accessElementalMenu(); 
-
   });
 
   it('Create an OS Version Channels', () => {
@@ -46,6 +45,24 @@ describe('Upgrade tests', () => {
     cy.get('.nav').contains('OS Versions').click();
     cy.contains('Active teal-5.2', {timeout: 120000});
     cy.contains('Active teal-5.3');
+  });
+
+  it('Delete OS Versions', () => {
+    cy.get('.nav').contains('Advanced').click();
+    cy.get('.nav').contains('OS Versions').click();
+    cy.contains('teal-5.2').parent().parent().click();
+    cy.clickButton('Delete');
+    cy.confirmDelete();
+    cy.contains('teal-5.2').should('not.exist');
+  });
+
+  it('Delete OS Versions Channels', () => {
+    cy.get('.nav').contains('Advanced').click();
+    cy.get('.nav').contains('OS Version Channels').click();
+    cy.deleteAllResources();
+    cy.get('.nav').contains('Advanced').click();
+    cy.get('.nav').contains('OS Versions').click();
+    cy.contains('There are no rows to show');
   });
 
   it('Upgrade one node with OS Image Upgrades', () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -17,7 +17,7 @@ declare global {
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
       createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, customCloudConfig?: string, checkDefaultCloudConfig?: boolean): Chainable<Element>;
       deleteMachReg(machRegName: string): Chainable<Element>;
-      deleteAllMachReg():Chainable<Element>;
+      deleteAllResources():Chainable<Element>;
       addMachRegLabel(labelName: string, labelValue: string):Chainable<Element>;
       checkMachRegLabel(machRegName: string, labelName: string, labelValue: string):Chainable<Element>;
       checkMachRegAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -116,6 +116,14 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl, repoType}) => {
   cy.clickButton('Create');
 });
 
+// Delete all resources from a page
+Cypress.Commands.add('deleteAllResources', () => {  
+  cy.get('[width="30"] > .checkbox-outer-container').click();
+  cy.clickButton('Delete');
+  cy.confirmDelete();
+  cy.contains('There are no rows to show');
+});
+
 // Machine registration functions
 
 // Create a machine registration
@@ -276,14 +284,6 @@ Cypress.Commands.add('deleteMachReg', ({machRegName}) => {
   cy.clickButton('Delete');
   cy.confirmDelete();
   cy.contains(machRegName).should('not.exist')
-});
-
-// Delete all machine registrations
-Cypress.Commands.add('deleteAllMachReg', () => {  
-  cy.get('[width="30"] > .checkbox-outer-container').click();
-  cy.clickButton('Delete');
-  cy.confirmDelete();
-  cy.contains('There are no rows to show');
 });
 
 // Machine Inventory functions


### PR DESCRIPTION
Fix #500
Testing removing OS versions ans OS version channel in the UI e2e tests.

Replace `deleteAllMachReg` function by a more generic one (`deleteAllResources`).

![image](https://user-images.githubusercontent.com/6025636/205071270-2a95a223-2d06-4ee2-9229-ef18f28dd933.png)

Verification run: :heavy_check_mark: 
https://github.com/rancher/elemental/actions/runs/3592921748/jobs/6049234957
