### PR TITLE
ci/e2e: add regression test for elemental-operator#352

### DIFF
--- a/tests/assets/selector.yaml
+++ b/tests/assets/selector.yaml
@@ -15,4 +15,5 @@ spec:
         - key: cluster-id
           operator: In
           values:
+          - just-a-dumb-value
           - id-%CLUSTER_NAME%

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -17,6 +17,7 @@ package e2e_test
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -71,6 +72,11 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 			defer os.Remove(selectorTmp)
 
+			// Get elemental-operator version
+			operatorVersion, err := misc.GetOperatorVersion()
+			Expect(err).To(Not(HaveOccurred()))
+			operatorVersionShort := strings.Split(operatorVersion, ".")
+
 			for _, pool := range []string{"master", "worker"} {
 				// Patterns to replace
 				addPatterns := []pattern{
@@ -87,6 +93,12 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 				// Create Yaml file
 				for _, p := range patterns {
 					err := tools.Sed(p.key, p.value, selectorTmp)
+					Expect(err).To(Not(HaveOccurred()))
+				}
+
+				// Remove 'just-a-dumb-value' if needed (multiple values only supported in operator v1.1+)
+				if (operatorVersionShort[0] + "." + operatorVersionShort[1]) == "1.0" {
+					err := tools.Sed(".*just-a-dumb-value.*", "", selectorTmp)
 					Expect(err).To(Not(HaveOccurred()))
 				}
 


### PR DESCRIPTION
Just add a value in the selector list to validate that the issue faced in rancher/elemental-operator#352 will not happen again.

Should fix #672.

Verification run:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4251423301)
- [OBS-Stable-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4251239429)