### PR TITLE
Add proxy tests in UI

### DIFF
--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -12,6 +12,10 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: number
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -46,6 +50,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -12,6 +12,10 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -46,6 +50,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -12,6 +12,10 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: number
+      proxy:
+        description: Deploy a proxy (none / rancher / elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -46,6 +50,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       node_number: ${{ inputs.node_number }}
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -48,6 +48,9 @@ on:
         description: Number of nodes to deploy on the provisioned cluster
         default: 5
         type: string
+      proxy:
+        description: Deploy a proxy
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -178,10 +181,15 @@ jobs:
           mv -f build/* .
           # Looks a little bit weird but we have to keep the ISO in build!
           mv -f elemental-*.iso build/
+      - name: Deploy Proxy
+        id: proxy
+        if: inputs.proxy == 'elemental' || inputs.proxy == 'rancher'
+        run: docker run -d -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
       - name: Install Rancher
         id: installation
         env:
           CA_TYPE: ${{ inputs.ca_type }}
+          PROXY: ${{ inputs.proxy }}
           TEST_TYPE: ${{ inputs.test_type }}
         run: |
           export MY_HOSTNAME=$(hostname -f)
@@ -240,6 +248,7 @@ jobs:
           UI_ACCOUNT: ${{ inputs.ui_account }}
           BROWSER: firefox
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          PROXY: ${{ inputs.proxy }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
           RANCHER_USER: admin

--- a/.github/workflows/ui-e2e-k3s.yaml
+++ b/.github/workflows/ui-e2e-k3s.yaml
@@ -8,6 +8,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -37,6 +41,7 @@ jobs:
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner || true }}
       k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}

--- a/tests/assets/squid.conf
+++ b/tests/assets/squid.conf
@@ -1,0 +1,83 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
+acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
+acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
+acl localnet src fc00::/7       # RFC 4193 local private network range
+acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl SSL_ports port 6443
+acl SSL_ports port 22
+acl SSL_ports port 2376
+ 
+acl Safe_ports port 22      # ssh
+acl Safe_ports port 2376    # docker port
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl Safe_ports port 6443        # k8s
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access allow all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+
+debug_options ALL,1 11,3 20,3
+

--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -34,6 +34,19 @@ describe('Machine inventory testing', () => {
     cy.typeValue({label: 'Cluster Description', value: 'My Elemental testing cluster'});
     cy.contains('Kubernetes Version').click();
     cy.contains(k8s_version).click();
+    // Configure proxy if proxy is set to elemental
+    if ( Cypress.env('proxy') == "elemental") {
+      cy.contains('Agent Environment Vars').click();
+      cy.get('#agentEnv > .key-value').contains('Add').click();
+      cy.get('.key > input').type('HTTP_PROXY');
+      cy.get('.no-resize').type('http://192.168.122.1:3128');
+      cy.get('#agentEnv > .key-value').contains('Add').click();
+      cy.get(':nth-child(7) > input').type('HTTPS_PROXY');
+      cy.get(':nth-child(8) > .no-resize').type('http://192.168.122.1:3128');
+      cy.get('#agentEnv > .key-value').contains('Add').click();
+      cy.get(':nth-child(10) > input').type('NO_PROXY');
+      cy.get(':nth-child(11) > .no-resize').type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
+    }
     cy.clickButton('Create');
     cy.contains('Updating myelementalcluster', {timeout: 20000});
     cy.contains('Active myelementalcluster', {timeout: 360000});

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -21,6 +21,8 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.k8s_version = process.env.K8S_VERSION_TO_PROVISION;
   config.env.ui_account = process.env.UI_ACCOUNT;
   config.env.operator_version = process.env.OPERATOR_VERSION;
+  config.env.proxy = process.env.PROXY;
+  config.env.proxy_ip = process.env.PROXY_IP;
 
   return config;
 };

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -152,6 +152,14 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				)
 			}
 
+			// Use Rancher Manager behind proxy
+			if proxy == "rancher" {
+				flags = append(flags,
+					"--set", "proxy=http://172.17.0.1:3128",
+					"--set", "noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local",
+				)
+			}
+
 			err = kubectl.RunHelmBinaryWithCustomErr(flags...)
 			Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -53,6 +53,7 @@ var (
 	isoBoot             string
 	k8sVersion          string
 	osImage             string
+	proxy               string
 	rancherChannel      string
 	rancherLogCollector string
 	rancherVersion      string
@@ -85,6 +86,7 @@ var _ = BeforeSuite(func() {
 	isoBoot = os.Getenv("ISO_BOOT")
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	osImage = os.Getenv("CONTAINER_IMAGE")
+	proxy = os.Getenv("PROXY")
 	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")
 	rancherVersion = os.Getenv("RANCHER_VERSION")

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -19,6 +19,7 @@ docker run -v $PWD:/e2e -w /e2e                            \
     -e K8S_VERSION_TO_PROVISION=$K8S_VERSION_TO_PROVISION  \
     -e UI_ACCOUNT=$UI_ACCOUNT                              \
     -e OPERATOR_VERSION=$OPERATOR_VERSION                  \
+    -e PROXY=$PROXY                                        \
     --add-host host.docker.internal:host-gateway           \
     --ipc=host                                             \
     $CYPRESS_DOCKER                                        \


### PR DESCRIPTION
Fix #492 
# What do we want to test?
1) Elemental node behind a proxy (most important one FMPOV)
2) Rancher manager behind the proxy

# How the proxy works?
It is a simple container running on the github runner:
`docker run -d -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid`
And the proxy is reachable via `192.168.122.1:3128`, a new firewall rule has been added to GCP to allow tcp traffic on port 3128.

# Verification runs:
## 1 - k3s - Elemental cluster behind proxy 
https://github.com/rancher/elemental/actions/runs/3799671144 :heavy_check_mark: 

![image](https://user-images.githubusercontent.com/6025636/209950888-93c0c9a6-de12-4e29-8440-107c80473871.png)
Proxy's log:
```
1672310331.838  54394 172.17.0.1 TCP_TUNNEL/200 204571 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310331.838  54406 172.17.0.1 TCP_TUNNEL/200 2011 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310333.487  64621 172.17.0.1 TCP_TUNNEL/200 204765 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310333.499 421937 172.17.0.1 TCP_TUNNEL/200 480816 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310333.499 423339 172.17.0.1 TCP_TUNNEL/200 1078264 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310377.636   5099 172.17.0.1 TCP_TUNNEL/200 10360 CONNECT auth.docker.io:443 - HIER_DIRECT/44.205.64.79 -
1672310378.691   6276 172.17.0.1 TCP_TUNNEL/200 10036 CONNECT index.docker.io:443 - HIER_DIRECT/3.228.146.75 -
1672310394.230      5 172.17.0.1 TCP_TUNNEL/200 1712 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310400.413     13 172.17.0.1 TCP_TUNNEL/200 3035 CONNECT elemental-ci-cf3e2af3-56dd-42de-8c08-c4ea1461d42f.us-central1-a.c.ei-container-eco.internal:443 - HIER_DIRECT/10.128.15.217 -
1672310404.385   1835 172.17.0.1 TCP_TUNNEL/200 222422 CONNECT git.rancher.io:443 - HIER_DIRECT/34.208.213.149 -
1672310405.294   2708 172.17.0.1 TCP_TUNNEL/200 17538996 CONNECT git.rancher.io:443 - HIER_DIRECT/34.208.213.149 -
```
We can see traffic goes through our proxy.

## 2 - k3s - Rancher Manager behind proxy 
https://github.com/rancher/elemental/actions/runs/3807453121 :heavy_check_mark: 

Proxy's log:
```
/var/log/squid # tail -f access.log 



1672411522.715   1086 172.17.0.1 TCP_TUNNEL/200 1747346 CONNECT git.rancher.io:443 - HIER_DIRECT/34.208.213.149 -
1672411523.748    681 172.17.0.1 TCP_TUNNEL/200 667621 CONNECT git.rancher.io:443 - HIER_DIRECT/34.208.213.149 -
1672411524.502   1932 172.17.0.1 TCP_TUNNEL/200 5663013 CONNECT git.rancher.io:443 - HIER_DIRECT/34.208.213.149 -
```

## TODO (in a next PR):
- use the same IP (172.17.0.1) for the proxy
- check the proxy log to make sure the traffic passes through it
- upload proxy log