### PR TITLE
ci/e2e: fix failure with KubeBuilder version of operator

### DIFF
--- a/tests/assets/machineregistration.yaml
+++ b/tests/assets/machineregistration.yaml
@@ -9,7 +9,6 @@ spec:
   # Labels to be added to the created MachineInventory object
   machineInventoryLabels:
     cluster-id: id-%CLUSTER_NAME%
-    cypress: uitesting
   # Annotations to be added to the created MachineInventory object
   machineInventoryAnnotations: {}
   # The config that will be used to provision the node

--- a/tests/assets/managedOSVersionChannel.yaml
+++ b/tests/assets/managedOSVersionChannel.yaml
@@ -10,3 +10,4 @@ spec:
     URI: http://192.168.122.1:8000/tests/assets/osVersions.json
     Timeout: 1m
   type: json
+  syncInterval: 5m

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -193,12 +193,9 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 		By("Waiting for known cluster state before adding the node", func() {
 			// Get elemental-operator version
-			operatorImage, err := kubectl.Run("get", "pod",
-				"--namespace", "cattle-elemental-system",
-				"-l", "app=elemental-operator", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+			operatorVersion, err := misc.GetOperatorVersion()
 			Expect(err).To(Not(HaveOccurred()))
-			operatorVersion := strings.Split(operatorImage, ":")
-			operatorVersionShort := strings.Split(operatorVersion[1], ".")
+			operatorVersionShort := strings.Split(operatorVersion, ".")
 
 			if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
 				// Only for elemental-operator v1.0.x

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -31,6 +31,29 @@ func GetServerId(clusterNS string, index int) (string, error) {
 	return serverId, nil
 }
 
+func GetOperatorImage() (string, error) {
+	operatorImage, err := kubectl.Run("get", "pod",
+		"--namespace", "cattle-elemental-system",
+		"-l", "app=elemental-operator", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+	if err != nil {
+		return "", err
+	}
+
+	return operatorImage, nil
+}
+
+func GetOperatorVersion() (string, error) {
+	operatorImage, err := GetOperatorImage()
+	if err != nil {
+		return "", err
+	}
+
+	// Extract version
+	operatorVersion := strings.Split(operatorImage, ":")
+
+	return operatorVersion[1], nil
+}
+
 func ConfigureiPXE() (int, error) {
 	ipxeScript, err := tools.GetFiles("../..", "*.ipxe")
 	if err != nil {

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -189,14 +189,14 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				Expect(err).To(Not(HaveOccurred()))
 			}
 
-			// Check Rancher version
-			operatorVersion, err := kubectl.Run("get", "pod",
+			// Check Rancher image
+			rancherImage, err := kubectl.Run("get", "pod",
 				"--namespace", "cattle-system",
 				"-l", "app=rancher",
 				"-o", "jsonpath={.items[*].status.containerStatuses[*].image}",
 			)
 			Expect(err).To(Not(HaveOccurred()))
-			GinkgoWriter.Printf("Rancher Version:\n%s\n", operatorVersion)
+			GinkgoWriter.Printf("Rancher Image:\n%s\n", rancherImage)
 		})
 		if testType == "ui" {
 			By("Workaround for upgrade test, restart Fleet controller and agent", func() {
@@ -241,12 +241,10 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				time.Sleep(misc.SetTimeout(60 * time.Second))
 			}
 
-			// Check elemental-operator version
-			operatorVersion, err := kubectl.Run("get", "pod",
-				"--namespace", "cattle-elemental-system",
-				"-l", "app=elemental-operator", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
+			// Check elemental-operator image
+			operatorImage, err := misc.GetOperatorImage()
 			Expect(err).To(Not(HaveOccurred()))
-			GinkgoWriter.Printf("Operator Version:\n%s\n", operatorVersion)
+			GinkgoWriter.Printf("Operator Image:\n%s\n", operatorImage)
 		})
 	})
 })

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -75,8 +75,20 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 				Expect(err).To(Not(HaveOccurred()))
 
 				if upgradeType == "managedOSVersionName" {
-					// Add OS list
 					osListYaml := "../assets/managedOSVersionChannel.yaml"
+
+					// Get elemental-operator version
+					operatorVersion, err := misc.GetOperatorVersion()
+					Expect(err).To(Not(HaveOccurred()))
+					operatorVersionShort := strings.Split(operatorVersion, ".")
+
+					// Remove 'syncInterval' option if needed (only supported in operator v1.1+)
+					if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
+						err = tools.Sed("syncInterval:.*", "", osListYaml)
+						Expect(err).To(Not(HaveOccurred()))
+					}
+
+					// Add OS list
 					err = kubectl.Apply(clusterNS, osListYaml)
 					Expect(err).To(Not(HaveOccurred()))
 


### PR DESCRIPTION
This should fix #565.

Verification Run (operator Dev version): https://github.com/rancher/elemental/actions/runs/3642668127
Verification Run (operator Stable version): https://github.com/rancher/elemental/actions/runs/3643034043