### PR TITLE
ci/e2e: add test on hardened cluster

### DIFF
--- a/.github/workflows/e2e-k3s-hard-stable.yaml
+++ b/.github/workflows/e2e-k3s-hard-stable.yaml
@@ -1,0 +1,31 @@
+# This workflow calls the master E2E workflow with custom variables
+name: K3s-hard-E2E-Stable_RM
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  pull_request:
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cert-manager_version: v1.9.2
+      cluster_name: cluster-k3s
+      cluster_type: hardened
+      k3s_flags: "--protect-kernel-defaults 
+        --kube-apiserver-arg=--enable-admission-plugins=NodeRestriction,PodSecurityPolicy,NamespaceLifecycle,ServiceAccount 
+        --kube-apiserver-arg=--audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log 
+        --kube-apiserver-arg=--audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml 
+        --kube-apiserver-arg=--audit-log-maxage=30 
+        --kube-apiserver-arg=--audit-log-maxbackup=10 
+        --kube-apiserver-arg=--audit-log-maxsize=100 
+        --kube-apiserver-arg=--request-timeout=300s 
+        --kube-apiserver-arg=--service-account-lookup=true 
+        --kubelet-arg=make-iptables-util-chains=true 
+        --kube-apiserver-arg=--anonymous-auth=false"
+      k8s_version_to_provision: v1.24.8+k3s1
+      node_number: 3

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -336,7 +336,7 @@ jobs:
           VM_INDEX: 2
         run: cd tests && make e2e-upgrade-node
       - name: Bootstrap additional nodes (total of ${{ inputs.node_number }}) with current build (use iPXE)
