### PR TITLE
ci/e2e: use Rancher Manager Admin user for CLI commands

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -151,7 +151,6 @@ jobs:
       INSTALL_K3S_VERSION: v1.24.7+k3s1
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
-      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       # For Rancher Manager
       RANCHER_CHANNEL: ${{ inputs.rancher_channel }}
       RANCHER_VERSION: ${{ inputs.rancher_version }}

--- a/tests/assets/local-kubeconfig-skel.yaml
+++ b/tests/assets/local-kubeconfig-skel.yaml
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: https://%RANCHER_URL%
+    server: https://%RANCHER_URL%/k8s/clusters/local
     certificate-authority-data: %RANCHER_CA%
 
 users:

--- a/tests/assets/local-kubeconfig-skel.yaml
+++ b/tests/assets/local-kubeconfig-skel.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: https://%RANCHER_URL%
+    certificate-authority-data: %RANCHER_CA%
+
+users:
+- name: local
+  user:
+    token: ci-access-token:our-own-ci-token
+
+contexts:
+- name: local
+  context:
+    user: local
+    cluster: local
+
+current-context: local

--- a/tests/assets/local-kubeconfig-token-skel.yaml
+++ b/tests/assets/local-kubeconfig-token-skel.yaml
@@ -1,0 +1,8 @@
+apiVersion: management.cattle.io/v3
+kind: Token
+authProvider: local
+metadata:
+  name: ci-access-token
+token: our-own-ci-token
+ttl: 0
+userId: %ADMIN_USER%

