### PR TITLE
ci/e2e: increase default node number to 10

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -46,7 +46,7 @@ on:
         type: string
       node_number:
         description: Number of nodes to deploy on the provisioned cluster
-        default: 5
+        default: 10
         type: string
       proxy:
         description: Deploy a proxy


### PR DESCRIPTION
With the latest changes to run node provisioning in parallel it's now possible to test 10 nodes on the same runner and in the same time as we did with 5 nodes.

Verification runs:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4116280399)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4113231429)