### PR TITLE
e2e: add separate upgrade test

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -1,0 +1,30 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-K3s-OS-Upgrade-RM_Latest
+
+# This worflow is scheduled because it uses Dev artifacts from OBS and
+# not the ones built in the CI (build-ci workflow).
+# The scheduling is also to avoid running the workflow on each push on main.
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: latest
+      rancher_version: devel
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -1,0 +1,30 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-K3s-OS-Upgrade-RM_Stable
+
+# This worflow is scheduled because it uses Dev artifacts from OBS and
+# not the ones built in the CI (build-ci workflow).
+# The scheduling is also to avoid running the workflow on each push on main.
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+k3s1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: stable
+      rancher_version: latest
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -1,0 +1,56 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-K3s-OS-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      iso_to_test:
+        description: ISO to test
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+        type: string
+      upgrade_os_channel:
+        description: Channel to use for the Elemental OS upgrade
+        default: dev
+        type: string
+
+concurrency:
+  group: cli-k3s-os-upgrade-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
+      iso_to_test: ${{ inputs.iso_to_test }}
+      k8s_version_to_provision: v1.24.8+k3s1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: ${{ inputs.upgrade_operator }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -1,0 +1,30 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-RKE2-OS-Upgrade-RM_Latest
+
+# This worflow is scheduled because it uses Dev artifacts from OBS and
+# not the ones built in the CI (build-ci workflow).
+# The scheduling is also to avoid running the workflow on each push on main.
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-rke2
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+rke2r1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: latest
+      rancher_version: devel
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -1,0 +1,30 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-RKE2-OS-Upgrade-RM_Stable
+
+# This worflow is scheduled because it uses Dev artifacts from OBS and
+# not the ones built in the CI (build-ci workflow).
+# The scheduling is also to avoid running the workflow on each push on main.
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-rke2
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.24.8+rke2r1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: stable
+      rancher_version: latest
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -1,0 +1,56 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-RKE2-OS-Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      iso_to_test:
+        description: ISO to test
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        type: string
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+        type: string
+      upgrade_os_channel:
+        description: Channel to use for the Elemental OS upgrade
+        default: dev
+        type: string
+
+concurrency:
+  group: cli-rke2-os-upgrade-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner }}
+      iso_to_test: ${{ inputs.iso_to_test }}
+      k8s_version_to_provision: v1.24.8+rke2r1
+      # Force to only deploy the first 3 nodes
+      node_number: 3
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_operator: ${{ inputs.upgrade_operator }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -3,7 +3,7 @@ name: K3s-E2E-Latest_RM
 
 # This worflow is scheduled *after* build-ci to be sure that we have
 # the lastest version built. The scheduling is also to avoid running
-# the worklow on each push on main.
+# the workflow on each push on main.
 on:
   schedule:
     - cron: '0 1 * * *'

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -96,8 +96,20 @@ on:
         description: Account used to test RBAC role in UI
         required: false
         type: string
+      upgrade_channel_list:
+        description: URL to version channel list for Elemental OS upgrade
+        type: string
+      upgrade_image:
+        description: Image to use for the Elemental OS upgrade
+        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
+        type: string
+      upgrade_os_channel:
+        description: Channel to use for the Elemental OS upgrade
+        type: string
+      upgrade_type:
+        description: Type of upgrade to use for the Elemental OS upgrade
         type: string
       workflow_download:
         description: build-ci workflow to use for artifacts
@@ -307,7 +319,7 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
         run: cd tests && make e2e-configure-rancher
-      - name: Bootstrap node 1, 2 and 3 with current build (use Emulated TPM and ISO) in pool "master"
+      - name: Bootstrap node 1, 2 and 3 (use Emulated TPM and ISO) in pool "master"
         if: inputs.test_type == 'cli'
         env:
           EMULATE_TPM: true
@@ -326,7 +338,23 @@ jobs:
           [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
 
           cd tests && make e2e-bootstrap-node
-      - name: Bootstrap additional nodes (total of ${{ inputs.node_number }}) with current build (use iPXE) in pool "worker"
+      - name: Upgrade node 1 to specified OS version with osImage
+        if: inputs.upgrade_image != ''
+        env:
+          UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
+          UPGRADE_TYPE: osImage
+          VM_INDEX: 1
+        run: cd tests && make e2e-upgrade-node
+      - name: Upgrade other nodes to specified OS version with managedOSVersionName
+        if: inputs.upgrade_os_channel != ''
+        env:
+          UPGRADE_CHANNEL_LIST: ${{ inputs.upgrade_channel_list }}
+          UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
+          UPGRADE_TYPE: managedOSVersionName
+          VM_INDEX: 2
+          VM_NUMBERS: 3
+        run: cd tests && make e2e-upgrade-node
+      - name: Bootstrap additional nodes (use iPXE) in pool "worker" (total of ${{ inputs.node_number }})
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
           POOL: worker
@@ -366,11 +394,6 @@ jobs:
                          -l app=rancher \
                          -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
           # Extract elemental-operator version
-          if ${{ env.UPGRADE_OPERATOR == '' }}; then
-            UPGRADE_OPERATOR_VALUE="N/A"
-          else
-            UPGRADE_OPERATOR_VALUE=${{ env.UPGRADE_OPERATOR }}
-          fi
           OPERATOR_VERSION=$(kubectl get pod \
                              --namespace cattle-elemental-system \
                              -l app=elemental-operator \
@@ -384,11 +407,18 @@ jobs:
           echo "## Versions used" >> $GITHUB_STEP_SUMMARY
           echo "Rancher Manager Channel: ${{ env.RANCHER_CHANNEL }}/${{ env.RANCHER_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "Rancher Manager Version: ${RM_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "Elemental Operator Upgrade: ${UPGRADE_OPERATOR_VALUE}" >> $GITHUB_STEP_SUMMARY
+          echo "Elemental Operator Upgrade: ${{ env.UPGRADE_OPERATOR || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
           echo "Elemental Operator Version: ${OPERATOR_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "Elemental UI Extension Version (if applicable): ${{ inputs.elemental_ui_version }}" >> $GITHUB_STEP_SUMMARY
           echo "K3s on Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "K3s/RKE2 version deployed on the cluster: ${{ inputs.k8s_version_to_provision }}" >> $GITHUB_STEP_SUMMARY
+          # Upgrade details
+          if ${{ inputs.upgrade_image != '' }} || ${{ inputs.upgrade_os_channel != '' }}; then
+            echo "## Upgrade details" >> $GITHUB_STEP_SUMMARY
+            echo "Channel list: ${{ inputs.upgrade_channel_list }}" >> $GITHUB_STEP_SUMMARY
+            echo "Channel used: ${{ inputs.upgrade_os_channel }}" >> $GITHUB_STEP_SUMMARY
+            echo "Upgrade image: ${{ inputs.upgrade_image }}" >> $GITHUB_STEP_SUMMARY
+          fi
       - name: Send failed status to slack
         if: failure() && github.event_name == 'schedule'
         uses: slackapi/slack-github-action@v1.23.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ CI with latest stable Rancher Manager:
 [![K3s-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml)
 [![RKE2-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml)
 
+[![CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml)
+[![CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml)
+
 [![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
 [![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
 
@@ -11,6 +14,9 @@ CI with latest devel Rancher Manager:
 
 [![K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml)
 [![RKE2-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml)
+
+[![CLI-K3s-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml)
+[![CLI-RKE2-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml)
 
 [![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
 [![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)

--- a/tests/assets/managedOSVersionChannel.yaml
+++ b/tests/assets/managedOSVersionChannel.yaml
@@ -1,13 +1,12 @@
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
-  name: os-versions
+  name: elemental-channel-list
   # The namespace must match the namespace of the cluster
   # assigned to the clusters.provisioning.cattle.io resource
   # namespace: fleet-default
 spec:
   options:
-    URI: http://192.168.122.1:8000/tests/assets/osVersions.json
-    Timeout: 1m
-  type: json
+    image: %UPGRADE_CHANNEL_LIST%
+  type: custom
   syncInterval: 5m

--- a/tests/assets/upgrade_skel.yaml
+++ b/tests/assets/upgrade_skel.yaml
@@ -1,11 +1,11 @@
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSImage
 metadata:
-  name: default-os-image
+  name: with-%UPGRADE_TYPE%
   # The namespace must match the namespace of the cluster
   # assigned to the clusters.provisioning.cattle.io resource
   # namespace: fleet-default
 spec:
-  %OS_IMAGE%
+  %UPGRADE_TYPE%
   clusterTargets:
     - clusterName: %CLUSTER_NAME%


### PR DESCRIPTION
Should fix #670 and #671.

Verification runs:
- [OBS-Stable-K3s-E2E-Upgrade](https://github.com/rancher/elemental/actions/runs/4236925512)
- [CLI-RKE2-Stable-RM_Stable-Upgrade](https://github.com/rancher/elemental/actions/runs/4241831890)
- [CLI-RKE2-Stable-RM_Stable-Upgrade with PrivateCA and Stable Operator](https://github.com/rancher/elemental/actions/runs/4242227097)
- [CLI-RKE2-Stable-RM_Stable-Upgrade with PrivateCA and Dev Operator](https://github.com/rancher/elemental/actions/runs/4242753691) -> it fails but it's not related to this PR, it will be checked later
- [CLI-K3s-OS-Upgrade with Upgrade Summary](https://github.com/rancher/elemental/actions/runs/4244959557)