### PR TITLE
ci/e2e: disable upgrade tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -307,13 +307,6 @@ jobs:
           EMULATE_TPM: true
           VM_INDEX: 1
         run: cd tests && make e2e-bootstrap-node
-      - name: Upgrade node 1 (with osImage method) to latest build
-        if: inputs.test_type == 'cli'
-        env:
-          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
-          UPGRADE_TYPE: osImage
-          VM_INDEX: 1
-        run: cd tests && make e2e-upgrade-node
       - name: Bootstrap node 2 and 3 with current build (use Emulated TPM and ISO)
         if: inputs.test_type == 'cli'
         env:
@@ -332,13 +325,6 @@ jobs:
           [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
 
           cd tests && make e2e-bootstrap-node
-      - name: Upgrade node 2 (with manual method) to latest build
-        if: inputs.test_type == 'cli'
-        env:
-          CONTAINER_IMAGE: quay.io/costoolkit/elemental-ci:latest
-          UPGRADE_TYPE: manual
-          VM_INDEX: 2
-        run: cd tests && make e2e-upgrade-node
       - name: Bootstrap additional nodes (total of ${{ inputs.node_number }}) with current build (use iPXE)
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -46,90 +46,76 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 			GinkgoWriter.Printf("OS Version:\n%s\n", out)
 		})
 
