### PR TITLE
ci: fix generated README for tests description

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -9,6 +9,12 @@ on:
         description: Credentials to use to connect
         required: true
       pat_token:
+        # A token is needed to be able to add runner on the repo, maybe this can be changed later
+        # This token is linked to a personal account
+        # So in case of token issue you have to check (no specific order and for example):
+        # - the expiration date
+        # - if the account associated still exists
+        # - if the person still has access to the repo
         description: PAT token used to add runner
         required: true
       slack_webhook_url:

--- a/.github/workflows/update-tests-description.yaml
+++ b/.github/workflows/update-tests-description.yaml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          # A token is needed to be able to push on main, maybe this can be changed later
+          # with another GHA or with some webhook?
+          # This token is linked to a personal account (already used for GCP runner)
+          # So in case of token issue you have to check (no specific order and for example):
+          # - the expiration date
+          # - if the account associated still exists
+          # - if the person still has access to the repo
           token: ${{ secrets.PAT_TOKEN }}
       - name: Generate tests description file
         id: readme_generator

--- a/.github/workflows/update-tests-description.yaml
+++ b/.github/workflows/update-tests-description.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
       - name: Generate tests description file
         id: readme_generator
         run: |


### PR DESCRIPTION
We have to use a token to allow commit's push on main branch.

Tested on my lab after adding the same restrictions on my `main` branch:
- [test with branch locked and no token](https://github.com/ldevulder/gha-tests/actions/runs/3806093679)
- [test with branch locked and token used](https://github.com/ldevulder/gha-tests/actions/runs/3806100777/jobs/6474599340)