### PR TITLE
ci/ui: remove user workaround in RKE tests

### DIFF
--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -38,9 +38,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -37,9 +37,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -37,9 +37,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -37,9 +37,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -40,6 +40,7 @@ jobs:
     with:
       # Using user account has to be disable due to this bug
       # https://github.com/rancher/elemental-ui/issues/64
+      # Fixed in elemental-ui 1.1.0
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -35,9 +35,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: upgrade

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -37,6 +37,7 @@ jobs:
     with:
       # Using user account has to be disable due to this bug
       # https://github.com/rancher/elemental-ui/issues/64
+      # Fixed in elemental-ui 1.1.0
       #ui_account: user
       ca_type: private
       cluster_name: cluster-rke2

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -49,6 +49,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
+      ui_account: user
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}


### PR DESCRIPTION
As https://github.com/rancher/elemental-ui/issues/64 is fixed, we can remove the user workaround to run RKE2 test as elemental-user instead of admin.

elemental-user test is disabled in tests where we use elemental-ui (1.0.0 - stable), we will enable it when a new stable will be released.

Verification runs:
[RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4304252795) :heavy_check_mark: 
[RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4304254380) :heavy_check_mark: 