### PR TITLE
Add support for Podman for registration injection into ISO

### DIFF
--- a/.github/elemental-iso-add-registration
+++ b/.github/elemental-iso-add-registration
@@ -47,7 +47,7 @@ iso_repack() {
 
   cp "${REG_CONFIG_FILE}" "${TEMPDIR}/config/${REG_FILE}"
 
-  if [ -f "/var/run/docker.pid" ]; then
+  if [ -S "/var/run/docker.sock" ]; then
     CONT_ENGINE="docker"
   elif [ -x "$(command -v podman)" ]; then
     CONT_ENGINE="podman"

--- a/.github/elemental-iso-add-registration
+++ b/.github/elemental-iso-add-registration
@@ -6,7 +6,7 @@ usage() {
 me=$(basename "$0")
 cat << EOF
 
-usage: 
+usage:
    $me REGISTRATION_CONFIG_FILE [ISO_URL]
 
 REGISTRATION_CONFIG_FILE is the yaml file required by elemental-register in
@@ -34,22 +34,30 @@ iso_repack() {
 
   [ -f "$(pwd)/${ISO_FILE}" ] && abort "$(pwd)/${ISO_FILE} already exists, aborting"
 
-  case ${ISO_URL} in 
+  case ${ISO_URL} in
     http*)
       wget -O "${TEMPDIR}/iso/${ISO_FILE}" "${ISO_URL}"
       ;;
     *)
       # Assume it is a local path
       [ -f "${ISO_URL}" ] || abort "${ISO_URL} does not exist, aborting"
-      cp "${ISO_URL}" "${TEMPDIR}/iso/${ISO_FILE}" 
+      cp "${ISO_URL}" "${TEMPDIR}/iso/${ISO_FILE}"
       ;;
   esac
 
   cp "${REG_CONFIG_FILE}" "${TEMPDIR}/config/${REG_FILE}"
 
+  if [ -f "/var/run/docker.pid" ]; then
+    CONT_ENGINE="docker"
+  elif [ -x "$(command -v podman)" ]; then
+    CONT_ENGINE="podman"
+  else
+    abort "No suitable container engine found, please install Docker or Podman first."
+  fi
+  echo -e "\nInfo: Using $CONT_ENGINE to run the ISO builder..."
 
-  docker pull "${BUILD_IMG}"
-  docker run --rm -v ${TEMPDIR}:/mnt -v $(pwd):/output ${BUILD_IMG} \
+  $CONT_ENGINE pull "${BUILD_IMG}"
+  $CONT_ENGINE run --rm -v ${TEMPDIR}:/mnt -v $(pwd):/output ${BUILD_IMG} \
       xorriso -indev "/mnt/iso/${ISO_FILE}" -outdev "/output/${ISO_FILE}" -map "/mnt/config/${REG_FILE}" "/${REG_FILE}" -boot_image any replay
 
   rm -rf "${TEMPDIR}"

--- a/.github/elemental-iso-add-registration
+++ b/.github/elemental-iso-add-registration
@@ -13,7 +13,7 @@ REGISTRATION_CONFIG_FILE is the yaml file required by elemental-register in
 order to self register against the elemental-operator.
 
 ISO_URL is the URL of an elemental ISO, defaults to community Elemental Teal
-ISO releases if not set. I can also be a local path.
+ISO releases if not set. It can also be a local path.
 
 EOF
 }
@@ -47,7 +47,8 @@ iso_repack() {
 
   cp "${REG_CONFIG_FILE}" "${TEMPDIR}/config/${REG_FILE}"
 
-  if [ -S "/var/run/docker.sock" ]; then
+  # Check which container engine might be available (tests use Colima).
+  if [ -S "/var/run/docker.sock" ] || [ -x "$(command -v colima)" ]; then
     CONT_ENGINE="docker"
   elif [ -x "$(command -v podman)" ]; then
     CONT_ENGINE="podman"


### PR DESCRIPTION
Here I've added support for using Podman for the injection of registration information to the Elemental Teal ISO. This does not replace Docker as the default (if it's available on the client) but provides an option for those of us using Podman instead (bypassing the `alias docker=podman` hack). This has been tested on Tumbleweed with Podman and Ubuntu with Docker.

I have also cleaned up a little bit of whitespace that I found lingering.