### PR TITLE
Revert "ci/e2e: increase default node number to 10"

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -55,7 +55,7 @@ on:
         type: string
       node_number:
         description: Number of nodes to deploy on the provisioned cluster
-        default: 10
+        default: 5
         type: string
       proxy:
         description: Deploy a proxy


### PR DESCRIPTION
This reverts commit 14c71b38c39cc204879c41f3d2af8f6218329d8e.

This is done because we have sporadic failures with 10 nodes, more debugging is needed on this.