### PR TITLE
Do not allow downgrades without force flag

### DIFF
--- a/framework/files/usr/sbin/suc-upgrade
+++ b/framework/files/usr/sbin/suc-upgrade
@@ -20,6 +20,24 @@ function config()
     fi
 }
 
+function isHigherVersion()
+{
+    local img_ver=$( . ${RELEASE_FILE} && printf '%s\n' "${IMAGE_TAG}" )
+    local host_ver=$( . ${HOST_DIR}${RELEASE_FILE} && printf '%s\n' "${IMAGE_TAG}" )
+    local higher_ver
+
+    # Without knowing the version in the host, all img versions are
+    # considered higher
+    [ -z "${host_ver}" ] && return 0
+    
+    [ "${host_ver}" == "${img_ver}" ] && return 1
+
+    # Note sort -V is a natural numbering sort, not semver
+    higher_ver=$(printf '%s\n' "${img_ver}" "${host_ver}" | sort -rV | head -n1)
+    [ "${higher_ver}" == "${img_ver}" ] && return 0
+    return 1
+}
+
 (
   flock -w $LOCK_TIMEOUT 200 || exit 1
   if ! nsenter -i -m -t 1 -- systemctl is-system-running; then
@@ -28,9 +46,9 @@ function config()
   fi
 
   if [ "$FORCE" != "true" ]; then
-      if diff $RELEASE_FILE ${HOST_DIR}${RELEASE_FILE} >/dev/null; then
-          echo Update to date with
-          cat ${RELEASE_FILE}
+      if ! isHigherVersion; then
+          echo "Up to date with release:"
+          cat ${HOST_DIR}${RELEASE_FILE}
 
           config
           exit 0

--- a/framework/files/usr/sbin/suc-upgrade
+++ b/framework/files/usr/sbin/suc-upgrade
@@ -38,6 +38,13 @@ function isHigherVersion()
     return 1
 }
 
+function isEqualVersion() {
+ if diff $RELEASE_FILE ${HOST_DIR}${RELEASE_FILE} >/dev/null; then
+     return 0
+ fi
+ return 1
+}
+
 (
   flock -w $LOCK_TIMEOUT 200 || exit 1
   if ! nsenter -i -m -t 1 -- systemctl is-system-running; then
@@ -45,12 +52,19 @@ function isHigherVersion()
       exit 1
   fi
 
+  if isEqualVersion; then
+      echo "Upgrade already done with release:"
+      cat ${HOST_DIR}${RELEASE_FILE}
+
+      config
+      exit 0
+  fi
+
   if [ "$FORCE" != "true" ]; then
       if ! isHigherVersion; then
-          echo "Up to date with release:"
+          echo "Current OS is in a higher version, use FORCE to downgrade. Current version:"
           cat ${HOST_DIR}${RELEASE_FILE}
-
-          config
+          
           exit 0
       fi
   fi


### PR DESCRIPTION
This commit sorts the current OS version with the one we aim to upgrade to. If the OS to be upgraded to is not higher than the current one it assumes we are up to date and the upgrade script exits 0. This causes the upgrade plan to succeed and to be considered as upgraded. This is to fix https://github.com/rancher/elemental-operator/issues/364#issuecomment-1443139017

Alternatively if a downgrade is required it is still possible, but requires a customized `Update Group` (`ManagedOSImage` crd) to include the `FORCE` environment variable within the upgrade script:

```yaml
apiVersion: elemental.cattle.io/v1beta1
kind: ManagedOSImage
metadata:
  name: upgrade3
  namespace: fleet-default
spec:
  clusterTargets:
    - clusterName: my-cluster
  upgradeContainer:
    command:
      - "/usr/sbin/suc-upgrade"
    envs:
      - name: FORCE
        value: "true"
    image: myimage:mytag
```

With the `FORCE` flag no version is taken into account and the image is applied in any case.

`elemental-operator` logic makes use of the `osImage` field if no `upgradeContainer` field is provided to actually create a default `ugpradeContainer`. However if `upgradeContainer` is provided then `osImage` field is ignored. I'd say this logic is not very intuitive, but I'd say this should be handled separately if we consider there is something to change in there.

Fixes rancher/elemental-operator#364 