### PR TITLE
ci/e2e: increase timeout when delete resource in UI

### DIFF
--- a/tests/cypress/support/functions.ts
+++ b/tests/cypress/support/functions.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl, repoType}) => {
   cy.clickClusterMenu(['Apps', 'Repositories'])
 
   // Make sure we are in the 'Repositories' screen (test failed here before)
-  cy.contains('header', 'Repositories', {timeout: 8000}).should('be.visible');
+  cy.contains('header', 'Repositories').should('be.visible');
   cy.contains('Create').should('be.visible');
 
   cy.clickButton('Create');

--- a/tests/cypress/support/functions.ts
+++ b/tests/cypress/support/functions.ts
@@ -292,7 +292,8 @@ Cypress.Commands.add('deleteMachReg', ({machRegName}) => {
   cy.contains(machRegName).parent().parent().click();
   cy.clickButton('Delete');
   cy.confirmDelete();
-  cy.contains(machRegName).should('not.exist')
+  // Timeout should fix this issue https://github.com/rancher/elemental/issues/643
+  cy.contains(machRegName, {timeout: 20000}).should('not.exist')
 });
 
 // Machine Inventory functions


### PR DESCRIPTION
Fix #643 

Verification run:
https://github.com/rancher/elemental/actions/runs/4101679988 :heavy_check_mark: 

Wait 20 sec instead of 10 sec when we delete a machine registration in our e2e UI tests.
I also remove a useless 8 seconds timeout, as the default is 10, we do not need a lower timeout.