### PR TITLE
ci/e2e: add operator uninstall test

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -397,6 +397,10 @@ jobs:
       - name: List installed nodes
         if: inputs.test_type == 'cli'
         run: sudo virsh list
+      - name: Uninstall Elemental Operator
+        # Don't test Operator uninstall if we want to keep the runner for debugging purposes
+        if: inputs.destroy_runner == true && inputs.test_type == 'cli'
+        run: cd tests && make e2e-uninstall-operator
       - name: Store logs
         if: always()
         env:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -65,17 +65,19 @@ generate-readme:
 	@./scripts/generate-readme > README.md
 
 # E2E tests
-e2e-install-rancher: deps
-	ginkgo --label-filter install -r -v ./e2e
-e2e-configure-rancher: deps
-	ginkgo --label-filter configure -r -v ./e2e
-e2e-ui-rancher: deps
-	ginkgo --label-filter ui -r -v ./e2e
 e2e-bootstrap-node: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
+e2e-configure-rancher: deps
+	ginkgo --label-filter configure -r -v ./e2e
+e2e-get-logs: deps
+	ginkgo --label-filter logs -r -v ./e2e
+e2e-install-rancher: deps
+	ginkgo --label-filter install -r -v ./e2e
+e2e-ui-rancher: deps
+	ginkgo --label-filter ui -r -v ./e2e
+e2e-uninstall-operator:
+	ginkgo --label-filter uninstall-operator -r -v ./e2e
 e2e-upgrade-node: deps
 	ginkgo --label-filter upgrade -r -v ./e2e
 start-cypress-tests:
 	@./scripts/start-cypress-tests
-e2e-get-logs: deps
-	ginkgo --label-filter logs -r -v ./e2e

--- a/tests/assets/dumb_machineRegistration.yaml
+++ b/tests/assets/dumb_machineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: dumb-machine-registration
+  # The namespace must match the namespace of the cluster
+  # assigned to the clusters.provisioning.cattle.io resource
+  # namespace: fleet-default
+spec:
+  # Labels to be added to the created MachineInventory object
+  machineInventoryLabels:
+    dumb-label: dumb-value
+  # Annotations to be added to the created MachineInventory object
+  machineInventoryAnnotations: {}
+  # The config that will be used to provision the node
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: dumb-password
+    elemental:
+      install:
+        device: /dev/dumb-device

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -267,6 +267,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			err = tools.Sed("%RANCHER_CA%", rancherCA, localKubeconfig)
 			Expect(err).To(Not(HaveOccurred()))
 
+			// Set correct file permissions
+			_ = exec.Command("chmod", "0600", localKubeconfig).Run()
+
 			// Remove the "old" kubeconfig file to force the use of the new one
 			// NOTE: in fact move it, just to keep it in case of issue
 			// Also don't check the returned error, as it will always not equal 0

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -32,6 +32,7 @@ const (
 	emulateTPMYaml        = "../assets/emulateTPM.yaml"
 	ciTokenYaml           = "../assets/local-kubeconfig-token-skel.yaml"
 	configPrivateCAScript = "../scripts/config-private-ca"
+	dumbRegistrationYaml  = "../assets/dumb_machineRegistration.yaml"
 	installConfigYaml     = "../../install-config.yaml"
 	installHardenedScript = "../scripts/config-hardened"
 	installVMScript       = "../scripts/install-vm"

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher/elemental/tests/e2e/helpers/misc"
+)
+
+func testClusterAvailability(ns, cluster string) {
+	Eventually(func() string {
+		out, _ := kubectl.Run("get", "cluster",
+			"--namespace", ns, cluster,
+			"-o", "jsonpath={.metadata.name}")
+		return out
+	}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(Equal(clusterName))
+}
+
+var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator"), func() {
+	// Create kubectl context
+	// Default timeout is too small, so New() cannot be used
+	k := &kubectl.Kubectl{
+		Namespace:    "",
+		PollTimeout:  misc.SetTimeout(300 * time.Second),
+		PollInterval: 500 * time.Millisecond,
+	}
+
+	It("Uninstall Elemental Operator", func() {
+		By("Testing cluster resource availability BEFORE operator uninstallation", func() {
+			testClusterAvailability(clusterNS, clusterName)
+		})
+
+		By("Uninstalling Operator via Helm", func() {
+			err := kubectl.RunHelmBinaryWithCustomErr(
+				"uninstall", "elemental-operator",
+				"--namespace", "cattle-elemental-system",
+			)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Testing cluster resource availability AFTER operator uninstallation", func() {
+			testClusterAvailability(clusterNS, clusterName)
+		})
+
+		By("Checking that Elemental resources are gone", func() {
+			Eventually(func() string {
+				out, _ := kubectl.Run("get", "MachineInventorySelectorTemplate",
+					"--namespace", clusterNS,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				return out
+			}, misc.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("NotFound"))
+		})
+
+		By("Deleting cluster resource", func() {
+			_, err := kubectl.Run("delete", "cluster",
+				"--namespace", clusterNS, clusterName)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Testing cluster resource unavailability", func() {
+			out, err := kubectl.Run("get", "cluster",
+				"--namespace", clusterNS, clusterName,
+				"-o", "jsonpath={.metadata.name}")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(ContainSubstring("NotFound"))
+		})
+	})
+
+	It("Re-install Elemental Operator", func() {
+		By("Installing Operator via Helm", func() {
+			operatorChart := "oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart"
+			err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator",
+				operatorChart,
+				"--namespace", "cattle-elemental-system",
+				"--create-namespace",
+			)
+			Expect(err).To(Not(HaveOccurred()))
+
+			k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Check elemental-operator image
+			operatorImage, err := misc.GetOperatorImage()
+			Expect(err).To(Not(HaveOccurred()))
+			GinkgoWriter.Printf("Operator Image:\n%s\n", operatorImage)
+		})
+
+		By("Creating a dumb MachineRegistration", func() {
+			err := kubectl.Apply(clusterNS, dumbRegistrationYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Creating cluster", func() {
+			// NOTE: we can re-use clusterYaml as it has already been configured correctly
+			err := kubectl.Apply(clusterNS, clusterYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Testing cluster resource availability", func() {
+			testClusterAvailability(clusterNS, clusterName)
+		})
+	})
+})


### PR DESCRIPTION
Check that Elemental Operator can be delete and reinstall after. Also check that non-elemental resources can still be deleted/created.

Should fix https://github.com/rancher/elemental-operator/issues/314.

Verification runs:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4499484550)
- [OBS-Dev-RKE-E2E](https://github.com/rancher/elemental/actions/runs/4499493942)
- [K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4499502065)