### PR TITLE
ci/ui: adapt cypress code to elem-ui 1.0.1

### DIFF
--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: latest
+        default: '1.0.0'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -44,7 +44,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: latest
+        default: '1.0.0'
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
@@ -44,7 +44,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}

--- a/tests/cypress/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/e2e/unit_tests/elemental_plugin.spec.ts
@@ -26,7 +26,7 @@ describe('Install Elemental plugin', () => {
     cy.contains('Enable Extension Support?')
     cy.contains('Add the Rancher Extension Repository').click();
     cy.clickButton('OK');
-    cy.contains('No Extensions installed', {timeout: 40000});
+    cy.get('.tabs', {timeout: 40000}).contains('Installed Available Updates All');
   });
 
   it('Install Elemental plugin', () => {
@@ -46,6 +46,6 @@ describe('Install Elemental plugin', () => {
     cy.get('.plugins')
       .children()
       .should('contain', 'elemental')
-      .and('contain', 'Uninstall')
+      .and('contain', 'Uninstall');
   });
 });

--- a/tests/cypress/e2e/unit_tests/machine_selector.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_selector.spec.ts
@@ -32,7 +32,7 @@ describe('Machine selector testing', () => {
   it('Testing selector with unmatching rule', () => {
     //cy.clickButton('Add Rule');
     // TODO: Cannot use the clickButton here, I do not know why yet 
-    cy.get('.mt-20 > .btn').contains('Add Rule').click();
+    cy.get('[cluster="[provisioning.cattle.io.cluster: undefined]"]').contains('Add Rule').click();
     cy.get('[data-testid="input-match-expression-values-0"] > input').click().type('wrong');
     cy.contains('.banner', 'Matches no existing Inventory of Machines').should('exist');
   });
@@ -40,7 +40,7 @@ describe('Machine selector testing', () => {
   it('Testing selector with matching rule', () => {
     //cy.clickButton('Add Rule');
     // TODO: Cannot use the clickButton here, I do not know why yet 
-    cy.get('.mt-20 > .btn').contains('Add Rule').click();
+    cy.get('[cluster="[provisioning.cattle.io.cluster: undefined]"]').contains('Add Rule').click();
     cy.get('#vs6__combobox').click()
     cy.contains('myInvLabel1').click();
     cy.get('[data-testid="input-match-expression-values-0"] > input').click().type('myInvLabelValue1');


### PR DESCRIPTION
Fix #663 

Verification runs:
[Latest Rancher Manager K3s](https://github.com/rancher/elemental/actions/runs/4195698892/jobs/7275629665) - Failed on upgrade, not related to this PR
[Stable Rancher Manager K3s](https://github.com/rancher/elemental/actions/runs/4195699792/jobs/7275629833)