### PR TITLE
e2e/ui: replace .xterm-cursor-layer in Cypress

### DIFF
--- a/tests/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -91,9 +91,9 @@ describe('Upgrade tests', () => {
     cy.contains('Workload').click();
     cy.contains('Pods').click();
     cy.get('.header-buttons > :nth-child(2)').click();
-    cy.wait(40000);
-    cy.get('.xterm-cursor-layer').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=0{enter}');
-    cy.get('.xterm-cursor-layer').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=1{enter}');
+    cy.wait(20000);
+    cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=0{enter}');
+    cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=1{enter}');
 
     // Check if the node reboots to apply the upgrade
     topLevelMenu.openIfClosed();


### PR DESCRIPTION
Fix #605 

![image](https://user-images.githubusercontent.com/6025636/214515509-8658f89c-383e-4342-aac3-635ca24d580d.png)

## Verification runs:

[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4004239136): :heavy_check_mark: 
[RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4004511104): :heavy_check_mark: Test failed for an external reason to this PR.
[K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/3984636470/jobs/6831082377): :heavy_check_mark:  Test failed a little bit after but for an external reason to this PR.
![image](https://user-images.githubusercontent.com/6025636/214517238-8ab1fef2-bb38-4f49-99ac-6c9e50c23fc9.png)

[RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/3994321457): :heavy_check_mark: 

I'm lucky with the provided fix because it also works for older Rancher Manager versions so no need to introduce `if version ==` in the code.