### PR TITLE
ci/e2e: use 2 pools for cluster provisioning

### DIFF
--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -4,6 +4,10 @@ name: OBS Dev - K3s - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -38,6 +42,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -4,6 +4,10 @@ name: OBS Stable - K3s - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -38,6 +42,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -4,6 +4,10 @@ name: OBS Staging - K3s - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -38,6 +42,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/e2e-rke2-obs-Dev.yaml
@@ -4,6 +4,10 @@ name: OBS Dev - RKE2 - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -39,6 +43,7 @@ jobs:
     with:
       ca_type: private
       cluster_name: cluster-rke2
+      boolean: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/e2e-rke2-obs-Stable.yaml
@@ -4,6 +4,10 @@ name: OBS Stable - RKE2 - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -39,6 +43,7 @@ jobs:
     with:
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/e2e-rke2-obs-Staging.yaml
@@ -4,6 +4,10 @@ name: OBS Staging - RKE2 - Elemental E2E tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
@@ -39,6 +43,7 @@ jobs:
     with:
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       node_number: ${{ inputs.node_number }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -15,14 +15,18 @@ on:
         description: WebHook URL to use for Slack
         required: true
     inputs:
-      ui_account:
-        description: Account used to test RBAC role in UI
-        required: false
+      ca_type:
+        description: CA type to use (selfsigned or private)
+        default: selfsigned
         type: string
       cluster_name:
         description: Name of the provisioned cluster
         required: true
         type: string
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       elemental_support:
         description: URL of the elemental support binary
         default: https://github.com/rancher/elemental-operator/releases/download/v1.0.0/elemental-support_1.0.0_linux_amd64
@@ -33,10 +37,6 @@ on:
       k8s_version_to_provision:
         description: Name and version of installed K8s distribution
         required: true
-        type: string
-      ca_type:
-        description: CA type to use (selfsigned or private)
-        default: selfsigned
         type: string
       node_number:
         description: Number of nodes to deploy on the provisioned cluster
@@ -66,16 +66,20 @@ on:
         description: Type of test to run (cli or ui)
         default: cli
         type: string
+      ui_account:
+        description: Account used to test RBAC role in UI
+        required: false
+        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
-        type: string
-      zone:
-        description: GCP zone to host the runner
-        default: us-central1-a
         type: string
       workflow_download:
         description: build-ci workflow to use for artifacts
         default: build-ci.yaml
+        type: string
+      zone:
+        description: GCP zone to host the runner
+        default: us-central1-a
         type: string
 
 jobs:
@@ -234,7 +238,11 @@ jobs:
             cypress/e2e/unit_tests/machine_inventory.spec.ts
             cypress/e2e/unit_tests/upgrade.spec.ts
         run: |
-          export OPERATOR_VERSION=$(kubectl get pods -n cattle-elemental-system -l app=elemental-operator -o jsonpath={.items[*].status.containerStatuses[*].image}|awk -F ':' '{print substr($2,0,3)}')
+          export OPERATOR_VERSION=$(kubectl get pods \
+                                      -n cattle-elemental-system \
+                                      -l app=elemental-operator \
+                                      -o jsonpath={.items[*].status.containerStatuses[*].image} \
+                                    | awk -F ':' '{print substr($2,0,3)}')
           make -f tests/Makefile start-cypress-tests
       - name: Upload Cypress screenshots (Advanced)
         if: failure()
@@ -382,7 +390,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   delete-runner:
-    if: always() && needs.create-runner.result == 'success'
+    if: always() && needs.create-runner.result == 'success' && inputs.destroy_runner == true
     needs: [create-runner, e2e]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -3,6 +3,10 @@ name: OBS Dev - K3s - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -29,6 +33,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -3,6 +3,10 @@ name: OBS Stable - K3s - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -29,6 +33,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -3,6 +3,10 @@ name: OBS Staging - K3s - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -29,6 +33,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-k3s.yaml
+++ b/.github/workflows/ui-e2e-k3s.yaml
@@ -4,6 +4,10 @@ name: K3s - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -31,6 +35,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner || true }}
       k8s_version_to_provision: v1.24.8+k3s1
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -4,6 +4,10 @@ name: OBS Dev - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -34,6 +38,7 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -4,6 +4,10 @@ name: OBS Stable - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -34,6 +38,7 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -4,6 +4,10 @@ name: OBS Staging - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -34,6 +38,7 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-rke2.yaml
+++ b/.github/workflows/ui-e2e-rke2.yaml
@@ -4,6 +4,10 @@ name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
 on:
   workflow_dispatch:
     inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -35,6 +39,7 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner || true }}
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/tests/assets/cluster.yaml
+++ b/tests/assets/cluster.yaml
@@ -11,10 +11,19 @@ spec:
       machineConfigRef:
         apiVersion: elemental.cattle.io/v1beta1
         kind: MachineInventorySelectorTemplate
