### PR TITLE
ci/ui: Disable upgrade

### DIFF
--- a/tests/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -67,7 +67,7 @@ describe('Upgrade tests', () => {
     cy.contains('There are no rows to show');
   });
 
-  it('Upgrade one node with OS Image Upgrades', () => {
+  it.skip('Upgrade one node with OS Image Upgrades', () => {
     // Create ManagedOSImage resource
     cy.get('.nav').contains('Advanced').click();
     cy.get('.nav').contains('Update Groups').click();


### PR DESCRIPTION
This PR disables upgrade test in our main scenario, we agreed to test upgrade in a separate test where we will use stable ISO and update to dev one.