### PR TITLE
ci/ui: test filtering with lower and upper case

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
@@ -38,13 +38,16 @@ filterTests(['main'], () => {
     });
   
     it('Create fake machine inventories', () => {
-      // TODO: Use loop?
-      cy.importMachineInventory({machineInventoryFile: 'machine_inventory_1.yaml',
-        machineInventoryName: 'test-filter-one'});
-      cy.importMachineInventory({machineInventoryFile: 'machine_inventory_2.yaml',
-        machineInventoryName: 'test-filter-two'});
-      cy.importMachineInventory({machineInventoryFile: 'machine_inventory_3.yaml',
-        machineInventoryName: 'shouldnotmatch'});
+      let machineInventoryMap = new Map([
+        ['machine_inventory_1', 'test-filter-one'],
+        ['machine_inventory_2', 'test-filter-two'],
+        ['machine_inventory_3', 'shouldnotmatch']
+      ]);
+
+      machineInventoryMap.forEach((value, key) => {
+        cy.importMachineInventory({machineInventoryFile: key +'.yaml',
+          machineInventoryName: value});
+      });
     });
   
     it('Two machine inventories should appear by filtering on test-filter', () => {
@@ -56,11 +59,14 @@ filterTests(['main'], () => {
     });
   
     it('One machine inventory should appear by filtering on test-filter-one', () => {
-      // Only test-filter-one should appear with test-filter-one as filter
-      cy.checkFilter({filterName: 'test-filter-one',
-        testFilterOne: true,
-        testFilterTwo: false,
-        shouldNotMatch: false});
+      // Only test-filter-one should appear with test-filter-one and Test-Filter_One as filter
+      // Checking with lower and upper case make sure we are not hitting https://github.com/rancher/elemental/issues/627
+      ['test-filter-one', 'Test-Filter-One'].forEach(filter => {
+        cy.checkFilter({filterName: filter,
+          testFilterOne: true,
+          testFilterTwo: false,
+          shouldNotMatch: false});
+      });
     });
   
     it('No machine inventory should appear by filtering on test-bad-filter', () => {

--- a/tests/cypress/latest/fixtures/machine_inventory_1.yaml
+++ b/tests/cypress/latest/fixtures/machine_inventory_1.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     myInvAnnotation1: myInvAnnotationValue1
   labels:
-    testfilter: test-filter-one
+    testfilter: Test-Filter-One
   name: test-filter-one
   namespace: fleet-default
 spec:


### PR DESCRIPTION
Fix #653 

Verification run: https://github.com/rancher/elemental/actions/runs/4627421933 :clock1: 

Regression test for https://github.com/rancher/elemental/issues/627

Now it tests with lowercase + lower/uppercase:

![image](https://user-images.githubusercontent.com/6025636/230310059-c34599aa-0c33-4143-b83d-d1170f9f55fa.png)
![image](https://user-images.githubusercontent.com/6025636/230332380-5b36466f-14f8-45e5-bf5f-10326d7e5984.png)

