### PR TITLE
ci/ui: increase timeout when checking cluster

### DIFF
--- a/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/e2e/unit_tests/machine_inventory.spec.ts
@@ -113,7 +113,7 @@ describe('Machine inventory testing', () => {
           .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
       }
       cy.clickButton('Create');
-      cy.contains('Updating ' + clusterName, {timeout: 20000});
+      cy.contains('Updating ' + clusterName, {timeout: 120000});
       cy.contains('Active ' + clusterName, {timeout: 360000});
     });
   });


### PR DESCRIPTION
With latest rancher manager `2.7.2-rc6`, there is something different regarding cluster status  when you create a cluster.
Looks like the status before `Updating` (`Reconciling` / `Provisioning`) are longer.
Actually, we do not want to test each status, we want an `Active` cluster after all.

## Verification runs
[K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4424444178/jobs/7758829555)
[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4424697891/jobs/7758851825)