-        name: selector-%CLUSTER_NAME%
-      name: pool-%CLUSTER_NAME%
+        name: selector-master-%CLUSTER_NAME%
+      name: pool-master-%CLUSTER_NAME%
       quantity: 1
-      unhealthyNodeTimeout: 0s
+      workerRole: true
+    - controlPlaneRole: false
+      etcdRole: false
+      labels: {}
+      machineConfigRef:
+        apiVersion: elemental.cattle.io/v1beta1
+        kind: MachineInventorySelectorTemplate
+        name: selector-worker-%CLUSTER_NAME%
+      name: pool-worker-%CLUSTER_NAME%
+      quantity: 0
       workerRole: true
     etcd:
       disableSnapshots: true

--- a/tests/assets/machineRegistration.yaml
+++ b/tests/assets/machineRegistration.yaml
@@ -1,7 +1,7 @@
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineRegistration
 metadata:
-  name: machine-registration
+  name: machine-registration-%POOL_TYPE%-%CLUSTER_NAME%
   # The namespace must match the namespace of the cluster
   # assigned to the clusters.provisioning.cattle.io resource
   # namespace: fleet-default
@@ -9,6 +9,7 @@ spec:
   # Labels to be added to the created MachineInventory object
   machineInventoryLabels:
     cluster-id: id-%CLUSTER_NAME%
+    pool-type: %POOL_TYPE%
   # Annotations to be added to the created MachineInventory object
   machineInventoryAnnotations: {}
   # The config that will be used to provision the node

--- a/tests/assets/selector.yaml
+++ b/tests/assets/selector.yaml
@@ -1,13 +1,17 @@
 kind: MachineInventorySelectorTemplate
 apiVersion: elemental.cattle.io/v1beta1
 metadata:
-  name: selector-%CLUSTER_NAME%
+  name: selector-%POOL_TYPE%-%CLUSTER_NAME%
   # namespace: fleet-default
 spec:
   template:
     spec:
       selector:
         matchExpressions:
+        - key: pool-type
+          operator: In
+          values:
+          - %POOL_TYPE%
         - key: cluster-id
           operator: In
           values:

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package e2e_test
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"time"
@@ -74,12 +73,16 @@ func waitForKnownState(condition, msg string) {
 }
 
 var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
