### PR TITLE
ci: add worflow to manually trigger a test

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -1,0 +1,60 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-OBS-Manual-Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      iso_to_test:
+        description: Defines the ISO to test
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+        type: string
+      k8s_version_to_provision:
+        description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
+        default: v1.24.8+k3s1
+        type: string
+      node_number:
+        description: Number of nodes (>3) to deploy on the provisioned cluster
+        default: 5
+        type: number
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
+      rancher_version:
+        description: Rancher Manager version to use for installation (fixed version or latest)
+        default: latest
+        type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        type: string
+      upgrade_operator:
+        description: URL to elemental-operator version to upgrade to
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+        type: string
+
+concurrency:
+  group: cli-obs-manual-workflow-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cluster_name: cluster-k3s
+      destroy_runner: ${{ inputs.destroy_runner }}
+      iso_to_test: ${ inputs.iso_to_test }}
+      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      node_number: ${{ inputs.node_number }}
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
+      upgrade_operator: ${{ inputs.upgrade_operator }}


### PR DESCRIPTION
This allows anyone to manually trigger a test on any version of Elemental ISO/operator/kubernetes client cluster.

Default is set to OBS-Dev on K3s.