### PR TITLE
Add service to kill k3s before umount

### DIFF
--- a/.obs/specfile/elemental.spec
+++ b/.obs/specfile/elemental.spec
@@ -99,6 +99,7 @@ rm -rf %{buildroot}/usr/libexec/.placeholder
 %dir %{_sysconfdir}/NetworkManager/conf.d
 %config %{_sysconfdir}/NetworkManager/conf.d/rke2-canal.conf
 %dir %{_unitdir}
+%{_unitdir}/shutdown-k3s.service
 %{_unitdir}/elemental-populate-node-labels.service
 %{_sbindir}/elemental-populate-node-labels
 %dir /usr/libexec

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -60,7 +60,7 @@ COPY --from=elemental-cli /usr/bin/elemental /usr/bin/elemental
 COPY framework/files/ /
 
 # Enable services
-RUN systemctl enable NetworkManager sshd elemental-populate-node-labels systemd-timesyncd
+RUN systemctl enable NetworkManager sshd elemental-populate-node-labels systemd-timesyncd shutdown-k3s
 
 ARG IMAGE_TAG=latest
 ARG IMAGE_COMMIT=""

--- a/framework/files/usr/lib/systemd/system/shutdown-k3s.service
+++ b/framework/files/usr/lib/systemd/system/shutdown-k3s.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kill containerd-shims on shutdown
+DefaultDependencies=false
+Before=shutdown.target umount.target
+
+[Service]
+ExecStart=/usr/local/bin/k3s-killall.sh
+Type=oneshot
+
+[Install]
+WantedBy=shutdown.target


### PR DESCRIPTION
Seems to be hitting this issue: https://github.com/k3s-io/k3s/issues/2400

The workaround suggested is to add a service that runs k3s-killall before umount.

Fixes #587 

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>