### PR TITLE
ci/ui: Workaround in delete machine reg test

### DIFF
--- a/tests/cypress/support/functions.ts
+++ b/tests/cypress/support/functions.ts
@@ -406,9 +406,17 @@ Cypress.Commands.add('editMachReg', ({
 Cypress.Commands.add('deleteMachReg', ({machRegName}) => {
   cy.contains('Registration Endpoint')
     .click();
+  /*  This code cannot be used anymore for now because of
+      https://github.com/rancher/elemental/issues/714
+      As it is not a blocker, we need to bypass it.
+      Instead of selecting resource to delete by name
+      we select all resources.
   cy.contains(machRegName)
     .parent()
     .parent()
+    .click();
+  */
+  cy.get('[width="30"] > .checkbox-outer-container')
     .click();
   cy.clickButton('Delete');
   cy.confirmDelete();


### PR DESCRIPTION
Fix #714 

Workaround for https://github.com/rancher/elemental/issues/714

* Delete all resources instead of selecting one by name
 

## Verification Run
 
https://github.com/rancher/elemental/actions/runs/4354615339
![image](https://user-images.githubusercontent.com/6025636/223444518-755f3afd-8a8b-44fc-bccf-9cb24288a88e.png)


## Local Cypress run
![image](https://user-images.githubusercontent.com/6025636/223440658-81d90ae7-b0cf-437c-bf09-43d8bd2e3da8.png)
