### PR TITLE
ci: add some improvements/fixes

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -23,7 +23,7 @@ jobs:
       node_number: 3
       rancher_channel: latest
       rancher_version: devel
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       node_number: 3
       rancher_channel: stable
       rancher_version: latest
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -49,7 +49,7 @@ jobs:
       node_number: 3
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -30,7 +30,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v3
         type: string
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -24,7 +24,7 @@ jobs:
       node_number: 3
       rancher_channel: latest
       rancher_version: devel
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -24,7 +24,7 @@ jobs:
       node_number: 3
       rancher_channel: stable
       rancher_version: latest
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -50,7 +50,7 @@ jobs:
       node_number: 3
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v2
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v3
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -45,8 +37,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -45,8 +37,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -45,8 +37,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/e2e-rke2-obs-Dev.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -46,8 +38,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/e2e-rke2-obs-Stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -46,8 +38,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/e2e-rke2-obs-Staging.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      node_number:
-        description: Number of nodes (>3) to deploy on the provisioned cluster
-        default: 5
-        type: number
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -19,10 +15,6 @@ on:
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
         type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
@@ -46,8 +38,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      node_number: ${{ inputs.node_number }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -82,7 +82,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v3
         type: string
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -45,7 +45,7 @@ on:
         type: boolean
       elemental_support:
         description: URL of the elemental support binary
-        default: https://github.com/rancher/elemental-operator/releases/download/v1.0.0/elemental-support_1.0.0_linux_amd64
+        default: https://github.com/rancher/elemental-operator/releases/download/v1.1.4/elemental-support_1.1.4_linux_amd64
         type: string
       elemental_ui_version:
         description: Version of the elemental ui which will be installed

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -24,10 +24,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         type: string
@@ -50,6 +46,5 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -16,10 +16,6 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -44,7 +40,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -23,10 +23,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
@@ -49,6 +45,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -23,10 +23,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
@@ -49,6 +45,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -23,10 +23,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
@@ -49,6 +45,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -16,10 +16,6 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -44,7 +40,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -24,10 +24,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         type: string
@@ -50,6 +46,5 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -12,10 +12,6 @@ on:
         description: Version of the elemental ui which will be installed
         default: latest
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -41,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest'}}
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         type: string
@@ -47,6 +43,5 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
@@ -47,6 +43,5 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
@@ -47,6 +43,5 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
@@ -47,6 +43,5 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         type: string
@@ -50,6 +46,5 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -12,10 +12,6 @@ on:
         description: Version of the elemental ui which will be installed
         default: '1.0.0'
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -44,7 +40,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -24,10 +24,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
   schedule:
     - cron: '0 1 * * *'
 
@@ -48,7 +44,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -16,10 +16,6 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -42,7 +38,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -24,10 +24,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
   schedule:
     - cron: '0 1 * * *'
 
@@ -48,7 +44,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -16,10 +16,6 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -42,7 +38,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -28,10 +28,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
@@ -58,7 +54,6 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
   schedule:
     - cron: '0 1 * * *'
 
@@ -45,7 +41,6 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -12,10 +12,6 @@ on:
         description: Version of the elemental ui which will be installed
         default: latest
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -39,7 +35,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'latest' }}
+      rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -12,10 +12,6 @@ on:
         description: Version of the elemental ui which will be installed
         default: '1.0.0'
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -42,7 +38,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
-      rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
+      rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -20,10 +20,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
   schedule:
     - cron: '0 1 * * *'
 
@@ -48,7 +44,6 @@ jobs:
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: ${{ inputs.rancher_channel || 'stable' }}
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
-      runner_template: ${{ inputs.runner_template || 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -28,10 +28,6 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v2
-        type: string
       upgrade_operator:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
@@ -59,7 +55,6 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest


### PR DESCRIPTION
- ci: bump GCP template runner version
- ci: bump elemental-support version
- ci/ui: fix Rancher channel in some tests
- ci/ui: use the default runner template
- ci/e2e: reduce number of inputs in OBS tests