### PR TITLE
Remove two CI steps not needed anymore due to ephemeral GH runners

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -331,21 +331,6 @@ jobs:
           echo "Elemental Operator Version: ${OPERATOR_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "K3s on Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "K3s/RKE2 version deployed on the cluster: ${{ inputs.k8s_version_to_provision }}" >> $GITHUB_STEP_SUMMARY
-      - name: Remove VMs and K3s/RancherManager from worker ♻
-        if: always()
-        run: |
-          # Remove all VMs
-          for I in $(sudo virsh list --all| awk '/node-/ { print $2 }'); do
-            for C in destroy undefine; do
-              [[ "${C}" == "undefine" ]] && OPT="--nvram" || unset OPT
-              sudo virsh ${C} ${OPT} ${I} >/dev/null 2>&1 || true
-            done
-          done
-          # Remove K3s and Rancher Manager
-          /usr/local/bin/k3s-uninstall.sh || true
-      - name: Remove remaining stuff from worker ♻
-        if: always()
-        uses: colpal/actions-clean@v1
       - name: Send failed status to slack
         if: failure() && github.event_name == 'schedule'
         uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
Our GH runners are now ephemeral, they are deleted after each run so we do not need paying attention to clean them.