--- a/tests/cypress/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_registration.spec.ts
@@ -23,9 +23,6 @@ describe('Machine registration testing', () => {
     // Delete all files previously downloaded
     cy.exec('rm cypress/downloads/*', {failOnNonZeroExit: false});
 
-    // Delete namespace
-    cy.exec('kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml delete ns mynamespace', {failOnNonZeroExit: false});
-    
     // Delete all existing machine registrations
     cy.contains('Manage Registration Endpoints').click();
     cy.get('.outlet > header').contains('Registration Endpoints');

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -104,9 +104,8 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 	It("Provision the node", func() {
 		By("Setting emulated TPM to "+strconv.FormatBool(emulateTPM), func() {
 			// Set temporary file
-			tmp, err := os.CreateTemp("", "emulatedTPM")
+			emulatedTmp, err := misc.CreateTemp("emulatedTPM")
 			Expect(err).To(Not(HaveOccurred()))
-			emulatedTmp := tmp.Name()
 			defer os.Remove(emulatedTmp)
 
 			// Save original file as it can be modified multiple time

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -149,11 +149,10 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 				// No need to recreate the ISO twice
 				if len(isIso) == 0 {
-					cmd := exec.Command(
+					out, err := exec.Command(
 						"bash", "-c",
 						"../../.github/elemental-iso-add-registration "+installConfigYaml+" ../../build/elemental-*.iso",
-					)
-					out, err := cmd.CombinedOutput()
+					).CombinedOutput()
 					GinkgoWriter.Printf("%s\n", out)
 					Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -67,9 +67,8 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 
 		By("Creating cluster selectors", func() {
 			// Set temporary file
-			tmp, err := os.CreateTemp("", "selector")
+			selectorTmp, err := misc.CreateTemp("selector")
 			Expect(err).To(Not(HaveOccurred()))
-			selectorTmp := tmp.Name()
 			defer os.Remove(selectorTmp)
 
 			for _, pool := range []string{"master", "worker"} {
@@ -118,9 +117,8 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 
 		By("Adding MachineRegistration", func() {
 			// Set temporary file
-			tmp, err := os.CreateTemp("", "machineRegistration")
+			registrationTmp, err := misc.CreateTemp("machineRegistration")
 			Expect(err).To(Not(HaveOccurred()))
-			registrationTmp := tmp.Name()
 			defer os.Remove(registrationTmp)
 
 			for _, pool := range []string{"master", "worker"} {

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -349,7 +349,7 @@ func ConcateFiles(srcfile, dstfile string, data []byte) error {
 	defer f.Close()
 
 	// Open/create destination file
-	d, err := os.OpenFile(dstfile, os.O_CREATE|os.O_WRONLY, 0644)
+	d, err := os.OpenFile(dstfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -447,3 +447,11 @@ func SetHostname(baseName string, index int) string {
 	}
 	return baseName + "-" + fmt.Sprintf("%03d", index)
 }
+
+func CreateTemp(baseName string) (string, error) {
+	t, err := os.CreateTemp("", baseName)
+	if err != nil {
+		return "", err
+	}
+	return t.Name(), nil
+}

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -86,8 +86,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 		if caType == "private" {
 			By("Configuring Private CA", func() {
-				cmd := exec.Command(configPrivateCAScript)
-				out, err := cmd.CombinedOutput()
+				out, err := exec.Command(configPrivateCAScript).CombinedOutput()
 				GinkgoWriter.Printf("%s\n", out)
 				Expect(err).To(Not(HaveOccurred()))
 			})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -27,10 +27,12 @@ import (
 const (
 	clusterYaml               = "../assets/cluster.yaml"
 	emulateTPMYaml            = "../assets/emulateTPM.yaml"
+	ciTokenYaml               = "../assets/local-kubeconfig-token-skel.yaml"
 	configPrivateCAScript     = "../scripts/config-private-ca"
 	installConfigYaml         = "../../install-config.yaml"
 	installHardenedScript     = "../scripts/config-hardened"
 	installVMScript           = "../scripts/install-vm"
+	localKubeconfigYaml       = "../assets/local-kubeconfig-skel.yaml"
 	netDefaultFileName        = "../assets/net-default.xml"
 	osListYaml                = "../assets/managedOSVersionChannel.yaml"
 	registrationYaml          = "../assets/machineRegistration.yaml"
@@ -53,6 +55,7 @@ var (
 	elementalSupport    string
 	emulateTPM          bool
 	eTPM                string
+	rancherHostname     string
 	imageVersion        string
 	isoBoot             string
 	k8sVersion          string
@@ -88,6 +91,7 @@ var _ = BeforeSuite(func() {
 	clusterType = os.Getenv("CLUSTER_TYPE")
 	elementalSupport = os.Getenv("ELEMENTAL_SUPPORT")
 	eTPM = os.Getenv("EMULATE_TPM")
+	rancherHostname = os.Getenv("HOSTNAME")
 	imageVersion = os.Getenv("IMAGE_VERSION")
 	index := os.Getenv("VM_INDEX")
 	isoBoot = os.Getenv("ISO_BOOT")

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -82,8 +82,7 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 
 		By("Creating and installing VM", func() {
 			// Install VM
-			cmd := exec.Command(installVMScript, vmName, macAdrs)
-			out, err := cmd.CombinedOutput()
+			out, err := exec.Command(installVMScript, vmName, macAdrs).CombinedOutput()
 			GinkgoWriter.Printf("%s\n", out)
 			Expect(err).To(Not(HaveOccurred()))
 		})

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -101,7 +101,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 
 					// Create new file for this specific upgrade
 					err = misc.ConcateFiles(upgradeClusterTargetsYaml, upgradeOSVersionNameYaml, selector)
-					Expect(err).To(Not(HaveOccurred()), selector)
+					Expect(err).To(Not(HaveOccurred()))
 
 					// Swap yaml file
 					upgradeOsYaml = upgradeOSVersionNameYaml


### PR DESCRIPTION
This is to be sure that all objects created with CLI commands are tagged with Rancher Manager user.

This should fix issue rancher/elemental-operator#310.

Verification runs:
- [RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4183113727)
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4175511640)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4175824667)

**NOTE:** the test OBS-Dev-RKE2-E2E has failed because the VM has been killed by GCP (SPOT), but the PR is validated as the changes are done during Rancher Manager installation.