### PR TITLE
ci/e2e: fix/reduce OOM killer issue in CI with lot of nodes

### DIFF
--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -17,9 +17,9 @@ if (( NR_HUGEPAGES == 0 )); then
   MEMTOTAL_KB=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
 
   # Number of hugepages (with hugepagesize set to 2MB)
-  # NOTE: keep 12GB by default for the hypervisor/Rancher Manager Server
+  # NOTE: keep 24GB by default for the hypervisor/Rancher Manager Server
   # And this value can be modified with HOST_MEMORY_RESERVED variable
-  (( VALUE = ((MEMTOTAL_KB - ${HOST_MEMORY_RESERVED:-12582912}) / 2048) ))
+  (( VALUE = ((MEMTOTAL_KB - ${HOST_MEMORY_RESERVED:-25165824}) / 2048) ))
 
   # Set nr_hugepage
   (( VALUE > 0 )) \

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -9,10 +9,11 @@ ARCH=$(uname -m)
 FW_CODE=/usr/share/qemu/ovmf-${ARCH}-smm-suse-code.bin
 FW_VARS=$(realpath ../assets/ovmf-template-vars.fd)
 EMULATED_TPM="none"
+VM_MEM=3072
 
 # Configure hugepages if needed
 NR_HUGEPAGES=$(</proc/sys/vm/nr_hugepages)
-if (( NR_HUGEPAGES == 0 )); then
+if (( NR_HUGEPAGES == 0 && USE_HUGEPAGES != 0 )); then
   # Not configured, do it now!
   MEMTOTAL_KB=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
 
@@ -24,6 +25,12 @@ if (( NR_HUGEPAGES == 0 )); then
   # Set nr_hugepage
   (( VALUE > 0 )) \
     && sudo bash -c "echo ${VALUE} > /proc/sys/vm/nr_hugepages"
+
+  # Set memory config on command line
+  INSTALL_FLAG+=" --memorybacking hugepages=yes,size=2,unit=M,locked=yes --memory ${VM_MEM},hugepages=yes"
+else
+  # Set memory config on command line
+  INSTALL_FLAG+=" --memory ${VM_MEM}"
 fi
 
 # Don't configure TPM if software emulation (EMULATE_TPM=true) is used
@@ -47,7 +54,7 @@ if [[ ${ISO_BOOT} == "true" ]]; then
   ln -s ${ISO} ${VM_NAME}/
 
   # Force ISO boot
-  INSTALL_FLAG="--cdrom ${VM_NAME}/${ISO##*/}"
+  INSTALL_FLAG+=" --cdrom ${VM_NAME}/${ISO##*/}"
 else
   # Create symlink for binary but only if it doesn't exist
   SYM_LINK=../../ipxe.efi
@@ -65,7 +72,7 @@ else
   fi
 
   # Force PXE boot
-  INSTALL_FLAG="--pxe"
+  INSTALL_FLAG+=" --pxe"
 fi
 
 # Wait randomly until 20s to avoid running virt-install at the same time
@@ -81,8 +88,6 @@ script -e -O logs/bootstrap_${VM_NAME}.log \
   --machine q35 \
   --boot loader=${FW_CODE},loader.readonly=yes,loader.secure=yes,loader.type=pflash,nvram.template=${FW_VARS} \
   --features smm.state=yes \
-  --memorybacking hugepages=yes,size=2,unit=M,locked=yes \
-  --memory 3072,hugepages=yes \
   --vcpus 2 \
   --cpu host \
   --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=35 \
@@ -93,5 +98,5 @@ script -e -O logs/bootstrap_${VM_NAME}.log \
   --rng random \
   --tpm ${EMULATED_TPM} \
   --noreboot \
-  ${INSTALL_FLAG} \
-  --network network=default,bridge=virbr0,model=virtio,mac=${MAC}"
+  --network network=default,bridge=virbr0,model=virtio,mac=${MAC} \
+  ${INSTALL_FLAG}"


### PR DESCRIPTION
This PR contains 2 commits:
- reserve 24GB of RAM for Rancher Manager instead of 12GB, as with more that 10 nodes we can see OOM killer errors
- make the use of hugepages optional: as if we add more nodes more memory seems to be needed on Rancher Nabager side (this should be debugged later)

Related to #655.

Verification runs:
- [OBS-Stable-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4322882661/jobs/7545846626)

**NOTE:** the VR is failing because of #667.