### PR TITLE
e2e/ui: Make sure we can bind a cluster to only one upgrade group at a time

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -56,6 +56,7 @@ describe('Upgrade tests', () => {
       cy.getBySel('form-save')
         .contains('Create')
         .click();
+      cy.wait(10000);
     });
 
     it('Check OS Versions', () => {
@@ -154,6 +155,18 @@ describe('Upgrade tests', () => {
         .contains('Updating', {timeout: 360000});
       cy.get('.primaryheader')
         .contains('Active', {timeout: 360000});
+    });
+
+    it('Cannot create two upgrade groups targeting the same cluster', () => {
+      cy.clickNavMenu(["Advanced", "Update Groups"]);
+      cy.getBySel('masthead-create')
+      .contains('Create')
+        .click();
+      cy.get('.primaryheader')
+        .contains('Update Group: Create');
+      cy.getBySel('cluster-target')
+        .click();
+      cy.contains('Sorry, no matching options');
     });
 
     it('Delete OS Versions', () => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -56,7 +56,11 @@ describe('Upgrade tests', () => {
       cy.getBySel('form-save')
         .contains('Create')
         .click();
-      cy.wait(10000);
+      // Status changes a lot right after the creation so let's wait 60 secondes
+      // before checking
+      cy.wait(60000);
+      cy.getBySel('sortable-cell-0-0')
+        .contains('Active');
     });
 
     it('Check OS Versions', () => {


### PR DESCRIPTION
Fix #737 

New test to make sure a cluster cannot be bound to two upgrade groups.

## Local test
![image](https://user-images.githubusercontent.com/6025636/227952578-3af6a765-e823-424b-ab01-35e2b4a3e39e.png)


## Verification runs
[UI-K3s-OS-Upgrade-Rancher_Latest ](https://github.com/rancher/elemental/actions/runs/4534063054 ):clock1: 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4534065565) :clock1: 