### PR TITLE
ci: fix UI tests with hugepages

### DIFF
--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/e2e-rke2-obs-Dev.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/e2e-rke2-obs-Stable.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/e2e-rke2-obs-Staging.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -233,6 +233,7 @@ jobs:
         if: inputs.test_type == 'ui'
         env:
           VM_INDEX: 1
+          HOST_MEMORY_RESERVED: 50331648
         run: |
           cd tests && (
             # Removing 'downloads' is needed to avoid this error during 'make':

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -65,7 +65,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       start_condition:
         description: Start condition of the runner

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -127,7 +127,7 @@ jobs:
     needs: create-runner
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     env:
-      TIMEOUT_SCALE: 2
+      TIMEOUT_SCALE: 3
       ARCH: amd64
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -17,8 +17,9 @@ if (( NR_HUGEPAGES == 0 )); then
   MEMTOTAL_KB=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
 
   # Number of hugepages (with hugepagesize set to 2MB)
-  # NOTE: keep 8GB for the hypervisor/Rancher Manager Server
-  (( VALUE = ((MEMTOTAL_KB - 8388608) / 2048) ))
+  # NOTE: keep 12GB by default for the hypervisor/Rancher Manager Server
+  # And this value can be modified with HOST_MEMORY_RESERVED variable
+  (( VALUE = ((MEMTOTAL_KB - ${HOST_MEMORY_RESERVED:-12582912}) / 2048) ))
 
   # Set nr_hugepage
   (( VALUE > 0 )) \


### PR DESCRIPTION
We should reserved much more memory for UI tests.

Verification runs:
- [K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4023151768)
- [RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4023154382)
- [RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4024402597)
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4024621102)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4024635315)
- [OBS-Staging-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4024389796)
- [OBS-Staging-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4025099008)