-		if upgradeType != "manual" {
-			By("Triggering Upgrade in Rancher with "+upgradeType, func() {
-				upgradeOsYaml := upgradeClusterTargetsYaml
-				upgradeTypeValue := osImage // Default to osImage
-				if upgradeType == "managedOSVersionName" {
-					upgradeTypeValue = imageVersion
+		By("Triggering Upgrade in Rancher with "+upgradeType, func() {
+			upgradeOsYaml := upgradeClusterTargetsYaml
+			upgradeTypeValue := osImage // Default to osImage
+			if upgradeType == "managedOSVersionName" {
+				upgradeTypeValue = imageVersion
+			}
+
+			// We should have a version defined
+			Expect(upgradeTypeValue).NotTo(BeNil())
+
+			// We don't know what is the previous type of upgrade, so easier to replace all here
+			// as there is only one in the yaml file anyway
+			for _, p := range []string{"%OS_IMAGE%", "osImage:.*", "managedOSVersionName:.*"} {
+				err := tools.Sed(p, upgradeType+": "+upgradeTypeValue, upgradeOsYaml)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			err := tools.Sed("%CLUSTER_NAME%", clusterName, upgradeClusterTargetsYaml)
+			Expect(err).To(Not(HaveOccurred()))
+
+			if upgradeType == "managedOSVersionName" {
+				// Get elemental-operator version
+				operatorVersion, err := misc.GetOperatorVersion()
+				Expect(err).To(Not(HaveOccurred()))
+				operatorVersionShort := strings.Split(operatorVersion, ".")
+
+				// Remove 'syncInterval' option if needed (only supported in operator v1.1+)
+				if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
+					err = tools.Sed("syncInterval:.*", "", osListYaml)
+					Expect(err).To(Not(HaveOccurred()))
 				}
 
-				// We should have a version defined
-				Expect(upgradeTypeValue).NotTo(BeNil())
-
-				// We don't know what is the previous type of upgrade, so easier to replace all here
-				// as there is only one in the yaml file anyway
-				for _, p := range []string{"%OS_IMAGE%", "osImage:.*", "managedOSVersionName:.*"} {
-					err := tools.Sed(p, upgradeType+": "+upgradeTypeValue, upgradeOsYaml)
-					Expect(err).To(Not(HaveOccurred()))
-				}
-
-				err := tools.Sed("%CLUSTER_NAME%", clusterName, upgradeClusterTargetsYaml)
+				// Add OS list
+				err = kubectl.Apply(clusterNS, osListYaml)
 				Expect(err).To(Not(HaveOccurred()))
 
-				if upgradeType == "managedOSVersionName" {
-					// Get elemental-operator version
-					operatorVersion, err := misc.GetOperatorVersion()
-					Expect(err).To(Not(HaveOccurred()))
-					operatorVersionShort := strings.Split(operatorVersion, ".")
+				// Wait for ManagedOSVersion to be populated from ManagedOSVersionChannel
+				Eventually(func() string {
+					out, _ := kubectl.Run("get", "ManagedOSVersion",
+						"--namespace", clusterNS, imageVersion)
+					return out
+				}, misc.SetTimeout(2*time.Minute), 10*time.Second).Should(Not(ContainSubstring("Error")))
 
-					// Remove 'syncInterval' option if needed (only supported in operator v1.1+)
-					if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
-						err = tools.Sed("syncInterval:.*", "", osListYaml)
-						Expect(err).To(Not(HaveOccurred()))
-					}
-
-					// Add OS list
-					err = kubectl.Apply(clusterNS, osListYaml)
-					Expect(err).To(Not(HaveOccurred()))
-
-					// Wait for ManagedOSVersion to be populated from ManagedOSVersionChannel
-					Eventually(func() string {
-						out, _ := kubectl.Run("get", "ManagedOSVersion",
-							"--namespace", clusterNS, imageVersion)
-						return out
-					}, misc.SetTimeout(2*time.Minute), 10*time.Second).Should(Not(ContainSubstring("Error")))
-
-					// Get *REAL* hostname
-					hostname, err := client.RunSSH("hostname")
-					Expect(err).To(Not(HaveOccurred()))
-					hostname = strings.Trim(hostname, "\n")
-
-					label := "kubernetes.io/hostname"
-					selector, err := misc.AddSelector(label, hostname)
-					Expect(err).To(Not(HaveOccurred()), selector)
-
-					// Create new file for this specific upgrade
-					err = misc.ConcateFiles(upgradeClusterTargetsYaml, upgradeOSVersionNameYaml, selector)
-					Expect(err).To(Not(HaveOccurred()))
-
-					// Swap yaml file
-					upgradeOsYaml = upgradeOSVersionNameYaml
-
-					// Set correct value for os osImage
-					out, err := kubectl.Run("get", "ManagedOSVersion",
-						"--namespace", clusterNS, imageVersion,
-						"-o", "jsonpath={.spec.metadata.upgradeImage}")
-					Expect(err).To(Not(HaveOccurred()))
-					osImage = misc.TrimStringFromChar(out, ":")
-				}
-
-				err = kubectl.Apply(clusterNS, upgradeOsYaml)
+				// Get *REAL* hostname
+				hostname, err := client.RunSSH("hostname")
 				Expect(err).To(Not(HaveOccurred()))
-			})
-		}
+				hostname = strings.Trim(hostname, "\n")
 
-		if upgradeType == "manual" {
-			By("Triggering Manual Upgrade", func() {
-				out, err := client.RunSSH("elemental upgrade --system.uri docker:" + osImage)
-				Expect(err).To(Not(HaveOccurred()), out)
-				Expect(out).To((ContainSubstring("Upgrade completed")))
+				label := "kubernetes.io/hostname"
+				selector, err := misc.AddSelector(label, hostname)
+				Expect(err).To(Not(HaveOccurred()), selector)
 
-				// Execute 'reboot' in background, to avoid ssh locking
-				_, err = client.RunSSH("setsid -f reboot")
+				// Create new file for this specific upgrade
+				err = misc.ConcateFiles(upgradeClusterTargetsYaml, upgradeOSVersionNameYaml, selector)
 				Expect(err).To(Not(HaveOccurred()))
-			})
-		}
+
+				// Swap yaml file
+				upgradeOsYaml = upgradeOSVersionNameYaml
+
+				// Set correct value for os osImage
+				out, err := kubectl.Run("get", "ManagedOSVersion",
+					"--namespace", clusterNS, imageVersion,
+					"-o", "jsonpath={.spec.metadata.upgradeImage}")
+				Expect(err).To(Not(HaveOccurred()))
+				osImage = misc.TrimStringFromChar(out, ":")
+			}
+
+			err = kubectl.Apply(clusterNS, upgradeOsYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
 
 		By("Checking VM upgrade", func() {
 			Eventually(func() string {
@@ -154,16 +140,14 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade"), func() {
 			GinkgoWriter.Printf("OS Version:\n%s\n", out)
 		})
 
-		if upgradeType != "manual" {
-			By("Cleaning upgrade orders", func() {
-				if upgradeType == "managedOSVersionName" {
-					err := kubectl.DeleteResource(clusterNS, "ManagedOSVersionChannel", "os-versions")
-					Expect(err).To(Not(HaveOccurred()))
-				}
-
-				err := kubectl.DeleteResource(clusterNS, "ManagedOSImage", "default-os-image")
+		By("Cleaning upgrade orders", func() {
+			if upgradeType == "managedOSVersionName" {
+				err := kubectl.DeleteResource(clusterNS, "ManagedOSVersionChannel", "os-versions")
 				Expect(err).To(Not(HaveOccurred()))
-			})
-		}
+			}
+
+			err := kubectl.DeleteResource(clusterNS, "ManagedOSImage", "default-os-image")
+			Expect(err).To(Not(HaveOccurred()))
+		})
 	})
 })


### PR DESCRIPTION
Upgrade tests scenarii should be changed. As they are not relevant anymore and sporadically fail it better to disable them.

This commit also remove the manual upgrade test with Elemental CLI, as this is not supported. And anyway the others upgrade methods are using the same API for the upgrade as the CLI. It could also be added in elemental-toolkit if needed.

Should fix #668 and #669.

**NOTE:** upgrade test in UI is kept, as it does a test do the latest version built and check the generated OS list from YAML, so still useful for now.

Verification runs:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4185423975)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4186904548)