### PR TITLE
Do not expand COS_PERSISTENT by default

### DIFF
--- a/framework/files/etc/cos/bootargs.cfg
+++ b/framework/files/etc/cos/bootargs.cfg
@@ -1,7 +1,7 @@
 set kernel=/boot/vmlinuz
-if [ ${label} == ${system_label} ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label cos-img/filename=$img rd.neednet=0 rd.cos.oemlabel=$oem_label"
+if [ "${img}" == "/cOS/recovery.img" ]; then
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label cos-img/filename=$img rd.neednet=0 rd.cos.oemlabel=$oem_label rd.cos.mount=LABEL=$oem_label:/oem"
 else
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label cos-img/filename=$img panic=5 rd.neednet=0 rd.cos.oemlabel=$oem_label fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label cos-img/filename=$img panic=5 rd.neednet=0 rd.cos.oemlabel=$oem_label fsck.mode=force fsck.repair=yes rd.cos.mount=LABEL=$oem_label:/oem rd.cos.mount=LABEL=$persistent_label:/usr/local"
 fi
 set initramfs=/boot/initrd

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -28,7 +28,6 @@ stages:
       name: "Layout configuration"
       environment_file: /run/cos/cos-layout.env
       environment:
-        VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv"
         PERSISTENT_STATE_PATHS: >-
@@ -55,13 +54,4 @@ stages:
       name: "Layout configuration"
       environment_file: /run/cos/cos-layout.env
       environment:
-        VOLUMES: "LABEL=COS_OEM:/oem"
         OVERLAY: "tmpfs:25%"
-  rootfs.after:
-    - if: '[ ! -f /run/cos/recovery_mode ] && [ ! -f /run/cos/live_mode ]'
-      name: "Grow persistent"
-      layout:
-        device:
-          label: COS_PERSISTENT
-        expand_partition:
-          size: 0


### PR DESCRIPTION
This commit drops the expansion cloud-init step for COS_PERSISTENT partition. The installation already uses all available size by default there is not need to attempt a resize on every boot.

In addition this commit also updates the persistent volumes configuration to be aligned with the latest elemental-toolkit changes. Now volumes are set as part of the kernel arguments at boot and not as part of the cloud-init setup. This prevents including filesystem label literals within the immutable OS.

Related to #732