### PR TITLE
e2e ui: change how we check that an app is deleted

### DIFF
--- a/tests/cypress/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/e2e/unit_tests/deploy_app.spec.ts
@@ -37,6 +37,6 @@ describe('Deploy application in fresh Elemental Cluster', () => {
     cy.clickButton('Delete');
     cy.confirmDelete();
     cy.contains('SUCCESS: helm uninstall', {timeout:30000});
-    cy.contains('CIS Benchmark').should('not.exist');
+    cy.contains('.apps', 'CIS Benchmark').should('not.exist');
   });
 });


### PR DESCRIPTION
This PR should fix a sporadic issue which happens when we check if the cis-benchmark app is deleted.
Broken test: https://github.com/rancher/elemental/actions/runs/3955300594/jobs/6773475455

![image](https://user-images.githubusercontent.com/6025636/213486774-5823f8ec-0e57-4a14-a991-9ab41c248ba9.png)

Verification runs:
I would like the test passes 3 times in a row to be sure it is not flaky anymore :smile: 
1)  https://github.com/rancher/elemental/actions/runs/3958665734 :heavy_check_mark: 
2) https://github.com/rancher/elemental/actions/runs/3959132781 :heavy_check_mark: 
3)  https://github.com/rancher/elemental/actions/runs/3960011054 :heavy_check_mark: 