### PR TITLE
ci/e2e: install the 3rd first nodes all in parallel

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -301,18 +301,13 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
         run: cd tests && make e2e-configure-rancher
-      - name: Bootstrap node 1 with current build (use Emulated TPM and iPXE)
-        if: inputs.test_type == 'cli'
-        env:
-          EMULATE_TPM: true
-          VM_INDEX: 1
-        run: cd tests && make e2e-bootstrap-node
-      - name: Bootstrap node 2 and 3 with current build (use Emulated TPM and ISO)
+      - name: Bootstrap node 1, 2 and 3 with current build (use Emulated TPM and ISO) in pool "master"
         if: inputs.test_type == 'cli'
         env:
           EMULATE_TPM: true
           ISO_BOOT: true
-          VM_INDEX: 2
+          POOL: master
+          VM_INDEX: 1
           VM_NUMBERS: 3
         run: |
           OPERATOR_VERSION=$(kubectl get pods \
@@ -325,9 +320,10 @@ jobs:
           [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
 
           cd tests && make e2e-bootstrap-node
-      - name: Bootstrap additional nodes (total of ${{ inputs.node_number }}) with current build (use iPXE)
+      - name: Bootstrap additional nodes (total of ${{ inputs.node_number }}) with current build (use iPXE) in pool "worker"
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
+          POOL: worker
           VM_INDEX: 4
           VM_NUMBERS: ${{ inputs.node_number }}
         run: cd tests && make e2e-bootstrap-node
@@ -437,4 +433,3 @@ jobs:
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
             --delete-disks all \
             --zone ${{ inputs.zone }}
-

--- a/tests/assets/cluster.yaml
+++ b/tests/assets/cluster.yaml
@@ -13,7 +13,7 @@ spec:
         kind: MachineInventorySelectorTemplate
         name: selector-master-%CLUSTER_NAME%
       name: pool-master-%CLUSTER_NAME%
-      quantity: 1
+      quantity: 0
       workerRole: true
     - controlPlaneRole: false
       etcdRole: false

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -101,17 +101,6 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 						"-o", "jsonpath={.items[*].metadata.name}")
 					return out
 				}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + pool + "-" + clusterName))
-
-				// Check that the selector for master is correctly created
-				// NOTE: the worker one is not created yet because 'quantity' is set to 0 for this one
-				if pool == "master" {
-					Eventually(func() string {
-						out, _ := kubectl.Run("get", "MachineInventorySelector",
-							"--namespace", clusterNS,
-							"-o", "jsonpath={.items[*].metadata.name}")
-						return out
-					}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + pool + "-" + clusterName))
-				}
 			}
 		})
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -61,6 +61,7 @@ var (
 	k8sVersion          string
 	numberOfVMs         int
 	osImage             string
+	poolType            string
 	proxy               string
 	rancherChannel      string
 	rancherLogCollector string
@@ -98,6 +99,7 @@ var _ = BeforeSuite(func() {
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	number := os.Getenv("VM_NUMBERS")
 	osImage = os.Getenv("CONTAINER_IMAGE")
+	poolType = os.Getenv("POOL")
 	proxy = os.Getenv("PROXY")
 	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -31,6 +31,9 @@ if [[ ${EMULATE_TPM} != "true" ]]; then
   EMULATED_TPM="emulator,model=tpm-crb,version=2.0"
 fi
 
+# Create directories: dedicated one for storage pool + logs one
+mkdir -p logs ${VM_NAME}
+
 # iPXE stuff will not be used if ISO is set
 if [[ ${ISO_BOOT} == "true" ]]; then
   ISO=$(realpath ../../elemental-*.iso 2>/dev/null)
@@ -40,8 +43,11 @@ if [[ ${ISO_BOOT} == "true" ]]; then
     && echo "File ${ISO} not found! Exiting!" >&2 \
     && exit 1
 
+  # Soft-link the ISO to avoid "Could not define storage pool" error
+  ln -s ${ISO} ${VM_NAME}/
+
   # Force ISO boot
-  INSTALL_FLAG="--cdrom ${ISO}"
+  INSTALL_FLAG="--cdrom ${VM_NAME}/${ISO##*/}"
 else
   # Create symlink for binary but only if it doesn't exist
   SYM_LINK=../../ipxe.efi
@@ -61,12 +67,6 @@ else
   # Force PXE boot
   INSTALL_FLAG="--pxe"
 fi
-
-# Create logs directory if needed
-mkdir -p logs
-
-# Create a dedicated directory for storage pool
-mkdir -p ${VM_NAME}
 
 # Wait randomly until 20s to avoid running virt-install at the same time
 # Because it can lead to some issues with hugepages


### PR DESCRIPTION
This will reduce CI execution time.

Nodes 1, 2 and 3 will be installed using the ISO and emulated TPM on the *master* pool, and the other nodes will be installed using iPXE and hardware TPM on the *worker* pool.

Verification runs:
- [RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4196674169)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4196402722)
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4196542635)
- [OBS-Staging-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4196763184)
- [OBS-Staging-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4196767180)