### PR TITLE
Fix ISO build and upgrade tests with managedOSVersionChannel 

### DIFF
--- a/Dockerfile.iso
+++ b/Dockerfile.iso
@@ -1,5 +1,5 @@
-ARG OS_IMAGE=registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-node-image/5.3:latest
-ARG TOOL_IMAGE=registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-builder-image/5.3:latest
+ARG OS_IMAGE=registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-teal/5.3:latest
+ARG TOOL_IMAGE=registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-builder-image/5.3:latest
 
 FROM $OS_IMAGE AS os
 FROM $TOOL_IMAGE as tools

--- a/tests/assets/osVersions.json
+++ b/tests/assets/osVersions.json
@@ -7,19 +7,19 @@
       "version": "teal-5.3",
       "type": "container",
       "metadata": {
-        "upgradeImage": "registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-node-image/5.3:latest"
+        "upgradeImage": "registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-node-image/5.3:latest"
       }
     }
   },
   {
     "metadata": {
-      "name": "teal-5.2"
+      "name": "fake-image"
     },
     "spec": {
-      "version": "teal-5.2",
+      "version": "fake-image",
       "type": "container",
       "metadata": {
-        "upgradeImage": "registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-node-image/5.2:latest"
+        "upgradeImage": "fake-image"
       }
     }
   }

--- a/tests/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -45,17 +45,17 @@ describe('Upgrade tests', () => {
   it('Check OS Versions', () => {
     cy.get('.nav').contains('Advanced').click();
     cy.get('.nav').contains('OS Versions').click();
-    cy.contains('Active teal-5.2', {timeout: 120000});
+    cy.contains('Active fake-image', {timeout: 120000});
     cy.contains('Active teal-5.3');
   });
 
   it('Delete OS Versions', () => {
     cy.get('.nav').contains('Advanced').click();
     cy.get('.nav').contains('OS Versions').click();
-    cy.contains('teal-5.2').parent().parent().click();
+    cy.contains('fake-image').parent().parent().click();
     cy.clickButton('Delete');
     cy.confirmDelete();
-    cy.contains('teal-5.2').should('not.exist');
+    cy.contains('fake-image').should('not.exist');
   });
 
   it('Delete OS Versions Channels', () => {


### PR DESCRIPTION
`teal-5.2` image doesn't exist anymore, better to use a `fake-image` for UI upgrade test. This PR also fix the ISO build by using the correct images.