### PR TITLE
ci/ui: add UI upgrade test back

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -287,6 +287,7 @@ jobs:
           RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
           RANCHER_USER: admin
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
+          UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           SPEC: |
             cypress/e2e/unit_tests/machine_selector.spec.ts
             cypress/e2e/unit_tests/machine_inventory.spec.ts

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -340,14 +340,14 @@ jobs:
 
           cd tests && make e2e-bootstrap-node
       - name: Upgrade node 1 to specified OS version with osImage
-        if: inputs.upgrade_image != ''
+        if: inputs.test_type == 'cli' && inputs.upgrade_image != ''
         env:
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           UPGRADE_TYPE: osImage
           VM_INDEX: 1
         run: cd tests && make e2e-upgrade-node
       - name: Upgrade other nodes to specified OS version with managedOSVersionName
-        if: inputs.upgrade_os_channel != ''
+        if: inputs.test_type == 'cli' && inputs.upgrade_os_channel != ''
         env:
           UPGRADE_CHANNEL_LIST: ${{ inputs.upgrade_channel_list }}
           UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -1,0 +1,66 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-K3s-OS-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: latest
+        type: string
+      iso_to_test:
+        description: ISO to test
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+        type: string
+      upgrade_os_channel:
+        description: Channel to use for the Elemental OS upgrade
+        default: dev
+        type: string
+
+jobs:
+  ui-k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      iso_to_test: ${{ inputs.iso_to_test }}
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: ${{ inputs.upgrade_operator }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
+

--- a/.github/workflows/ui-k3s-stable-rm_latest-upgrade.yaml
+++ b/.github/workflows/ui-k3s-stable-rm_latest-upgrade.yaml
@@ -1,0 +1,54 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-K3s-Stable-RM_Latest-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: '1.0.0'
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: latest
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: devel
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  ui-k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner || true }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-k3s-stable-rm_stable-upgrade.yaml
+++ b/.github/workflows/ui-k3s-stable-rm_stable-upgrade.yaml
@@ -1,0 +1,54 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-K3s-Stable-RM_Stable-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: '1.0.0'
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  ui-k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner || true }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -1,0 +1,65 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-RKE2-OS-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: latest
+        type: string
+      iso_to_test:
+        description: ISO to test
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+        type: string
+      upgrade_os_channel:
+        description: Channel to use for the Elemental OS upgrade
+        default: dev
+        type: string
+
+jobs:
+  ui-k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-rke2
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      iso_to_test: ${{ inputs.iso_to_test }}
+      k8s_version_to_provision: v1.24.8+rke2r1
+      proxy: ${{ inputs.proxy }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: ${{ inputs.upgrade_operator }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-rke2-stable-rm_latest-upgrade.yaml
+++ b/.github/workflows/ui-rke2-stable-rm_latest-upgrade.yaml
@@ -1,0 +1,53 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-RKE2-Stable-RM_Latest-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: '1.0.0'
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: latest
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: devel
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  ui-rke2:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      #ui_account: user
+      ca_type: private
+      cluster_name: cluster-rke2
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner || true }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+rke2r1
+      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-rke2-stable-rm_stable-upgrade.yaml
+++ b/.github/workflows/ui-rke2-stable-rm_stable-upgrade.yaml
@@ -1,0 +1,53 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-RKE2-Stable-RM_Stable-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed
+        default: '1.0.0'
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  ui-rke2:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      #ui_account: user
+      ca_type: private
+      cluster_name: cluster-rke2
+      cypress_tags: upgrade
+      destroy_runner: ${{ inputs.destroy_runner || true }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+rke2r1
+      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
+      test_type: ui
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ CI with latest stable Rancher Manager:
 [![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
 [![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
 
+[![UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml)
+[![UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml)
+
 CI with latest devel Rancher Manager:
 
 [![K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml)
@@ -20,6 +23,9 @@ CI with latest devel Rancher Manager:
 
 [![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
 [![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)
+
+[![UI-K3s-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml)
+[![UI-RKE2-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml)
 
 Elemental is a software stack enabling a centralized, full cloud-native OS management solution with Kubernetes.
 

--- a/tests/cypress/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/e2e/unit_tests/deploy_app.spec.ts
@@ -27,7 +27,7 @@ filterTests(['main'], () => {
     
     it('Deploy CIS Benchmark application', () => {
       topLevelMenu.openIfClosed();
-      cy.contains('myelementalcluster').click();
+      cy.contains('mycluster').click();
       cy.contains('Apps').click();
       cy.contains('Charts').click();
       cy.contains('CIS Benchmark').click();
@@ -42,7 +42,7 @@ filterTests(['main'], () => {
   
     it('Remove CIS Benchmark application', () => {
       topLevelMenu.openIfClosed();
-      cy.contains('myelementalcluster').click();
+      cy.contains('mycluster').click();
       cy.contains('Apps').click();
       cy.contains('Installed Apps').click();
       cy.contains('.title', 'Installed Apps', {timeout:20000});

--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -49,7 +49,7 @@ describe('Machine inventory testing', () => {
   filterTests(['main', 'upgrade'], () => {
     it('Create Elemental cluster', () => {
       cy.contains('Create Elemental Cluster').click();
-      cy.typeValue({label: 'Cluster Name', value: 'myelementalcluster'});
+      cy.typeValue({label: 'Cluster Name', value: 'mycluster'});
       cy.typeValue({label: 'Cluster Description', value: 'My Elemental testing cluster'});
       cy.contains('Show deprecated Kubernetes').click();
       cy.contains('Kubernetes Version').click();
@@ -68,8 +68,8 @@ describe('Machine inventory testing', () => {
         cy.get(':nth-child(11) > .no-resize').type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
       }
       cy.clickButton('Create');
-      cy.contains('Updating myelementalcluster', {timeout: 20000});
-      cy.contains('Active myelementalcluster', {timeout: 360000});
+      cy.contains('Updating mycluster', {timeout: 20000});
+      cy.contains('Active mycluster', {timeout: 360000});
     });
   });
   
@@ -78,10 +78,10 @@ describe('Machine inventory testing', () => {
       topLevelMenu.openIfClosed();
       cy.contains('Home').click();
       // The new cluster must be in active state
-      cy.get('[data-node-id="fleet-default/myelementalcluster"]').contains('Active');
+      cy.get('[data-node-id="fleet-default/mycluster"]').contains('Active');
       // Go into the dedicated cluster page
       topLevelMenu.openIfClosed();
-      cy.contains('myelementalcluster').click();
+      cy.contains('mycluster').click();
     })
   });
 });

--- a/tests/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -1,6 +1,5 @@
 /*
 Copyright © 2022 - 2023 SUSE LLC
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -27,6 +26,7 @@ describe('Upgrade tests', () => {
   const operator_version = Cypress.env('operator_version');
   const elemental_user   = "elemental-user"
   const ui_password      = "rancherpassword"
+  const upgrade_image    = Cypress.env('upgrade_image')
 
   beforeEach(() => {
     (ui_account == "user") ? cy.login(elemental_user, ui_password) : cy.login();
@@ -93,8 +93,8 @@ describe('Upgrade tests', () => {
       cy.get('.primaryheader').contains('Update Group: Create');
       cy.typeValue({label: 'Name', value: 'upgrade'});
       cy.contains('Target Cluster').click();
-      cy.contains('myelementalcluster').click();
-      cy.typeValue({label: 'OS Image', value: 'registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest'});
+      cy.contains('mycluster').click();
+      cy.typeValue({label: 'OS Image', value: upgrade_image});
       cy.clickButton('Create');
       // Status changes a lot right after the creation so let's wait 10 secondes
       // before checking
@@ -105,7 +105,7 @@ describe('Upgrade tests', () => {
       // https://github.com/rancher/elemental/issues/410
       // Restart fleet agent inside downstream cluster
       topLevelMenu.openIfClosed();
-      cy.contains('myelementalcluster').click();
+      cy.contains('mycluster').click();
       cy.contains('Workload').click();
       cy.contains('Pods').click();
       cy.get('.header-buttons > :nth-child(2)').click();
@@ -119,10 +119,10 @@ describe('Upgrade tests', () => {
       cy.clickNavMenu(["Dashboard"]);
       cy.clickButton('Manage Elemental Clusters');
       cy.get('.title').contains('Clusters');
-      cy.contains('myelementalcluster').click();
+      cy.contains('mycluster').click();
       cy.get('.primaryheader').contains('Active');
       cy.get('.primaryheader').contains('Updating', {timeout: 240000});
       cy.get('.primaryheader').contains('Active', {timeout: 240000});
     });
   });
-}); 
+});

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -39,6 +39,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.proxy_ip = process.env.PROXY_IP;
   config.env.elemental_ui_version = process.env.ELEMENTAL_UI_VERSION;
   config.env.cypress_tags = process.env.CYPRESS_TAGS;
+  config.env.upgrade_image = process.env.UPGRADE_IMAGE;
 
   return config;
 };

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -98,7 +98,7 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 				checkRC(err)
 				err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
 				checkRC(err)
-				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT charts.rancher.io"))
+				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT.*rancher.io"))
 			})
 		}
 	})

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -22,6 +22,7 @@ docker run -v $PWD:/e2e -w /e2e                            \
     -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION          \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                          \
     -e PROXY=$PROXY                                        \
+    -e UPGRADE_IMAGE=$UPGRADE_IMAGE                        \
     --add-host host.docker.internal:host-gateway           \
     --ipc=host                                             \
     $CYPRESS_DOCKER                                        \


### PR DESCRIPTION
Fix #659 

Verification runs:
[UI-K3s-Stable-RM_Latest-Upgrade](https://github.com/rancher/elemental/actions/runs/4247873025/jobs/7386410896) - This one failed for a reason external to the PR.
[UI-K3s-Stable-RM_Stable-Upgrade](https://github.com/rancher/elemental/actions/runs/4247873032/jobs/7386411012) :heavy_check_mark: 
[UI-RKE2-Stable-RM_Latest-Upgrade](https://github.com/rancher/elemental/actions/runs/4247873037/jobs/7386409520):heavy_check_mark: 
[UI-RKE2-Stable-RM_Stable-Upgrade](https://github.com/rancher/elemental/actions/runs/4247873028/jobs/7386412170):heavy_check_mark: 

- cluster renamed from `myelementalcluster` to `mycluster` due to this bug https://github.com/rancher/elemental-operator/issues/365
- update the regex which is making sure we went through proxy