### PR TITLE
ci/e2e: test emulated TPM on more than one node

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -297,9 +297,10 @@ jobs:
           UPGRADE_TYPE: osImage
           VM_INDEX: 1
         run: cd tests && make e2e-upgrade-node
-      - name: Bootstrap node 2 and 3 with current build (use ISO)
+      - name: Bootstrap node 2 and 3 with current build (use Emulated TPM and ISO)
         if: inputs.test_type == 'cli'
         env:
+          EMULATE_TPM: true
           ISO_BOOT: true
           VM_INDEX: 2
           VM_NUMBERS: 3

--- a/tests/assets/emulateTPM.yaml
+++ b/tests/assets/emulateTPM.yaml
@@ -3,3 +3,4 @@ spec:
     elemental:
       registration:
         emulate-tpm: %EMULATE_TPM%
+        emulated-tpm-seed: -1

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -2,16 +2,17 @@
 
 set -e -x
 
-# Variable(s)
+# Variable(s) and default values
 VM_NAME=$1
 MAC=$2
 ARCH=$(uname -m)
 FW_CODE=/usr/share/qemu/ovmf-${ARCH}-smm-suse-code.bin
 FW_VARS=$(realpath ../assets/ovmf-template-vars.fd)
+EMULATED_TPM="none"
 
 # Don't configure TPM if software emulation (EMULATE_TPM=true) is used
 if [[ ${EMULATE_TPM} != "true" ]]; then
-  EMULATED_TPM="--tpm emulator,model=tpm-crb,version=2.0"
+  EMULATED_TPM="emulator,model=tpm-crb,version=2.0"
 fi
 
 # iPXE stuff will not be used if ISO is set
@@ -65,7 +66,7 @@ script -e -O logs/bootstrap_${VM_NAME}.log \
   --serial pty \
   --console pty,target_type=virtio \
   --rng random \
-  ${EMULATED_TPM} \
+  --tpm ${EMULATED_TPM} \
   --noreboot \
   ${INSTALL_FLAG} \
   --network network=default,bridge=virbr0,model=virtio,mac=${MAC}"


### PR DESCRIPTION
As emulated TPM now works on more than one node, the seed is generated based on the server UUID.

This should fix #586.

Verification run:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/3984396725)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/3984400204)