### PR TITLE
Disable Rancher extension repository in UI tests

### DIFF
--- a/cypress/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/cypress/e2e/unit_tests/elemental_plugin.spec.ts
@@ -23,6 +23,7 @@ describe('Install Elemental plugin', () => {
     cy.contains('Extensions').click();
     cy.clickButton('Enable');
     cy.contains('Enable Extension Support?')
+    cy.contains('Add the Rancher Extension Repository').click();
     cy.clickButton('OK');
     cy.contains('No Extensions installed', {timeout: 40000});
   });
@@ -35,6 +36,11 @@ describe('Install Elemental plugin', () => {
     cy.contains('Install Extension elemental');
     cy.clickButton('Install');
     cy.contains('Installing');
-    cy.wait(20000);
+    cy.contains('Extensions changed - reload required', {timeout: 40000});
+    cy.clickButton('Reload');
+    cy.get('.plugins')
+      .children()
+      .should('contain', 'elemental')
+      .and('contain', 'Uninstall')
   });
 });


### PR DESCRIPTION
Fix #579 

## Main change
Disable the rancher extension repository to be able to install elemental-ui from a dev repository.
![image](https://user-images.githubusercontent.com/6025636/207556324-aaeb8fa1-b27d-494a-9513-a6666446774e.png)

## Local Cypress run
![image](https://user-images.githubusercontent.com/6025636/207555978-528b336f-3dcc-4665-aefd-34e8bd14d86f.png)

## Verification run
https://github.com/rancher/elemental/actions/runs/3693433209

