### PR TITLE
ci/ui: fix permissions for 'downloads' directory #2

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -342,7 +342,13 @@ jobs:
           ELEMENTAL_SUPPORT: ${{ inputs.elemental_support }}
           RANCHER_LOG_COLLECTOR: ${{ inputs.rancher_log_collector }}
         run: |
-          cd tests && make e2e-get-logs
+          cd tests && (
+            # Removing 'downloads' is needed to avoid this error during 'make':
+            # 'pattern all: open .../elemental/tests/cypress/downloads: permission denied'
+            sudo rm -rf cypress/downloads
+
+            make e2e-get-logs
+          )
       - name: Upload cluster logs
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
It was missing for `Store logs` step.

It should fix this [issue](https://github.com/rancher/elemental/actions/runs/3828137506/jobs/6513408580).