### PR TITLE
Convert runner_template to input variable

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -50,6 +50,10 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        type: string
       start_condition:
         description: Start condition of the runner
         default: success
@@ -69,9 +73,6 @@ on:
         description: build-ci workflow to use for artifacts
         default: build-ci.yaml
         type: string
-
-env:
-  runner_template: elemental-e2e-ci-runner-spot-x86-64-template-v2
 
 jobs:
   create-runner:
@@ -99,7 +100,7 @@ jobs:
       - name: Create runner
         run: |
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
-            --source-instance-template ${{ env.runner_template }} \
+            --source-instance-template ${{ inputs.runner_template }} \
             --machine-type ${{ inputs.machine_type }} \
             --zone ${{ inputs.zone }}
       - name: Create PAT token secret

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -38,10 +38,6 @@ on:
         description: Number of nodes to deploy on the provisioned cluster
         default: 5
         type: string
-      machine_type:
-        description: Type of VM
-        default: n2-standard-8
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -101,7 +97,6 @@ jobs:
         run: |
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --source-instance-template ${{ inputs.runner_template }} \
-            --machine-type ${{ inputs.machine_type }} \
             --zone ${{ inputs.zone }}
       - name: Create PAT token secret
         run: |

--- a/.github/workflows/ui-e2e-k3s.yaml
+++ b/.github/workflows/ui-e2e-k3s.yaml
@@ -28,7 +28,9 @@ jobs:
     with:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.8+k3s1
+      machine_type: n2-standard-16
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s.yaml
+++ b/.github/workflows/ui-e2e-k3s.yaml
@@ -28,7 +28,6 @@ jobs:
     with:
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.24.8+k3s1
-      machine_type: n2-standard-16
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2

--- a/.github/workflows/ui-e2e-rke2.yaml
+++ b/.github/workflows/ui-e2e-rke2.yaml
@@ -30,7 +30,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.8+rke2r1
-      machine_type: n2-standard-16
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2

--- a/.github/workflows/ui-e2e-rke2.yaml
+++ b/.github/workflows/ui-e2e-rke2.yaml
@@ -30,7 +30,9 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.8+rke2r1
+      machine_type: n2-standard-16
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}


### PR DESCRIPTION
Convert the `runner_template` env variable to an input one. 
Like that, it will be easier to use another instance template.

VR:
[k3s UI test with n2-standard-16](https://github.com/rancher/elemental/actions/runs/3619255818)