### PR TITLE
ui/ci: increase timeout when creating RKE2 cluster

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -117,7 +117,7 @@ describe('Machine inventory testing', () => {
       }
       cy.clickButton('Create');
       cy.contains('Updating ' + clusterName, {timeout: 120000});
-      cy.contains('Active ' + clusterName, {timeout: 360000});
+      cy.contains('Active ' + clusterName, {timeout: 480000});
     });
   });
   

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -153,7 +153,7 @@ describe('Upgrade tests', () => {
       cy.get('.primaryheader')
         .contains('Updating', {timeout: 240000});
       cy.get('.primaryheader')
-        .contains('Active', {timeout: 240000});
+        .contains('Active', {timeout: 360000});
     });
 
     it('Delete OS Versions', () => {


### PR DESCRIPTION
Fix #741 

## Verification runs
[RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4446200296) :heavy_check_mark: 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4446179234) :heavy_check_mark: 