### PR TITLE
ci/e2e: fix E2E scheduled tests with latest RMS

### DIFF
--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -20,5 +20,3 @@ jobs:
       k8s_version_to_provision: v1.24.8+k3s1
       rancher_channel: latest
       rancher_version: devel
-      start_condition: ${{ github.event.workflow_run.conclusion }}
-      workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/e2e-rke2-latest.yaml
+++ b/.github/workflows/e2e-rke2-latest.yaml
@@ -21,5 +21,3 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: latest
       rancher_version: devel
-      start_condition: ${{ github.event.workflow_run.conclusion }}
-      workflow_download: ${{ github.event.workflow_run.workflow_id }}


### PR DESCRIPTION
E2E tests with latest/devel version of Rancher Manager are not scheduled because of wrong start_condition and workflow_download values.