### PR TITLE
ci/ui: update regex to check proxy logs

### DIFF
--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -98,7 +98,7 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 				checkRC(err)
 				err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
 				checkRC(err)
-				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT git.rancher.io"))
+				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT charts.rancher.io"))
 			})
 		}
 	})


### PR DESCRIPTION
Failed tests: https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml and https://github.com/rancher/elemental/actions/runs/4225773365/jobs/7339319440

The test which using proxy fails sporadically, we trap this `TCP_TUNNEL/200.*CONNECT git.rancher.io` and sometimes we cannot see it in the log, I checked and when we see it, it is the last line of the file so I'm thinking about a race condition there. We should check something else to make the test more resilient.

Verification run:
https://github.com/rancher/elemental/actions/runs/4231654361
https://github.com/rancher/elemental/actions/runs/4232912174