### PR TITLE
ci/e2e: fix sporadic kubectl version issue

### DIFF
--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -377,10 +377,14 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					defer GinkgoRecover()
 
 					By("Checking cluster version on "+h, func() {
-						// Show cluster version, could be useful for debugging purposes
-						version, err := client.RunSSH("kubectl version")
-						Expect(err).To(Not(HaveOccurred()))
-						GinkgoWriter.Printf("K8s version on %s:\n%s\n", h, version)
+						Eventually(func() error {
+							k8sVer, err := cl.RunSSH("kubectl version 2>/dev/null")
+							if strings.Contains(k8sVer, "Server Version:") {
+								// Show cluster version, could be useful for debugging purposes
+								GinkgoWriter.Printf("K8s version on %s:\n%s\n", h, k8sVer)
+							}
+							return err
+						}, misc.SetTimeout(1*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
 					})
 				}(hostName, client)
 			}


### PR DESCRIPTION
This should fix this [sporadic issue](https://github.com/rancher/elemental/actions/runs/4592090596/jobs/8110878318).

Verification runs:
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/4594685995) with K3s and sequential bootstrapping
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/4595302245) with RKE2 and parallel bootstrapping
- [K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4594918575)