### PR TITLE
e2e ui: show k8s deprecated versions

### DIFF
--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -33,6 +33,7 @@ describe('Machine inventory testing', () => {
     cy.contains('Create Elemental Cluster').click();
     cy.typeValue({label: 'Cluster Name', value: 'myelementalcluster'});
     cy.typeValue({label: 'Cluster Description', value: 'My Elemental testing cluster'});
+    cy.contains('Show deprecated Kubernetes').click();
     cy.contains('Kubernetes Version').click();
     cy.contains(k8s_version).click();
     // Configure proxy if proxy is set to elemental


### PR DESCRIPTION
Deprecated k8s versions need to be displayed to use same k8s versions as the test on latest stable rancher manager.

Verification run: https://github.com/rancher/elemental/actions/runs/3950601139 :heavy_check_mark: 