### PR TITLE
ci/e2e: delay nodes boot to reduce CPU and I/O load

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -53,7 +53,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      cluster_name: cluster-k3s
+      cluster_name: my-own-cluster
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,14 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 export CLOUD_INIT_ISO?=$(ROOT_DIR)/build/ci.iso
 
+# Define Ginkgo timeout for the bootstrapping test
+GINKGO_TIMEOUT?=3600
+ifdef VM_NUMBERS
+	ifeq ($(shell expr $(VM_NUMBERS) \> 100), 1)
+		GINKGO_TIMEOUT=6000
+	endif
+endif
+
 clean:
 	VBoxManage controlvm "test" poweroff &>/dev/null || true
 	VBoxManage unregistervm "test" --delete &>/dev/null || true
@@ -64,7 +72,7 @@ e2e-configure-rancher: deps
 e2e-ui-rancher: deps
 	ginkgo --label-filter ui -r -v ./e2e
 e2e-bootstrap-node: deps
-	ginkgo --label-filter bootstrap -r -v ./e2e
+	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
 e2e-upgrade-node: deps
 	ginkgo --label-filter upgrade -r -v ./e2e
 start-cypress-tests:

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -37,6 +37,7 @@ const (
 	installVMScript       = "../scripts/install-vm"
 	localKubeconfigYaml   = "../assets/local-kubeconfig-skel.yaml"
 	netDefaultFileName    = "../assets/net-default.xml"
+	numberOfNodesMax      = 30
 	osListYaml            = "../assets/managedOSVersionChannel.yaml"
 	registrationYaml      = "../assets/machineRegistration.yaml"
 	selectorYaml          = "../assets/selector.yaml"

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -75,28 +75,27 @@ else
   INSTALL_FLAG+=" --pxe"
 fi
 
-# Wait randomly until 20s to avoid running virt-install at the same time
-# Because it can lead to some issues with hugepages
-sleep $((RANDOM % 20))
+# VM variables
+LOG_FILE=logs/bootstrap_${VM_NAME}.log
+CMD="sudo virt-install \
+       --name ${VM_NAME} \
+       --os-variant opensuse-unknown \
+       --virt-type kvm \
+       --machine q35 \
+       --boot loader=${FW_CODE},loader.readonly=yes,loader.secure=yes,loader.type=pflash,nvram.template=${FW_VARS} \
+       --features smm.state=yes \
+       --vcpus 2 \
+       --cpu host \
+       --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=35 \
+       --check disk_size=off \
+       --graphics none \
+       --serial pty \
+       --console pty,target_type=virtio \
+       --rng random \
+       --tpm ${EMULATED_TPM} \
+       --noreboot \
+       --network network=default,bridge=virbr0,model=virtio,mac=${MAC} \
+       ${INSTALL_FLAG}"
 
 # Create VM
-script -e -O logs/bootstrap_${VM_NAME}.log \
-  -c "sudo virt-install \
-  --name ${VM_NAME} \
-  --os-variant opensuse-unknown \
-  --virt-type kvm \
-  --machine q35 \
-  --boot loader=${FW_CODE},loader.readonly=yes,loader.secure=yes,loader.type=pflash,nvram.template=${FW_VARS} \
-  --features smm.state=yes \
-  --vcpus 2 \
-  --cpu host \
-  --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=35 \
-  --check disk_size=off \
-  --graphics none \
-  --serial pty \
-  --console pty,target_type=virtio \
-  --rng random \
-  --tpm ${EMULATED_TPM} \
-  --noreboot \
-  --network network=default,bridge=virbr0,model=virtio,mac=${MAC} \
-  ${INSTALL_FLAG}"
+script -E never -e -f -q -O ${LOG_FILE} -c "${CMD}" >/dev/null 2>&1


### PR DESCRIPTION
This fix #734.

Verification runs:
- [CLI-OBS-Manual-Workflow  with 50 nodes](https://github.com/rancher/elemental/actions/runs/4429384060)
- [CLI-OBS-Manual-Workflow  with 100 nodes](https://github.com/rancher/elemental/actions/runs/4430742731)
- [CLI-OBS-Manual-Workflow  with 80 nodes](https://github.com/rancher/elemental/actions/runs/4437077202/) 
- [CLI-OBS-Manual-Workflow  with 160 nodes](https://github.com/rancher/elemental/actions/runs/4439953126)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4446071247)
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4446108604)
- [K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4446121424)

Latest VRs after creating `waitNodesBoot` function:
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4446455404)
- [CLI-OBS-Manual-Workflow ](https://github.com/rancher/elemental/actions/runs/4446473761)

**Note:** I hit issue #732 in most of the VR, but I was able to locally workaround it by rebooting the impacted nodes.