### PR TITLE
Automatic is no longer a valid value

### DIFF
--- a/tests/assets/machineregistration.yaml
+++ b/tests/assets/machineregistration.yaml
@@ -20,7 +20,6 @@ spec:
           passwd: %PASSWORD%
     elemental:
       install:
-        automatic: true
         reboot: false
         poweroff: true
         device: /dev/sda


### PR DESCRIPTION
With the current kubebuilder branch the operator complains if unknown values are passed. On former code they were simply ignored.

Signed-off-by: David Cassany <dcassany@suse.com>