### PR TITLE
ci/e2e: fix VM bootstrapping with OBS Stable

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -291,7 +291,7 @@ jobs:
           VM_INDEX: 1
         run: cd tests && make e2e-bootstrap-node
       - name: Upgrade node 1 (with osImage method) to latest build
-        if: inputs.test_type == 'cli'
+        if: inputs.test_type == 'cli' && !contains(inputs.iso_to_test, '/Stable:/')
         env:
           CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
           UPGRADE_TYPE: osImage
@@ -316,7 +316,7 @@ jobs:
 
           cd tests && make e2e-bootstrap-node
       - name: Upgrade node 2 (with manual method) to latest build
-        if: inputs.test_type == 'cli'
+        if: inputs.test_type == 'cli' && !contains(inputs.iso_to_test, '/Stable:/')
         env:
           CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
           UPGRADE_TYPE: manual

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -304,7 +304,17 @@ jobs:
           ISO_BOOT: true
           VM_INDEX: 2
           VM_NUMBERS: 3
-        run: cd tests && make e2e-bootstrap-node
+        run: |
+          OPERATOR_VERSION=$(kubectl get pods \
+                               -n cattle-elemental-system \
+                               -l app=elemental-operator \
+                               -o jsonpath={.items[*].status.containerStatuses[*].image} \
+                             | awk -F ':' '{print substr($2,0,3)}')
+
+          # If elemental-operator is a v1.0.x we should disable EMULATE_TPM
+          [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
+
+          cd tests && make e2e-bootstrap-node
       - name: Upgrade node 2 (with manual method) to latest build
         if: inputs.test_type == 'cli'
         env:


### PR DESCRIPTION
If elemental-operator is version 1.0.x we should disable `EMULATE_TPM` as this version doesn't generate unique TPM seed.

This PR also temporary removed the upgrade tests for OBS-Stable artifacts because of isse #632.

Verification runs:
- [OBS-Stable-K3s-E2E ](https://github.com/rancher/elemental/actions/runs/4016320699)
- [OBS-Stable-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4014810703)
- [OBS-Dev-K3s-E2E ](https://github.com/rancher/elemental/actions/runs/4015540608)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4009680078)

**NOTE:** OBS-Stable-K3s-E2E fails but not because of this PR. As the 3 other tests are OK I will check/fix the issue in another issue/PR.