-	var (
-		client  *tools.Client
-		macAdrs string
-	)
+	It("Install node and add it in Rancher", func() {
+		var (
+			indexInPool int
+			macAdrs     string
+			poolType    string
+		)
 
-	BeforeEach(func() {
+		// indexInPool is 1 by default
+		indexInPool = 1
+
 		// Add node in network configuration if needed
 		if macAdrs == "" {
 			err := misc.AddNode(vmName, vmIndex, netDefaultFileName)
@@ -89,15 +92,26 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		hostData, err := tools.GetHostNetConfig(".*name=\""+vmName+"\".*", netDefaultFileName)
 		Expect(err).To(Not(HaveOccurred()))
 
-		client = &tools.Client{
+		client := &tools.Client{
 			Host:     string(hostData.IP) + ":22",
 			Username: userName,
 			Password: userPassword,
 		}
 		macAdrs = hostData.Mac
-	})
 
-	It("Install node and add it in Rancher", func() {
+		// Set pool type and name
+		poolName := "pool-"
+		if vmIndex < 4 {
+			// First third nodes are in Master pool
+			poolType = "master"
+			poolName += poolType + "-" + clusterName
+		} else {
+			// The others are in Worker pool
+			poolType = "worker"
+			poolName += poolType + "-" + clusterName
+		}
+		machineReg := "machine-registration-" + poolType + "-" + clusterName
+
 		By("Setting emulated TPM to "+emulateTPM, func() {
 			// Set correct value for TPM emulation
 			value := "false"
@@ -110,7 +124,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			out, err := kubectl.Run("patch", "MachineRegistration",
-				"--namespace", clusterNS, "machine-registration",
+				"--namespace", clusterNS, machineReg,
 				"--type", "merge", "--patch-file", emulatedTPMYaml,
 			)
 			Expect(err).To(Not(HaveOccurred()), out)
@@ -119,8 +133,8 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		By("Downloading installation config file", func() {
 			// Download the new YAML installation config file
 			tokenURL, err := kubectl.Run("get", "MachineRegistration",
-				"--namespace", clusterNS,
-				"machine-registration", "-o", "jsonpath={.status.registrationURL}")
+				"--namespace", clusterNS, machineReg,
+				"-o", "jsonpath={.status.registrationURL}")
 			Expect(err).To(Not(HaveOccurred()))
 
 			fileName := "../../install-config.yaml"
@@ -171,23 +185,16 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Expect(id).To(Not(BeEmpty()))
 		})
 
-		By("Ensuring that the cluster is in healthy state (not on 1st node)", func() {
-			if vmIndex > 1 {
-				checkClusterState()
-			}
-		})
-
 		if vmIndex > 1 {
-			By("Increasing 'quantity' node of predefined cluster", func() {
-				// Patch the already-created yaml file directly
-				err := tools.Sed("quantity:.*", "quantity: "+fmt.Sprint(vmIndex), clusterYaml)
-				Expect(err).To(Not(HaveOccurred()))
+			By("Ensuring that the cluster is in healthy state", func() {
+				checkClusterState()
+			})
 
-				out, err := kubectl.Run("patch", "cluster",
-					"--namespace", clusterNS, clusterName,
-					"--type", "merge", "--patch-file", clusterYaml,
-				)
-				Expect(err).To(Not(HaveOccurred()), out)
+			By("Increasing 'quantity' node of predefined cluster", func() {
+				// Increase 'quantity' field
+				var err error
+				indexInPool, err = misc.IncreaseQuantity(clusterName, clusterNS, poolName)
+				Expect(err).To(Not(HaveOccurred()))
 			})
 		}
 
@@ -200,8 +207,13 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
 				// Only for elemental-operator v1.0.x
 				if vmIndex > 1 {
-					waitForKnownState(".status.conditions[?(@.type==\"Updated\")].message",
-						"WaitingForBootstrapReason")
+					if indexInPool == 1 {
+						waitForKnownState(".status.conditions[?(@.type==\"Updated\")].message",
+							"waiting for agent to check in and apply initial plan")
+					} else {
+						waitForKnownState(".status.conditions[?(@.type==\"Updated\")].message",
+							"WaitingForBootstrapReason")
+					}
 				} else {
 					waitForKnownState(".status.conditions[?(@.type==\"Provisioned\")].message",
 						"waiting for viable init node")

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -260,7 +260,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			Eventually(func() string {
 				out, _ := client.RunSSH("kubectl version 2>/dev/null | grep 'Server Version:'")
 				return out
-			}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring(k8sVersion))
+			}, misc.SetTimeout(5*time.Minute), 5*time.Second).Should(ContainSubstring(k8sVersion))
 		})
 
 		By("Checking cluster state", func() {

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -16,6 +16,7 @@ package e2e_test
 
 import (
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -156,6 +157,17 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 				}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("machine-registration-" + pool + "-" + clusterName))
 			}
 		})
+
+		// Only for K3s cluster
+		if strings.Contains(k8sVersion, "k3s") {
+			By("Setting controlPlane role for worker pool", func() {
+				// Wait a little before toggling the role
+				time.Sleep(misc.SetTimeout(1 * time.Minute))
+
+				err := misc.ToggleRole(clusterNS, clusterName, "pool-worker-"+clusterName, "ControlPlaneRole", true)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+		}
 
 		By("Starting HTTP server for network installation", func() {
 			// TODO: improve it to run in background!

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -1,11 +1,13 @@
 package misc
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -91,6 +93,52 @@ type ClusterCondition struct {
 const (
 	httpSrv = "http://192.168.122.1:8000"
 )
+
+func (c *Cluster) getCluster(ns, name string) error {
+	out, err := kubectl.Run("get", "cluster",
+		"--namespace", ns, name,
+		"-o", "yaml")
+	if err != nil {
+		return err
+	}
+
+	// Decode content
+	if err := yaml.Unmarshal([]byte(out), c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Cluster) setCluster(ns, name string) error {
+	// Encode content
+	out, err := yaml.Marshal(&c)
+	if err != nil {
+		return err
+	}
+
+	// Use temporary file
+	f, err := os.CreateTemp("", "updatedCluster")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+
+	if _, err := f.Write(out); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Apply new cluster configuration
+	if err := kubectl.Apply(ns, f.Name()); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func GetServerId(clusterNS string, index int) (string, error) {
 	serverId, err := kubectl.Run("get", "MachineInventories",
@@ -183,58 +231,88 @@ func SetTimeout(timeout time.Duration) time.Duration {
 	return timeout
 }
 
-func IncreaseQuantity(clusterName, clusterNS, pool string) (int, error) {
-	// Quantity set
-	quantitySet := 0
-
-	// Data to store
+func IncreaseQuantity(ns, name, pool string) (int, error) {
 	c := &Cluster{}
+	quantitySet := 0
+	poolFound := false
 
-	// Get content
-	out, err := kubectl.Run("get", "cluster",
-		"--namespace", clusterNS, clusterName,
-		"-o", "yaml")
-	if err != nil {
+	// Get cluster configuration
+	if err := c.getCluster(ns, name); err != nil {
 		return 0, err
 	}
 
-	// Convert string to []byte
-	clusterConf := []byte(out)
-
-	// Decode content
-	if err := yaml.Unmarshal(clusterConf, &c); err != nil {
-		return 0, err
-	}
-
-	// Increase quantity field
+	// Try to increase quantity field
 	for i := range c.Spec.RkeConfig.MachinePools {
 		// Only on selected pool
 		if c.Spec.RkeConfig.MachinePools[i].Name == pool {
+			// Pool found!
+			poolFound = true
+
+			// Increase quantity
 			c.Spec.RkeConfig.MachinePools[i].Quantity++
 			quantitySet = c.Spec.RkeConfig.MachinePools[i].Quantity
+
+			// Quantity increased, loop can be stopped
+			break
 		}
 	}
 
-	// Encode content
-	clusterConf, err = yaml.Marshal(&c)
-	if err != nil {
+	// Throw an error if the pool has not been found
+	if !poolFound {
+		return 0, errors.New("pool '" + pool + "' does not exist!")
+	}
+
+	// Save and apply cluster configuration
+	if err := c.setCluster(ns, name); err != nil {
 		return 0, err
 	}
 
-	// Write temporary file
-	tempFile := "updated-" + pool + ".yaml"
-	if err = os.WriteFile(tempFile, clusterConf, 0644); err != nil {
-		return 0, err
-	}
-
-	// Apply the new configuration
-	err = kubectl.Apply(clusterNS, tempFile)
-	if err != nil {
-		return 0, err
-	}
-
-	// All good!
 	return quantitySet, nil
+}
+
+func ToggleRole(ns, name, pool, role string, value bool) error {
+	c := &Cluster{}
+	poolFound := false
+
+	// Get cluster configuration
+	if err := c.getCluster(ns, name); err != nil {
+		return err
+	}
+
+	// Try to set value to role
+	for i := range c.Spec.RkeConfig.MachinePools {
+		// Only on selected pool
+		if c.Spec.RkeConfig.MachinePools[i].Name == pool {
+			// Pool found!
+			poolFound = true
+
+			// Get fields list and check that the role exist
+			v := reflect.ValueOf(&c.Spec.RkeConfig.MachinePools[i]).Elem()
+			f := v.FieldByName(role)
+			if f == (reflect.Value{}) {
+				// No, return an error
+				return errors.New("role '" + role + "' does not exist!")
+			} else {
+				// Yes, set the value accordingly
+				v.FieldByName(role).SetBool(value)
+
+				// Role toggled, loop can be stopped
+				break
+			}
+		}
+	}
+
+	// Throw an error if the pool has not been found
+	if !poolFound {
+		return errors.New("pool '" + pool + "' does not exist!")
+	}
+
+	// Save and apply cluster configuration
+	if err := c.setCluster(ns, name); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func AddSelector(key, value string) ([]byte, error) {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -31,7 +31,7 @@ const (
 	netDefaultFileName = "../assets/net-default.xml"
 	clusterYaml        = "../assets/cluster.yaml"
 	selectorYaml       = "../assets/selector.yaml"
-	registrationYaml   = "../assets/machineregistration.yaml"
+	registrationYaml   = "../assets/machineRegistration.yaml"
 	emulatedTPMYaml    = "../assets/emulated_tpm.yaml"
 )
 

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -26,22 +26,16 @@ import (
 )
 
 var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
-	var (
-		client *tools.Client
-	)
-
-	BeforeEach(func() {
+	It("Upgrade node", func() {
 		hostData, err := tools.GetHostNetConfig(".*name=\""+vmName+"\".*", netDefaultFileName)
 		Expect(err).To(Not(HaveOccurred()))
 
-		client = &tools.Client{
+		client := &tools.Client{
 			Host:     string(hostData.IP) + ":22",
 			Username: userName,
 			Password: userPassword,
 		}
-	})
 
-	It("Upgrade node", func() {
 		By("Checking if upgrade type is set", func() {
 			Expect(upgradeType).To(Not(BeEmpty()))
 		})
@@ -65,8 +59,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 
 				// We don't know what is the previous type of upgrade, so easier to replace all here
 				// as there is only one in the yaml file anyway
-				patterns := []string{"%OS_IMAGE%", "osImage:.*", "managedOSVersionName:.*"}
-				for _, p := range patterns {
+				for _, p := range []string{"%OS_IMAGE%", "osImage:.*", "managedOSVersionName:.*"} {
 					err := tools.Sed(p, upgradeType+": "+upgradeTypeValue, upgradeOsYaml)
 					Expect(err).To(Not(HaveOccurred()))
 				}


### PR DESCRIPTION
Use a "master" pool for the first 3 nodes and a "worker" pool for all others.

Should fix #531.

Verification runs:
  - [OBS Stable - RKE2 - Elemental UI End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/runs/3713901006)
  - [OBS Stable - RKE2 - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/runs/3713954273)
  - [OBS Stable - K3s - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/runs/3715364100)
  - [OBS Dev - K3s - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/runs/3716567199) - It fails because of this [operator issue](https://github.com/rancher/elemental-operator/pull/307)

Non Regression tests on UI: https://github.com/rancher/elemental/actions/runs/3713901006