### PR TITLE
Add dev, staging and stage scenarios for UI e2e

### DIFF
--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -1,5 +1,4 @@
-# This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Dev - K3s - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,26 +17,22 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
-  ui-rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      cluster_name: cluster-k3s
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -1,5 +1,4 @@
-# This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Stable - K3s - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,26 +17,22 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
-  ui-rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      cluster_name: cluster-k3s
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -1,5 +1,4 @@
-# This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Staging - K3s - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,26 +17,22 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
-  ui-rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      cluster_name: cluster-k3s
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Dev - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,9 +18,8 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
   ui-rke2:
@@ -35,9 +34,10 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Stable - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,9 +18,8 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
   ui-rke2:
@@ -35,9 +34,10 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS Staging - RKE2 - Elemental UI End-To-End tests with Rancher Manager
 
 on:
   workflow_dispatch:
@@ -18,9 +18,8 @@ on:
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
   ui-rke2:
@@ -35,9 +34,10 @@ jobs:
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}


### PR DESCRIPTION
Fix #580 

With this PR, we will be able to manually trigger e2e UI tests on many OBS artifacts like dev, staging and stage like we do for e2e CLI.

Verification Run:
[k3s OBS Dev](https://github.com/rancher/elemental/actions/runs/3695822413/jobs/6258727210)
[k3s OBS Staging](https://github.com/rancher/elemental/actions/runs/3696729959/jobs/6263407056)