### PR TITLE
ci/ui: group all upgrade tests in upgrade scenario

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -287,6 +287,7 @@ jobs:
           RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
           RANCHER_USER: admin
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
+          UPGRADE_CHANNEL_LIST: ${{ inputs.upgrade_channel_list }}
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           SPEC: |
             cypress/e2e/unit_tests/machine_selector.spec.ts

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: latest
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -42,7 +42,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
@@ -50,5 +50,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -50,5 +50,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -60,6 +60,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: ${{ inputs.upgrade_operator }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: latest
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
@@ -42,12 +42,13 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -49,5 +49,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -60,6 +60,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       test_type: ui
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: ${{ inputs.upgrade_operator }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/tests/cypress/plugins/index.ts
+++ b/tests/cypress/plugins/index.ts
@@ -39,6 +39,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.proxy_ip = process.env.PROXY_IP;
   config.env.elemental_ui_version = process.env.ELEMENTAL_UI_VERSION;
   config.env.cypress_tags = process.env.CYPRESS_TAGS;
+  config.env.upgrade_channel_list = process.env.UPGRADE_CHANNEL_LIST;
   config.env.upgrade_image = process.env.UPGRADE_IMAGE;
 
   return config;

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -22,6 +22,7 @@ docker run -v $PWD:/e2e -w /e2e                            \
     -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION          \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                          \
     -e PROXY=$PROXY                                        \
+    -e UPGRADE_CHANNEL_LIST=$UPGRADE_CHANNEL_LIST          \
     -e UPGRADE_IMAGE=$UPGRADE_IMAGE                        \
     --add-host host.docker.internal:host-gateway           \
     --ipc=host                                             \


### PR DESCRIPTION
Fix issue with OS channel tests: https://github.com/rancher/elemental/actions/runs/4249379692/jobs/7389488389
First thing is moving those tests in the upgrade scenario instead of main.

Verification runs:
[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4253058702) :heavy_check_mark: 
[K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4253067554) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4253417339) :heavy_check_mark: 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4253410532) :heavy_check_mark: 

