### PR TITLE
Improve proxy tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -184,7 +184,7 @@ jobs:
       - name: Deploy Proxy
         id: proxy
         if: inputs.proxy == 'elemental' || inputs.proxy == 'rancher'
-        run: docker run -d -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
+        run: docker run -d --name squid_proxy -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
       - name: Install Rancher
         id: installation
         env:
@@ -340,6 +340,7 @@ jobs:
         if: always()
         env:
           ELEMENTAL_SUPPORT: ${{ inputs.elemental_support }}
+          PROXY: ${{ inputs.proxy }}
           RANCHER_LOG_COLLECTOR: ${{ inputs.rancher_log_collector }}
         run: |
           cd tests && (

--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -8,8 +8,9 @@ describe('Machine inventory testing', () => {
   const elemental      = new Elemental();
   const k8s_version    = Cypress.env('k8s_version');
   const ui_account     = Cypress.env('ui_account');
-  const elemental_user = "elemental-user"
-  const ui_password    = "rancherpassword"
+  const elemental_user = 'elemental-user'
+  const ui_password    = 'rancherpassword'
+  const proxy          = 'http://172.17.0.1:3128'
 
   beforeEach(() => {
     (ui_account == "user") ? cy.login(elemental_user, ui_password) : cy.login();
@@ -39,10 +40,10 @@ describe('Machine inventory testing', () => {
       cy.contains('Agent Environment Vars').click();
       cy.get('#agentEnv > .key-value').contains('Add').click();
       cy.get('.key > input').type('HTTP_PROXY');
-      cy.get('.no-resize').type('http://192.168.122.1:3128');
+      cy.get('.no-resize').type(proxy);
       cy.get('#agentEnv > .key-value').contains('Add').click();
       cy.get(':nth-child(7) > input').type('HTTPS_PROXY');
-      cy.get(':nth-child(8) > .no-resize').type('http://192.168.122.1:3128');
+      cy.get(':nth-child(8) > .no-resize').type(proxy);
       cy.get('#agentEnv > .key-value').contains('Add').click();
       cy.get(':nth-child(10) > input').type('NO_PROXY');
       cy.get(':nth-child(11) > .no-resize').type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -77,5 +77,13 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 				}
 			}
 		})
+
+		if proxy != "" {
+			log := exec.Command("docker", "exec", "squid_proxy", "cat", "/var/log/squid/access.log")
+			out, err := log.CombinedOutput()
+			checkRC(err)
+			err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
+			checkRC(err)
+		}
 	})
 })

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -79,11 +79,13 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 		})
 
 		if proxy != "" {
-			log := exec.Command("docker", "exec", "squid_proxy", "cat", "/var/log/squid/access.log")
-			out, err := log.CombinedOutput()
-			checkRC(err)
-			err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
-			checkRC(err)
+			By("Collecting proxy log and make sure traffic went through it", func() {
+				out, err := exec.Command("docker", "exec", "squid_proxy", "cat", "/var/log/squid/access.log").CombinedOutput()
+				checkRC(err)
+				err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
+				checkRC(err)
+				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT git.rancher.io"))
+			})
 		}
 	})
 })


### PR DESCRIPTION
Fix #601 

## Verification runs:
1) k3s + elemental node behind proxy: :heavy_check_mark: 
https://github.com/rancher/elemental/actions/runs/3829106330/jobs/6515446391

![image](https://user-images.githubusercontent.com/6025636/210358391-0c231b39-5eda-4d68-a4ef-9681947a526a.png)
Proxy log is in the support-logs archive

2) k3s + Rancher manager behind proxy: :heavy_check_mark: 
https://github.com/rancher/elemental/actions/runs/3829964335
