### PR TITLE
ci/ui: Test embedded hardware labels

### DIFF
--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -21,6 +21,9 @@ Cypress.config();
 describe('Machine inventory testing', () => {
   const elemental     = new Elemental();
   const elementalUser = "elemental-user"
+  const hwLabels      = ["TotalCPUThread", "TotalMemory", "CPUModel",
+                        "CPUVendor", "NumberBlockDevices", "NumberNetInterface",
+                        "CPUVendorTotalCPUCores"]
   const k8sVersion    = Cypress.env('k8s_version');
   const clusterName   = "mycluster"
   const proxy         = "http://172.17.0.1:3128"
@@ -44,11 +47,33 @@ describe('Machine inventory testing', () => {
       cy.clickNavMenu(["Inventory of Machines"]);
       cy.contains('.badge-state', 'Active')
         .should('exist');
+      cy.contains('.sortable-table', 'my-machine')
+        .should('exist');
       cy.contains('Namespace: fleet-default')
         .should('exist');
     });
-  });
 
+    it('Check we can see our embedded hardware labels', () => {
+      cy.clickNavMenu(["Inventory of Machines"]);
+      cy.contains('my-machine')
+        .click()
+      cy.checkMachInvLabel({machRegName: 'machine-registration',
+        labelName: 'myInvLabel1',
+        labelValue: 'myInvLabelValue1',
+        afterBoot: true});
+      for (var hwLabel in hwLabels) { 
+        cy.clickNavMenu(["Inventory of Machines"]);
+        cy.get('.table-options-group > .btn > .icon')
+          .click()
+          .parent()
+          .parent()
+          .contains(hwLabels[hwLabel])
+          .click({force: true})
+        cy.contains(hwLabels[hwLabel]);
+      }
+    });
+  });
+  
   filterTests(['main', 'upgrade'], () => {
     it('Create Elemental cluster', () => {
       cy.contains('Create Elemental Cluster')

--- a/tests/cypress/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_registration.spec.ts
@@ -48,7 +48,7 @@ describe('Machine registration testing', () => {
       };
     });
   });
-  
+
   filterTests(['main'], () => {
     it('Create machine registration with default options', () => {
       cy.createMachReg({machRegName: 'default-options-test'});

--- a/tests/cypress/fixtures/custom_cloud-config.yaml
+++ b/tests/cypress/fixtures/custom_cloud-config.yaml
@@ -8,3 +8,4 @@ config:
       poweroff: true
       device: /dev/sda
       debug: true
+machineName: my-machine

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -21,13 +21,13 @@ declare global {
       // Functions declared in functions.ts
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string,): Chainable<Element>;
       addMachInvAnnotation(annotationName: string, annotationValue: string):Chainable<Element>;
-      addMachInvLabel(labelName: string, labelValue: string):Chainable<Element>;
+      addMachInvLabel(labelName: string, labelValue: string, useHardwareLabels: boolean):Chainable<Element>;
       addMachRegAnnotation(annotationName: string, annotationValue: string):Chainable<Element>;
       addMachRegLabel(labelName: string, labelValue: string):Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       checkFilter(filterName: string, testFilterOne: boolean, testFilterTwo: boolean, shouldNotMatch: boolean): Chainable<Element>;
       checkMachInvAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;
-      checkMachInvLabel(machRegName: string, labelName: string, labelValue: string):Chainable<Element>;
+      checkMachInvLabel(machRegName: string, labelName: string, labelValue: string, useHardwareLabels: boolean, afterBoot: boolean):Chainable<Element>;
       checkMachRegAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;
       checkMachRegLabel(machRegName: string, labelName: string, labelValue: string):Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;


### PR DESCRIPTION
Fix #676 

We test two things in this new test:
- Add hardware labels in Machine Registration and make sure we can see them inside YAML
![image](https://user-images.githubusercontent.com/6025636/223376645-2fed514d-d066-4f04-aabb-9489022e500c.png)

- Check we can also see them in machine inventoy after booting a node

## Verification Runs
[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4346381195) :heavy_check_mark:
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4348068771) :heavy_check_mark: 
## Videos
Configure label and check inside Machine registration test (**from 8:13 to the end**):
https://user-images.githubusercontent.com/6025636/223232322-7e6932d1-f6e5-4c2e-8b83-a011f036ef59.mp4

Machine inventory check (**from 0:20 to 1:30**)
https://user-images.githubusercontent.com/6025636/223231675-6dd8ca0a-db69-497b-9361-ee3bb1f87073.mp4

