### PR TITLE
ci/e2e: fix emulated TPM

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -343,8 +343,11 @@ jobs:
 
           # Disable EMULATE_TPM in case of upgrade test
           # This is because we don't know the version in advance, so easier to not use it
-          [[ ${{ inputs.upgrade_image != '' }} || ${{ inputs.upgrade_os_channel != '' }} ]] \
-            && unset EMULATE_TPM
+          if ${{ inputs.upgrade_image != '' }}      || \
+             ${{ inputs.upgrade_os_channel != '' }} || \
+             ${{ contains(inputs.iso_to_test, '/Stable:/') }}; then
+            unset EMULATE_TPM
+          fi
 
           cd tests && make e2e-bootstrap-node
       - name: Upgrade node 1 to specified OS version with osImage

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -62,7 +62,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			misc.CopyFile(emulateTPMYaml, emulatedTmp)
 
 			// Patch the yaml file
-			err = tools.Sed("emulate-tpm:.*", "emulate-tpm: "+strconv.FormatBool(emulateTPM), emulatedTmp)
+			err = tools.Sed("%EMULATE_TPM%", strconv.FormatBool(emulateTPM), emulatedTmp)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// And apply it


### PR DESCRIPTION
Emulated TPM should be used if set to true.

We can see that Emulated TPM is not used in this [test](https://github.com/rancher/elemental/actions/runs/4338278640/jobs/7574869063) even if `EMULATE_TPM: true` is set:
```
STEP: Setting emulated TPM to false @ 03/05/23 22:26:08.494
```

Verification run (it fails for another issue):
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4345339110)