### PR TITLE
ci: debug hardened cluster issue

### DIFF
--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -173,6 +173,8 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 				_ = exec.Command("sudo", "virsh", c, "default").Run()
 			}
 
+			// Wait a bit between virsh commands
+			time.Sleep(1 * time.Minute)
 			err := exec.Command("sudo", "virsh", "net-create", netDefaultFileName).Run()
 			Expect(err).To(Not(HaveOccurred()))
 		})


### PR DESCRIPTION
Hardened cluster test fails since 5 days in a row.
https://github.com/rancher/elemental/actions/runs/4464004969/jobs/7839756974
`  In [It] at: /home/gh-runner/actions-runner/_work/elemental/elemental/tests/e2e/configure_test.go:177 @ 03/20/23 02:19:26.06`
It looks like an issue with network creation, I need to manually trigger the test and figure out what happens there.

## Solution
Add wait between virsh commands.

## Verifcation run
1- https://github.com/rancher/elemental/actions/runs/4470203781/jobs/7853419414?pr=748 :heavy_check_mark: 
2- https://github.com/rancher/elemental/actions/runs/4470203781/jobs/7855078487 :heavy_check_mark: 
3- https://github.com/rancher/elemental/actions/runs/4470203781/jobs/7855595677 :heavy_check_mark: 
4- https://github.com/rancher/elemental/actions/runs/4470203781/jobs/7857732128 :heavy_check_mark: 
5- https://github.com/rancher/elemental/actions/runs/4470203781/jobs/7858188007 :heavy_check_mark: 