### PR TITLE
ci/ui: add test to upgrade via os version channel

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -230,14 +230,13 @@ jobs:
         # Basics means tests without an extra elemental node needed
         if: inputs.test_type == 'ui'
         env:
-          UI_ACCOUNT: ${{ inputs.ui_account }}
           BROWSER: chrome
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
           RANCHER_USER: admin
-          CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           SPEC: |
             cypress/e2e/unit_tests/first_connection.spec.ts
             cypress/e2e/unit_tests/elemental_plugin.spec.ts
@@ -245,6 +244,7 @@ jobs:
             cypress/e2e/unit_tests/menu.spec.ts
             cypress/e2e/unit_tests/machine_registration.spec.ts
             cypress/e2e/unit_tests/advanced_filtering.spec.ts
+          UI_ACCOUNT: ${{ inputs.ui_account }}
         run: cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure() && inputs.test_type == 'ui'
@@ -279,21 +279,23 @@ jobs:
         # Advanced means tests which needs an extra elemental node (provisioned with libvirt)
         if: inputs.test_type == 'ui'
         env:
-          UI_ACCOUNT: ${{ inputs.ui_account }}
           BROWSER: firefox
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          CYPRESS_TAGS: ${{ inputs.cypress_tags }}
+          ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           PROXY: ${{ inputs.proxy }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ steps.installation.outputs.MY_HOSTNAME }}/dashboard
           RANCHER_USER: admin
-          CYPRESS_TAGS: ${{ inputs.cypress_tags }}
-          UPGRADE_CHANNEL_LIST: ${{ inputs.upgrade_channel_list }}
-          UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           SPEC: |
             cypress/e2e/unit_tests/machine_selector.spec.ts
             cypress/e2e/unit_tests/machine_inventory.spec.ts
             cypress/e2e/unit_tests/deploy_app.spec.ts
             cypress/e2e/unit_tests/upgrade.spec.ts
