### PR TITLE
ci: fix "test inject in iso" workflow

### DIFF
--- a/.github/elemental-iso-add-registration
+++ b/.github/elemental-iso-add-registration
@@ -25,7 +25,7 @@ abort() {
 }
 
 iso_repack() {
-  local TEMPDIR=$(mktemp -d)
+  local TEMPDIR=$(mktemp -d $HOME/elemental_iso.XXX)
   local ISO_FILE=$(basename "${ISO_URL}")
   local REG_FILE="livecd-cloud-config.yaml"
 

--- a/.github/workflows/build-iso-inject-pr.yaml
+++ b/.github/workflows/build-iso-inject-pr.yaml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         arch: ["amd64"]
-        include:
-          - os: ubuntu-latest
-            arch: "arm64"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Docker on MacOS and start Colima

--- a/.github/workflows/build-iso-inject-pr.yaml
+++ b/.github/workflows/build-iso-inject-pr.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/elemental-iso-add-registration
+      - .github/workflows/build-iso-inject-pr.yaml
 
 jobs:
   elemental-iso-build:
@@ -18,18 +19,26 @@ jobs:
             arch: "arm64"
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Docker on MacOS and start Colima
+        if: runner.os == 'macOS'
+        run: |
+          # NOTE: we're not using docker-practice/actions-setup-docker because of issues with it
+          brew install docker
+          # Docker engine is not available because of licensing issue
+          # See https://github.com/actions/runner-images/issues/2150#issuecomment-737125967
+          # Alternative Colima is part of the github macOS runner, start it for Docker
+          colima start
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Install deps (${{ matrix.os}})
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install deps (${{ runner.os }})
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mkisofs
-      - name: Install deps (${{ matrix.os}})
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install cdrtools
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y mkisofs
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            brew install cdrtools
+          fi
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -53,6 +62,6 @@ jobs:
         run: |
           ISO=$(find . -name "elemental-*.iso" -print)
           # Check it has eltorito
-          isoinfo -d -i $ISO|grep -q Eltorito
+          isoinfo -d -i $ISO | grep -q Eltorito
           # check bootable flag
-          isoinfo -d -i $ISO|grep -q bootable        
+          isoinfo -d -i $ISO | grep -q bootable


### PR DESCRIPTION
It fails on macOS, as Docker needs to be installed before buildx.