### PR TITLE
ci/e2e: multiple changes to improve scalability tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -323,11 +323,10 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
         run: cd tests && make e2e-configure-rancher
-      - name: Bootstrap node 1, 2 and 3 (use and ISO) in pool "master" (use Emulated TPM if possible)
+      - name: Bootstrap node 1, 2 and 3 (with iPXE) in pool "master" (use Emulated TPM if possible)
         if: inputs.test_type == 'cli'
         env:
           EMULATE_TPM: true
-          ISO_BOOT: true
           POOL: master
           VM_INDEX: 1
           VM_NUMBERS: 3
@@ -366,9 +365,10 @@ jobs:
           VM_INDEX: 2
           VM_NUMBERS: 3
         run: cd tests && make e2e-upgrade-node
-      - name: Bootstrap additional nodes (use iPXE) in pool "worker" (total of ${{ inputs.node_number }})
+      - name: Bootstrap additional nodes (with ISO) in pool "worker" (total of ${{ inputs.node_number }})
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
+          ISO_BOOT: true
           POOL: worker
           VM_INDEX: 4
           VM_NUMBERS: ${{ inputs.node_number }}


### PR DESCRIPTION
Multiple changes to improve scalability tests:
- Use LVM with striping I/O for local storage, this will improve I/O performance for bootstrapping nodes when multiples local SSDs are used (which is the case for highmem runner).
- Bootstrap additional nodes with ISO and use PXE to bootstrap the master ones.
- Wait a little bit before rebooting the nodes, this is to avoid starting all VMs at the same time.

Verification runs:
- [OBS-Stable-RKE2-E2E with 30 nodes](https://github.com/rancher/elemental/actions/runs/4365471173)
- [OBS-Stable-RKE2-E2E with 50 nodes](https://github.com/rancher/elemental/actions/runs/4375907053)

**NOTE:** VR with 50 nodes is failing because of issue #667, not related to this PR.