### PR TITLE
ci: bump k3s to v1.24.11+k3s1

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -7,6 +7,7 @@ name: CLI-K3s-OS-Upgrade-Rancher_Latest
 on:
   schedule:
     - cron: '0 2 * * *'
+  pull_request:
 
 jobs:
   k3s:
@@ -18,7 +19,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: latest

--- a/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
@@ -18,7 +18,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       rancher_channel: latest
       rancher_version: devel
       sequential: true

--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -7,6 +7,7 @@ name: K3s-E2E-Latest_RM
 on:
   schedule:
     - cron: '0 1 * * *'
+  pull_request:
 
 jobs:
   k3s:
@@ -17,6 +18,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       rancher_channel: latest
       rancher_version: devel

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -168,7 +168,7 @@ jobs:
       CLUSTER_TYPE: ${{ inputs.cluster_type }}
       # For K3s installation used to host Rancher Manager
       INSTALL_K3S_EXEC: ${{ inputs.k3s_flags }}
-      INSTALL_K3S_VERSION: v1.24.7+k3s1
+      INSTALL_K3S_VERSION: v1.24.11+k3s1
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
       # For Rancher Manager

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -38,7 +38,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}


### PR DESCRIPTION
Will fix https://github.com/rancher/rancher/issues/40679

## Verification runs:
### UI
[UI-K3s-OS-Upgrade-Rancher_Latest ](https://github.com/rancher/elemental/actions/runs/4446398743) :heavy_check_mark: 
[K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4448136663) ❌ (not related to k3s, elemental-ui was bumped in the same time (1.2.0)

### CLI
[CLI-K3s-Sequential-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4448114226) :heavy_check_mark: 
[CLI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4448112985) :heavy_check_mark: 
[K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4448112991l) :heavy_check_mark: 
