### PR TITLE
Update README CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Elemental
-[![Elemental End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/e2e.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e.yaml)
+[![K3s - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/e2e-k3s.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s.yaml)
+[![RKE2 - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/e2e-rke2.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2.yaml)
 
-[![Elemental UI End-To-End tests](https://github.com/rancher/elemental/actions/workflows/ui-e2e.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e.yaml)
+[![K3s - Elemental UI End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s.yaml)
+[![RKE2 - Elemental UI End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2.yaml)
 
 Elemental is a software stack enabling a centralized, full cloud-native OS management solution with Kubernetes.
 


### PR DESCRIPTION
Badges have to be updated as we have split the tests into small ones dedicated to either k3s or RKE2.

![image](https://user-images.githubusercontent.com/6025636/205642642-40f9bc76-49c7-4849-88c1-0304a81861e7.png)