+          UI_ACCOUNT: ${{ inputs.ui_account }}
+          UPGRADE_CHANNEL_LIST: ${{ inputs.upgrade_channel_list }}
+          UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
+
         run: |
           export OPERATOR_VERSION=$(kubectl get pods \
                                       -n cattle-elemental-system \

--- a/tests/cypress/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/e2e/unit_tests/upgrade.spec.ts
@@ -20,17 +20,21 @@ import filterTests from '~/cypress/support/filterTests.js';
 
 Cypress.config();
 describe('Upgrade tests', () => {
-  const topLevelMenu            = new TopLevelMenu();
-  const elemental               = new Elemental();
-  const ui_account              = Cypress.env('ui_account');
-  const operator_version        = Cypress.env('operator_version');
-  const elemental_user          = "elemental-user"
-  const ui_password             = "rancherpassword"
-  const upgrade_channel_list    = Cypress.env('upgrade_channel_list')
-  const upgrade_image           = Cypress.env('upgrade_image')
+  const channelName        = "mychannel"
+  const clusterName        = "mycluster"
+  const checkK3s: RegExp   = /k3s/
+  const elemental          = new Elemental();
+  const elementalUIVersion = Cypress.env('elemental_ui_version')
+  const elementalUser      = "elemental-user"
+  const k8sVersion         = Cypress.env('k8s_version')
+  const topLevelMenu       = new TopLevelMenu();
+  const uiAccount          = Cypress.env('ui_account');
+  const uiPassword         = "rancherpassword"
+  const upgradeChannelList = Cypress.env('upgrade_channel_list')
+  const upgradeImage       = Cypress.env('upgrade_image')
 
   beforeEach(() => {
-    (ui_account == "user") ? cy.login(elemental_user, ui_password) : cy.login();
+    (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
     cy.visit('/');
 
     // Open the navigation menu
@@ -41,22 +45,31 @@ describe('Upgrade tests', () => {
   });
   filterTests(['upgrade'], () => {
     it('Create an OS Version Channels', () => {
-      (operator_version == "1.0") ? cy.exec(`sed -i '/syncInterval/d' assets/managedOSVersionChannel.yaml`) : "" ;
-      // Create ManagedOSVersionChannel resource
-      cy.exec(`sed -i 's/# namespace: fleet-default/namespace: fleet-default/g' assets/managedOSVersionChannel.yaml`);
-      cy.exec(`sed -i 's@image: %UPGRADE_CHANNEL_LIST%@image: ${upgrade_channel_list}@g' assets/managedOSVersionChannel.yaml`);
-      cy.get('.nav').contains('Advanced').click();
-      cy.get('.nav').contains('OS Version Channels').click();
-      cy.clickButton('Create from YAML');
-      // Wait needed to avoid crash with the upload
-      cy.wait(2000);
-      cy.get('input[type="file"]').attachFile({filePath: '../../assets/managedOSVersionChannel.yaml'});
-      // Wait needed to avoid crash with the upload
-      cy.wait(2000);
-      // Wait for os-versions to be printed, that means the upload is done
-      cy.clickButton('Create');
-      // The new resource must be active
-      cy.contains('Active');
+      // TODO: REMOVE 'IF' BLOCK AFTER NEXT STABLE VERSION (> 1.0.0)
+      // OSversion channel was not integrated in the UI before 1.1.0
+      if ( elementalUIVersion == '1.0.0' ) {
+        cy.exec(`sed -i 's/# namespace: fleet-default/namespace: fleet-default/g' assets/managedOSVersionChannel.yaml`);
+        cy.exec(`sed -i 's@image: %UPGRADE_CHANNEL_LIST%@image: ${upgradeChannelList}@g' assets/managedOSVersionChannel.yaml`);
+        cy.get('.nav').contains('Advanced').click();
+        cy.get('.nav').contains('OS Version Channels').click();
+        cy.clickButton('Create from YAML');
+        // Wait needed to avoid crash with the upload
+        cy.wait(2000);
+        cy.get('input[type="file"]').attachFile({filePath: '../../assets/managedOSVersionChannel.yaml'});
+        // Wait needed to avoid crash with the upload
+        cy.wait(2000);
+        // Wait for os-versions to be printed, that means the upload is done
+        cy.clickButton('Create');
+        // The new resource must be active
+        cy.contains('Active');
+      } else {
+        cy.get('.nav').contains('Advanced').click();
+        cy.get('.nav').contains('OS Version Channels').click();
+        cy.clickButton('Create');
+        cy.typeValue({label: 'Name', value: channelName});
+        cy.typeValue({label: 'Image registry path', value: upgradeChannelList});
+        cy.clickButton('Create');
+      }
     });
 
     it('Check OS Versions', () => {
@@ -65,6 +78,60 @@ describe('Upgrade tests', () => {
       cy.contains('Active dev', {timeout: 120000});
       cy.contains('Active stable');
       cy.contains('Active staging');
+    });
+
+    it('Upgrade one node (different methods if rke2 or k3s)', () => {
+      // K3s cluster upgraded with OS Image
+      // RKE2 cluster upgraded with OS version channel
+      cy.get('.nav').contains('Advanced').click();
+      cy.get('.nav').contains('Update Groups').click();
+      cy.clickButton('Create');
+      cy.get('.primaryheader').contains('Update Group: Create');
+      cy.typeValue({label: 'Name', value: 'upgrade'});
+      cy.contains('Target Cluster').click();
+      cy.contains(clusterName).click();
+      // TODO: REMOVE FIRST 'IF' BLOCK AFTER NEXT STABLE VERSION (> 1.0.0)
+      // Following 'if' code will be removed once we get a new stable version
+      if (elementalUIVersion == '1.0.0') {
+        cy.typeValue({label: 'OS Image', value: upgradeImage});
+      } else {
+          if (checkK3s.test(k8sVersion)) {
+            cy.contains('Use image from registry').click();
+            cy.typeValue({label: 'Image path', value: upgradeImage});
+          } else {
+            cy.contains('Use Managed OS version').click();
+            cy.get(':nth-child(4) > .labeled-select').contains('Managed OS version').click();
+            cy.contains('staging').click();
+          };
+      }; 
+      cy.clickButton('Create');
+      // Status changes a lot right after the creation so let's wait 10 secondes
+      // before checking
+      cy.wait(10000);
+      cy.get('[data-testid="sortable-cell-0-0"]').contains('Active');
+
+      // Workaround to avoid sporadic issue with Upgrade
+      // https://github.com/rancher/elemental/issues/410
+      // Restart fleet agent inside downstream cluster
+      topLevelMenu.openIfClosed();
+      cy.contains(clusterName).click();
+      cy.contains('Workload').click();
+      cy.contains('Pods').click();
+      cy.get('.header-buttons > :nth-child(2)').click();
+      cy.wait(20000);
+      cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=0{enter}');
+      cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=1{enter}');
+
+      // Check if the node reboots to apply the upgrade
+      topLevelMenu.openIfClosed();
+      elemental.accessElementalMenu();
+      cy.clickNavMenu(["Dashboard"]);
+      cy.clickButton('Manage Elemental Clusters');
+      cy.get('.title').contains('Clusters');
+      cy.contains(clusterName).click();
+      cy.get('.primaryheader').contains('Active');
+      cy.get('.primaryheader').contains('Updating', {timeout: 240000});
+      cy.get('.primaryheader').contains('Active', {timeout: 240000});
     });
 
     it('Delete OS Versions', () => {
@@ -83,46 +150,6 @@ describe('Upgrade tests', () => {
       cy.get('.nav').contains('Advanced').click();
       cy.get('.nav').contains('OS Versions').click();
       cy.contains('There are no rows to show');
-    });
-
-    it('Upgrade one node with OS Image Upgrades', () => {
-      // Create ManagedOSImage resource
-      cy.get('.nav').contains('Advanced').click();
-      cy.get('.nav').contains('Update Groups').click();
-      cy.clickButton('Create');
-      cy.get('.primaryheader').contains('Update Group: Create');
-      cy.typeValue({label: 'Name', value: 'upgrade'});
-      cy.contains('Target Cluster').click();
-      cy.contains('mycluster').click();
-      cy.typeValue({label: 'OS Image', value: upgrade_image});
-      cy.clickButton('Create');
-      // Status changes a lot right after the creation so let's wait 10 secondes
-      // before checking
-      cy.wait(10000);
-      cy.get('[data-testid="sortable-cell-0-0"]').contains('Active');
-
-      // Workaround to avoid sporadic issue with Upgrade
-      // https://github.com/rancher/elemental/issues/410
-      // Restart fleet agent inside downstream cluster
-      topLevelMenu.openIfClosed();
-      cy.contains('mycluster').click();
-      cy.contains('Workload').click();
-      cy.contains('Pods').click();
-      cy.get('.header-buttons > :nth-child(2)').click();
-      cy.wait(20000);
-      cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=0{enter}');
-      cy.get('.shell-body').type('kubectl scale deployment/fleet-agent -n cattle-fleet-system --replicas=1{enter}');
-
-      // Check if the node reboots to apply the upgrade
-      topLevelMenu.openIfClosed();
-      elemental.accessElementalMenu();
-      cy.clickNavMenu(["Dashboard"]);
-      cy.clickButton('Manage Elemental Clusters');
-      cy.get('.title').contains('Clusters');
-      cy.contains('mycluster').click();
-      cy.get('.primaryheader').contains('Active');
-      cy.get('.primaryheader').contains('Updating', {timeout: 240000});
-      cy.get('.primaryheader').contains('Active', {timeout: 240000});
     });
   });
 });


### PR DESCRIPTION
Fix #696 

- If test uses elemental-ui `1.0.0`, we cannot test upgrade with OS version channel, so we test upgrading with OS image only both for K3s and RKE2
![image](https://user-images.githubusercontent.com/6025636/222461735-3441d0dc-006f-449a-9cd8-86c1cd222032.png)


- If elemental-ui >` 1.0.0`, UI is different than before
  - OS image upgrade is tested if the cluster type is K3s, 
![image](https://user-images.githubusercontent.com/6025636/222461640-20aa3d29-2d43-4da9-835f-62cf4ffe8bcf.png)

  - Os version channel upgrade is tested if the cluster type is RKE2
![image](https://user-images.githubusercontent.com/6025636/222461546-98d9a80b-fc3c-4998-b952-553a936e3120.png)


Verification runs:
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4314521676/jobs/7527682726) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4314520729/jobs/7527682292) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Latest ](https://github.com/rancher/elemental/actions/runs/4314522401/jobs/7527684173) ❌ - not related to the PR (Rancher bug)
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4314523320/jobs/7527688154) :heavy_check_mark: 
