### PR TITLE
ci/ui: test ISO building feature

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -54,6 +54,9 @@ on:
       iso_to_test:
         description: ISO to test (default built one is empty)
         type: string
+      iso_boot:
+        description: Choose booting from ISO
+        type: boolean
       k3s_flags:
         description: Argument to configure INSTALL_K3S_EXEC env variable 
         type: string
@@ -243,6 +246,7 @@ jobs:
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
+          ISO_BOOT: ${{ inputs.iso_boot }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
@@ -274,6 +278,7 @@ jobs:
       - name: Deploy a node to join Rancher manager
         if: inputs.test_type == 'ui'
         env:
+          ISO_BOOT: ${{ inputs.iso_boot }} 
           VM_INDEX: 1
           HOST_MEMORY_RESERVED: 50331648
         run: |

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -1,5 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-K3s-OS-Upgrade-Rancher_Latest
+# We test upgrade with: 
+# - Iso stable to dev
+# - Elemental-operator dev
+#
+# Main reason of dev operator is to test ISO building.
+# Later it will be moved to main scenario when we will be able to choose the ISO
+# because for now, we can only build ISO with stable ISO
 
 on:
   workflow_dispatch:
@@ -35,7 +42,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_boot: true
       k8s_version_to_provision: v1.24.11+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'
@@ -43,4 +50,3 @@ jobs:
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -1,6 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-RKE2-OS-Upgrade-Rancher_Latest
-
+# We test upgrade with: 
+# - Iso stable to dev
+# - Elemental-operator dev
+#
+# Main reason of dev operator is to test ISO building.
+# Later it will be moved to main scenario when we will be able to choose the ISO
+# because for now, we can only build ISO with stable ISO
 on:
   workflow_dispatch:
     inputs:
@@ -33,11 +39,10 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_boot: true
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_operator: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -143,15 +143,31 @@ describe('Machine registration testing', () => {
         .click();
       cy.verifyDownload('download-yaml-test.yaml');
     });
-  });
 
   // This test must stay the last one because we use this machine registration when we test adding a node.
   // It also tests using a custom cloud config by using read from file button.
-  filterTests(['main', 'upgrade'], () => {
     it('Create Machine registration we will use to test adding a node', () => {
       cy.createMachReg({machRegName: 'machine-registration',
         checkInventoryLabels: true,
         checkInventoryAnnotations: true,
+        customCloudConfig: 'custom_cloud-config.yaml',
+        checkDefaultCloudConfig: false});
+      cy.checkMachInvLabel({machRegName: 'machine-registration',
+        labelName: 'myInvLabel1',
+        labelValue: 'myInvLabelValue1'});
+    });
+  });
+
+  // In the upgrade test we test the ISO building feature 
+  // and boot from the stable ISO, mainly because we can
+  // only select stable ISO for now.
+  // We will move the test to the standard scenario later
+  filterTests(['upgrade'], () => {
+    it('Create Machine registration we will use to test adding a node', () => {
+      cy.createMachReg({machRegName: 'machine-registration',
+        checkInventoryLabels: true,
+        checkInventoryAnnotations: true,
+        checkIsoBuilding: true,
         customCloudConfig: 'custom_cloud-config.yaml',
         checkDefaultCloudConfig: false});
       cy.checkMachInvLabel({machRegName: 'machine-registration',

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -35,7 +35,8 @@ declare global {
       clickElementalMenu(label: string,): Chainable<Element>;
       clickNavMenu(listLabel: string[],): Chainable<Element>;
       confirmDelete(): Chainable<Element>;
-      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, customCloudConfig?: string, checkDefaultCloudConfig?: boolean): Chainable<Element>;
+      createMachReg(machRegName: string, namespace?: string, checkLabels?: boolean, checkAnnotations?: boolean, checkIsoBuilding?: boolean,
+        customCloudConfig?: string, checkDefaultCloudConfig?: boolean): Chainable<Element>;
       deleteAllResources():Chainable<Element>;
       deleteMachReg(machRegName: string): Chainable<Element>;
       editMachReg(machRegName: string, addLabel?: boolean, addAnnotation?: boolean, withYAML?: boolean): Chainable<Element>;

--- a/tests/cypress/latest/support/functions.ts
+++ b/tests/cypress/latest/support/functions.ts
@@ -198,6 +198,7 @@ Cypress.Commands.add('createMachReg', ({
   checkAnnotations=false,
   checkInventoryLabels=false,
   checkInventoryAnnotations=false,
+  checkIsoBuilding=false,
   customCloudConfig='',
   checkDefaultCloudConfig=true }) => {
     cy.clickNavMenu(["Dashboard"]);
@@ -255,6 +256,27 @@ Cypress.Commands.add('createMachReg', ({
     cy.verifyDownload(machRegName + '_registrationURL.yaml');
     cy.contains('Saving')
       .should('not.exist');
+
+    // Test ISO building feature
+    if (checkIsoBuilding) {
+      cy.getBySel('select-os-version-build-iso')
+        .contains('Elemental Teal');
+      cy.getBySel('build-iso-btn')
+        .click();
+      cy.getBySel('build-iso-btn')
+        .get('.icon-spin');
+      // Download button is disabled while ISO is building
+      cy.getBySel('download-iso-btn').should(($input) => {
+        expect($input).to.have.attr('disabled')
+      })
+      // Download button is enabled once ISO building done
+      cy.getBySel('download-iso-btn', { timeout: 180000 }).should(($input) => {
+        expect($input).to.not.have.attr('disabled')
+      })
+      cy.getBySel('download-iso-btn')
+        .click()
+      cy.verifyDownload('elemental.iso', { timeout: 180000, interval: 5000 });
+    }
   
       // Check Cloud configuration
     // TODO: Maybe the check may be improved in one line

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -55,11 +55,13 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		By("Configuring iPXE boot script for network installation", func() {
-			numberOfFile, err := misc.ConfigureiPXE()
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(numberOfFile).To(BeNumerically(">=", 1))
-		})
+		if isoBoot != "true" {
+			By("Configuring iPXE boot script for network installation", func() {
+				numberOfFile, err := misc.ConfigureiPXE()
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(numberOfFile).To(BeNumerically(">=", 1))
+			})
+		}
 
 		By("Adding VM in default network", func() {
 			// Add node in network configuration if needed

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -31,9 +31,12 @@ docker run -v $PWD:/workdir -w /workdir                     \
     $CYPRESS_DOCKER                                         \
     -s $SPEC
 
-pwd
 popd
-pwd
+
+# Move elemental.iso into the expected folder
+if [[ ${ISO_BOOT} == "true" ]]; then
+    sudo mv cypress/$ELEMENTAL_UI_VERSION/downloads/elemental.iso ../elemental-from-cypress.iso
+fi
 
 # Kill the HTTP server
 pkill -f "${HTTP_SRV_CMD}"


### PR DESCRIPTION
Fix #578 

At the time of writing, we can only build an ISO based on the stable ISO, that means the best place to test it is in the upgrade test before in that one, we start from STABLE ISO and upgrade to DEV ISO.

Later on, when we will be able to select building from DEV ISO, the test could be moved to the main scenario.

## Verification run
- [UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4515878010)
it booted perfectly with ISO built in the UI:
```
  + ln -s /home/gh-runner/actions-runner/_work/elemental/elemental/elemental-from-cypress.iso node-001/
  + INSTALL_FLAG+=' --cdrom node-001/elemental-from-cypress.iso'
```

- [UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4519482195)
Same comment as above.

Check if it does not break tests which are not booting via ISO
- [K3s-UI_E2E-Latest_RM]([K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4529758712)) ✔️  