### PR TITLE
ci/e2e: don't run test on latest RM on every push

### DIFF
--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -1,14 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
 name: K3s-E2E-Latest_RM
 
+# This worflow is scheduled *after* build-ci to be sure that we have
+# the lastest version built. The scheduling is also to avoid running
+# the worklow on each push on main.
 on:
-  workflow_run:
-    workflows:
-      - build-ci
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   k3s:

--- a/.github/workflows/e2e-rke2-latest.yaml
+++ b/.github/workflows/e2e-rke2-latest.yaml
@@ -1,14 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
 name: RKE2-E2E-Latest_RM
 
+# This worflow is scheduled *after* build-ci to be sure that we have
+# the lastest version built. The scheduling is also to avoid running
+# the worklow on each push on main.
 on:
-  workflow_run:
-    workflows:
-      - build-ci
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   rke2:


### PR DESCRIPTION
This worflow is scheduled *after* build-ci to be sure that we have the lastest version built. The scheduling is also to avoid running the worklow on each push on main.