### PR TITLE
ci: Improve tests on hardened cluster

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s-hard-E2E-Stable_RM
+name: CLI-K3s-Hardened-Rancher_Latest
 
 on:
   schedule:
@@ -26,5 +26,7 @@ jobs:
         --kube-apiserver-arg=--service-account-lookup=true 
         --kubelet-arg=make-iptables-util-chains=true 
         --kube-apiserver-arg=--anonymous-auth=false"
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.24.11+k3s1
       node_number: 3
+      rancher_channel: latest
+      rancher_version: devel

--- a/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
@@ -1,0 +1,30 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-K3s-Hardened-Rancher_Stable
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  k3s:
+    uses: ./.github/workflows/master-e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      cert-manager_version: v1.9.2
+      cluster_name: cluster-k3s
+      cluster_type: hardened
+      k3s_flags: "--protect-kernel-defaults 
+        --kube-apiserver-arg=--enable-admission-plugins=NodeRestriction,PodSecurityPolicy,NamespaceLifecycle,ServiceAccount 
+        --kube-apiserver-arg=--audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log 
+        --kube-apiserver-arg=--audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml 
+        --kube-apiserver-arg=--audit-log-maxage=30 
+        --kube-apiserver-arg=--audit-log-maxbackup=10 
+        --kube-apiserver-arg=--audit-log-maxsize=100 
+        --kube-apiserver-arg=--request-timeout=300s 
+        --kube-apiserver-arg=--service-account-lookup=true 
+        --kubelet-arg=make-iptables-util-chains=true 
+        --kube-apiserver-arg=--anonymous-auth=false"
+      k8s_version_to_provision: v1.24.8+k3s1
+      node_number: 3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ CI with latest stable Rancher Manager:
 [![CLI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_stable.yaml)
 [![CLI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml)
 
+[![CLI-K3s-Hardened-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml)
+
 [![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
 [![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
 
@@ -26,6 +28,8 @@ CI with latest devel Rancher Manager:
 
 [![CLI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-os-upgrade-rancher_latest.yaml)
 [![CLI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml)
+
+[![CLI-K3s-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml)
 
 [![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
 [![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)


### PR DESCRIPTION
- Test hardened cluster with latest Rancher Manager (this case was missing)
- Add status badges in the README

## Verification run:
[CLI-K3s-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4479456183) :heavy_check_mark: 