### PR TITLE
ci/e2e: fix a sporadic issue when retrieving server id

### DIFF
--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -16,6 +16,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
+      ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -16,6 +16,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
+      ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -41,6 +41,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
+      ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -321,7 +321,7 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
         run: cd tests && make e2e-configure-rancher
-      - name: Bootstrap node 1, 2 and 3 (use Emulated TPM and ISO) in pool "master"
+      - name: Bootstrap node 1, 2 and 3 (use and ISO) in pool "master" (use Emulated TPM if possible)
         if: inputs.test_type == 'cli'
         env:
           EMULATE_TPM: true
@@ -338,6 +338,11 @@ jobs:
 
           # If elemental-operator is a v1.0.x we should disable EMULATE_TPM
           [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
+
+          # Disable EMULATE_TPM in case of upgrade test
+          # This is because we don't know the version in advance, so easier to not use it
+          [[ ${{ inputs.upgrade_image != '' }} || ${{ inputs.upgrade_os_channel != '' }} ]] \
+            && unset EMULATE_TPM
 
           cd tests && make e2e-bootstrap-node
       - name: Upgrade node 1 to specified OS version with osImage

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -158,9 +158,10 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 				defer GinkgoRecover()
 
 				By("Checking that node "+h+" is available in Rancher", func() {
-					id, err := misc.GetServerId(c, i)
-					Expect(err).To(Not(HaveOccurred()))
-					Expect(id).To(Not(BeEmpty()))
+					Eventually(func() string {
+						id, _ := misc.GetServerId(c, i)
+						return id
+					}, misc.SetTimeout(1*time.Minute), 5*time.Second).Should(Not(BeEmpty()))
 				})
 			}(clusterNS, hostName, index)
 		}


### PR DESCRIPTION
Sometimes the MachineInventory is empty on the first try, better to check it in a loop with a timeout.

Verification run:
- [CLI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/4254057925)
- [CLI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/4254218258)
- [OBS-Stable-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4255914779)