### PR TITLE
ci/e2e: fix Cluster structure

### DIFF
--- a/tests/e2e/helpers/misc/misc.go
+++ b/tests/e2e/helpers/misc/misc.go
@@ -63,21 +63,24 @@ type ClusterSpec struct {
 
 // RKEConfig has all RKE/K3s cluster information
 type RKEConfig struct {
-	Etcd                interface{}    `yaml:"etcd,omitempty"`
-	ChartValues         interface{}    `yaml:"chartValues"`
-	MachineGlobalConfig interface{}    `yaml:"machineGlobalConfig"`
-	MachinePools        []MachinePools `yaml:"machinePools"`
-	UpgradeStrategy     interface{}    `yaml:"upgradeStrategy,omitempty"`
+	Etcd                  interface{}            `yaml:"etcd,omitempty"`
+	ChartValues           map[string]interface{} `yaml:"chartValues,omitempty" wrangler:"nullable"`
+	MachineGlobalConfig   interface{}            `yaml:"machineGlobalConfig"`
+	MachinePools          []MachinePools         `yaml:"machinePools"`
+	MachineSelectorConfig interface{}            `yaml:"machineSelectorConfig"`
+	UpgradeStrategy       interface{}            `yaml:"upgradeStrategy,omitempty"`
+	Registries            interface{}            `yaml:"registries"`
 }
 
 // MachinePools has all pools information
 type MachinePools struct {
-	ControlPlaneRole bool             `yaml:"controlPlaneRole,omitempty"`
-	EtcdRole         bool             `yaml:"etcdRole,omitempty"`
-	MachineConfigRef MachineConfigRef `yaml:"machineConfigRef"`
-	Name             string           `yaml:"name"`
-	Quantity         int              `yaml:"quantity"`
-	WorkerRole       bool             `yaml:"workerRole,omitempty"`
+	ControlPlaneRole     bool             `yaml:"controlPlaneRole,omitempty"`
+	EtcdRole             bool             `yaml:"etcdRole,omitempty"`
+	MachineConfigRef     MachineConfigRef `yaml:"machineConfigRef"`
+	Name                 string           `yaml:"name"`
+	Quantity             int              `yaml:"quantity"`
+	UnhealthyNodeTimeout string           `yaml:"unhealthyNodeTimeout"`
+	WorkerRole           bool             `yaml:"workerRole,omitempty"`
 }
 
 // MachineConfigRef makes the link between the cluster, pool and the Elemental nodes


### PR DESCRIPTION
We need to add `protect-kernel-defaults` value to be able to install applications from the UI.

Verification runs:
- [OBS-Dev-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4568394875)
- [OBS-Dev-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4568392768)

I manually validated that I was able to install an application through the Rancher UI.