### PR TITLE
ci/ui: fix ui upgrade tests names to match README

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-K3s-OS-Upgrade-RM_Latest
+name: CLI-K3s-OS-Upgrade-Rancher_Latest
 
 # This worflow is scheduled because it uses Dev artifacts from OBS and
 # not the ones built in the CI (build-ci workflow).

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-K3s-OS-Upgrade-RM_Stable
+name: CLI-K3s-OS-Upgrade-Rancher_Stable
 
 # This worflow is scheduled because it uses Dev artifacts from OBS and
 # not the ones built in the CI (build-ci workflow).

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-RKE2-OS-Upgrade-RM_Latest
+name: CLI-RKE2-OS-Upgrade-Rancher_Latest
 
 # This worflow is scheduled because it uses Dev artifacts from OBS and
 # not the ones built in the CI (build-ci workflow).

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-RKE2-OS-Upgrade-RM_Stable
+name: CLI-RKE2-OS-Upgrade-Rancher_Stable
 
 # This worflow is scheduled because it uses Dev artifacts from OBS and
 # not the ones built in the CI (build-ci workflow).

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-RKE2-Stable-RM_Stable-Upgrade
+name: UI-K3s-OS-Upgrade-Rancher_Latest
 
 on:
   workflow_dispatch:
@@ -12,13 +12,17 @@ on:
         description: Version of the elemental ui which will be installed
         default: '1.0.0'
         type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
+        default: latest
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        default: devel
         type: string
       runner_template:
         description: Runner template to use
@@ -28,25 +32,22 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  ui-rke2:
+  ui-k3s:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
+      cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      k8s_version_to_provision: v1.24.8+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'devel' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-K3s-Stable-RM_Latest-Upgrade
+name: UI-K3s-OS-Upgrade-Rancher_Stable
 
 on:
   workflow_dispatch:
@@ -18,11 +18,11 @@ on:
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
       runner_template:
         description: Runner template to use
@@ -46,8 +46,8 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -63,4 +63,3 @@ jobs:
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: ${{ inputs.upgrade_operator }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-RKE2-Stable-RM_Latest-Upgrade
+name: UI-RKE2-OS-Upgrade-Rancher_Latest
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-K3s-Stable-RM_Stable-Upgrade
+name: UI-RKE2-OS-Upgrade-Rancher_Stable
 
 on:
   workflow_dispatch:
@@ -11,10 +11,6 @@ on:
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
         default: '1.0.0'
-        type: string
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
@@ -32,20 +28,23 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  ui-k3s:
+  ui-rke2:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      cluster_name: cluster-k3s
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      #ui_account: user
+      ca_type: private
+      cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
-      proxy: ${{ inputs.proxy || 'elemental' }}
+      k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}

--- a/README.md
+++ b/README.md
@@ -4,28 +4,28 @@ CI with latest stable Rancher Manager:
 [![K3s-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml)
 [![RKE2-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml)
 
-[![CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml)
-[![CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml)
+[![CLI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml)
+[![CLI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml)
 
 [![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
-[![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
+[![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
 
-[![UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml)
-[![UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml)
+[![UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml)
+[![UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml)
 
 CI with latest devel Rancher Manager:
 
 [![K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml)
 [![RKE2-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml)
 
-[![CLI-K3s-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml)
-[![CLI-RKE2-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml)
+[![CLI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml)
+[![CLI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml)
 
 [![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
-[![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)
+[![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)
 
-[![UI-K3s-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml)
-[![UI-RKE2-OS-Upgrade-RM_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml)
+[![UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml)
+[![UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml)
 
 Elemental is a software stack enabling a centralized, full cloud-native OS management solution with Kubernetes.
 


### PR DESCRIPTION
This PR fixes bad `links/tests names` for github badges introduced by https://github.com/rancher/elemental/pull/683.