### PR TITLE
Run nightly CI tests on stable Rancher Manager

### DIFF
--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -1,0 +1,26 @@
+# This workflow calls the master E2E workflow with custom variables
+name: K3s-E2E-Latest_RM
+
+on:
+  workflow_run:
+    workflows:
+      - build-ci
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      k8s_version_to_provision: v1.24.8+k3s1
+      rancher_channel: latest
+      rancher_version: devel
+      start_condition: ${{ github.event.workflow_run.conclusion }}
+      workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Dev - K3s - Elemental E2E tests with Rancher Manager
+name: OBS-Dev-K3s-E2E
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
         type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Stable - K3s - Elemental E2E tests with Rancher Manager
+name: OBS-Stable-K3s-E2E
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Staging - K3s - Elemental E2E tests with Rancher Manager
+name: OBS-Staging-K3s-E2E
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
         type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/e2e-k3s-stable.yaml
+++ b/.github/workflows/e2e-k3s-stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s - Elemental E2E tests with Rancher Manager
+name: K3s-E2E-Stable_RM
 
 on:
   workflow_run:

--- a/.github/workflows/e2e-rke2-latest.yaml
+++ b/.github/workflows/e2e-rke2-latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental E2E tests with Rancher Manager
+name: RKE2-E2E-Latest_RM
 
 on:
   workflow_run:
@@ -21,5 +21,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.24.8+rke2r1
+      rancher_channel: latest
+      rancher_version: devel
       start_condition: ${{ github.event.workflow_run.conclusion }}
       workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/e2e-rke2-obs-Stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Stable - RKE2 - Elemental E2E tests with Rancher Manager
+name: OBS-Stable-RKE2-E2E
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/e2e-rke2-obs-Staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Staging - RKE2 - Elemental E2E tests with Rancher Manager
+name: OBS-Staging-RKE2-E2E
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
         type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/e2e-rke2-stable.yaml
+++ b/.github/workflows/e2e-rke2-stable.yaml
@@ -1,0 +1,25 @@
+# This workflow calls the master E2E workflow with custom variables
+name: RKE2-E2E-Stable_RM
+
+on:
+  workflow_run:
+    workflows:
+      - build-ci
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  rke2:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      ca_type: private
+      cluster_name: cluster-rke2
+      k8s_version_to_provision: v1.24.8+rke2r1
+      start_condition: ${{ github.event.workflow_run.conclusion }}
+      workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: K3s-UI_E2E-Latest_RM
 
 on:
   workflow_dispatch:
@@ -8,6 +8,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: latest
@@ -27,20 +31,17 @@ on:
     - cron: '0 4 * * *'
 
 jobs:
-  ui-rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
+      cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}

--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -1,4 +1,4 @@
-name: OBS Dev - K3s - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Dev-K3s-UI_E2E
 
 on:
   workflow_dispatch:
@@ -13,11 +13,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -1,4 +1,4 @@
-name: OBS Stable - K3s - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Stable-K3s-UI_E2E
 
 on:
   workflow_dispatch:
@@ -13,11 +13,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -1,4 +1,4 @@
-name: OBS Staging - K3s - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Staging-K3s-UI_E2E
 
 on:
   workflow_dispatch:
@@ -13,11 +13,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Dev-RKE2-E2E
+name: K3s-UI_E2E-Stable_RM
 
 on:
   workflow_dispatch:
@@ -8,10 +8,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -22,32 +22,28 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
-        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
-
-concurrency:
-  group: e2e-rke2-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
-  rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      ca_type: private
-      cluster_name: cluster-rke2
-      boolean: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
-      node_number: ${{ inputs.node_number }}
-      rancher_channel: ${{ inputs.rancher_channel }}
-      rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner || true }}
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Dev-RKE2-E2E
+name: RKE2-UI_E2E-Latest_RM
 
 on:
   workflow_dispatch:
@@ -8,46 +8,41 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
+        default: latest
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        default: devel
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
-        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
-
-concurrency:
-  group: e2e-rke2-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
-  rke2:
+  ui-rke2:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
-      boolean: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+      destroy_runner: ${{ inputs.destroy_runner || true }}
       k8s_version_to_provision: v1.24.8+rke2r1
-      node_number: ${{ inputs.node_number }}
-      rancher_channel: ${{ inputs.rancher_channel }}
-      rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Dev - RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Dev-RKE2-UI_E2E
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
         type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Stable - RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Stable-RKE2-UI_E2E
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS Staging - RKE2 - Elemental UI End-To-End tests with Rancher Manager
+name: OBS-Staging-RKE2-UI_E2E
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
         type: boolean
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s - Elemental UI End-To-End tests with Rancher Manager
+name: RKE2-UI_E2E-Stable_RM
 
 on:
   workflow_dispatch:
@@ -8,17 +8,13 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use
@@ -31,19 +27,22 @@ on:
     - cron: '0 4 * * *'
 
 jobs:
-  ui-k3s:
+  ui-rke2:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      cluster_name: cluster-k3s
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      #ui_account: user
+      ca_type: private
+      cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      k8s_version_to_provision: v1.24.8+k3s1
-      proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      k8s_version_to_provision: v1.24.8+rke2r1
+      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # Elemental
-[![K3s - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/e2e-k3s.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s.yaml)
-[![RKE2 - Elemental E2E tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/e2e-rke2.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2.yaml)
+CI with latest stable Rancher Manager:
 
-[![K3s - Elemental UI End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s.yaml)
-[![RKE2 - Elemental UI End-To-End tests with Rancher Manager](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2.yaml)
+[![K3s-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml)
+[![RKE2-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml)
+
+[![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
+[![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
+
+CI with latest devel Rancher Manager:
+
+[![K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml)
+[![RKE2-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml)
+
+[![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
+[![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)
 
 Elemental is a software stack enabling a centralized, full cloud-native OS management solution with Kubernetes.
 


### PR DESCRIPTION
Fix #606 

The PR adds new workflow files to run nightly tests on top of latest stable Rancher manager instead of latest dev only.
Some files were also renamed to be fully viewable in the actions menu

Better with new names:
![image](https://user-images.githubusercontent.com/6025636/212930320-81d5d9f5-214e-45fa-9fb9-88e2bb94259a.png)

## Verification runs:
Latest RM: https://github.com/rancher/elemental/actions/runs/3940389848/jobs/6741517419
`docker.io/rancher/rancher:v2.7.2-rc1`

Stable RM: https://github.com/rancher/elemental/actions/runs/3940389857/jobs/6741499953
`docker.io/rancher/rancher:v2.7.0`