-        if: inputs.test_type == 'cli'
+        if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
           VM_INDEX: 4
           VM_NUMBERS: ${{ inputs.node_number }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -25,9 +25,15 @@ on:
         description: CA type to use (selfsigned or private)
         default: selfsigned
         type: string
+      cert-manager_version:
+        description: Version of cert-manager to use
+        type: string
       cluster_name:
         description: Name of the provisioned cluster
         required: true
+        type: string
+      cluster_type:
+        description: Type of the cluster
         type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -39,6 +45,9 @@ on:
         type: string
       iso_to_test:
         description: ISO to test (default built one is empty)
+        type: string
+      k3s_flags:
+        description: Argument to configure INSTALL_K3S_EXEC env variable 
         type: string
       k8s_version_to_provision:
         description: Name and version of installed K8s distribution
@@ -129,9 +138,12 @@ jobs:
     env:
       TIMEOUT_SCALE: 3
       ARCH: amd64
+      CERT-MANAGER_VERSION: ${{ inputs.cert-manager_version }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default
+      CLUSTER_TYPE: ${{ inputs.cluster_type }}
       # For K3s installation used to host Rancher Manager
+      INSTALL_K3S_EXEC: ${{ inputs.k3s_flags }}
       INSTALL_K3S_VERSION: v1.24.7+k3s1
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
@@ -434,3 +446,4 @@ jobs:
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
             --delete-disks all \
             --zone ${{ inputs.zone }}
+

--- a/tests/assets/hardened_cluster/90-kubelet.conf
+++ b/tests/assets/hardened_cluster/90-kubelet.conf
@@ -1,0 +1,4 @@
+vm.panic_on_oom=0
+vm.overcommit_memory=1
+kernel.panic=10
+kernel.panic_on_oops=1

--- a/tests/assets/hardened_cluster/audit.yaml
+++ b/tests/assets/hardened_cluster/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/tests/assets/hardened_cluster/networkpolicy.yaml
+++ b/tests/assets/hardened_cluster/networkpolicy.yaml
@@ -1,0 +1,72 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: kube-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-network-dns-policy
+  namespace: kube-system
+spec:
+  ingress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-metrics-server
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: metrics-server
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-svclbtraefik-ingress
+  namespace: kube-system
+spec:
+  podSelector: 
+    matchLabels:
+      svccontroller.k3s.cattle.io/svcname: traefik
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-traefik-v121-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress

--- a/tests/assets/hardened_cluster/policy.yaml
+++ b/tests/assets/hardened_cluster/policy.yaml
@@ -1,0 +1,223 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'csi'
+    - 'persistentVolumeClaim'
+    - 'ephemeral'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: system-unrestricted-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: svclb-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  allowedUnsafeSysctls:
+  - net.ipv4.ip_forward
+  - net.ipv6.conf.all.forwarding
+  fsGroup:
+    rule: RunAsAny
+  hostPorts:
+  - max: 65535
+    min: 0
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:restricted-psp
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - restricted-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:system-unrestricted-psp
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - system-unrestricted-psp
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:svclb-psp
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - svclb-psp
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:restricted-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:restricted-psp
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-unrestricted-node-psp-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:system-unrestricted-psp
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-unrestricted-svc-acct-psp-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:system-unrestricted-psp
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: svclb-psp-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:svclb-psp
+subjects:
+- kind: ServiceAccount
+  name: svclb
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: kube-system
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: default
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: default
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: kube-public
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: kube-public

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -29,6 +29,7 @@ const (
 	emulateTPMYaml            = "../assets/emulateTPM.yaml"
 	configPrivateCAScript     = "../scripts/config-private-ca"
 	installConfigYaml         = "../../install-config.yaml"
+	installHardenedScript     = "../scripts/config-hardened"
 	installVMScript           = "../scripts/install-vm"
 	netDefaultFileName        = "../assets/net-default.xml"
 	osListYaml                = "../assets/managedOSVersionChannel.yaml"
@@ -45,8 +46,10 @@ var (
 	addedNode           int
 	arch                string
 	caType              string
+	CertManagerVersion  string
 	clusterName         string
 	clusterNS           string
+	clusterType         string
 	elementalSupport    string
 	emulateTPM          bool
 	eTPM                string
@@ -79,8 +82,10 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	arch = os.Getenv("ARCH")
 	caType = os.Getenv("CA_TYPE")
+	CertManagerVersion = os.Getenv("CERT-MANAGER_VERSION")
 	clusterName = os.Getenv("CLUSTER_NAME")
 	clusterNS = os.Getenv("CLUSTER_NS")
+	clusterType = os.Getenv("CLUSTER_TYPE")
 	elementalSupport = os.Getenv("ELEMENTAL_SUPPORT")
 	eTPM = os.Getenv("EMULATE_TPM")
 	imageVersion = os.Getenv("IMAGE_VERSION")

--- a/tests/scripts/config-hardened
+++ b/tests/scripts/config-hardened
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script configures all we need to enable a k3s hardened cluster
+# Instructions from https://docs.k3s.io/security/hardening-guide
+
+set -e -x
+
+# Variables
+K3S_SERVER_DIR="/var/lib/rancher/k3s/server"
+MANIFESTS_DIR="${K3S_SERVER_DIR}/manifests/"
+SYSCTL_DIR="/etc/sysctl.d"
+HARDENED_DIR="../assets/hardened_cluster"
+SYSCTL_CONF="${HARDENED_DIR}/90-kubelet.conf"
+POLICY_YAML="${HARDENED_DIR}/policy.yaml"
+NETWORK_POLICY_YAML="${HARDENED_DIR}/networkpolicy.yaml"
+AUDIT_YAML="${HARDENED_DIR}/audit.yaml"
+
+# Apply mandatory sysctl config
+cp ${SYSCTL_CONF} ${SYSCTL_DIR}
+sysctl -p ${SYSCTL_DIR}/90-kubelet.conf
+
+# Create K3S directories to preload manifests
+mkdir -p -m 700 ${MANIFESTS_DIR}
+mkdir ${K3S_SERVER_DIR}/logs
+
+# Copy policies to manifests directory
+cp ${POLICY_YAML} ${NETWORK_POLICY_YAML} ${MANIFESTS_DIR}
+
+# Enable auditing
+cp ${AUDIT_YAML} ${K3S_SERVER_DIR}


### PR DESCRIPTION
Fix #604 
Instruction comes from https://docs.k3s.io/security/hardening-guide

Verification run:
[Hardened K3s](https://github.com/rancher/elemental/actions/runs/4164214683/jobs/7206478937)
[Standard K3s](https://github.com/rancher/elemental/actions/runs/4164623724/jobs/7206520230)

Documented in our documentation space :heavy_check_mark: 