### PR TITLE
ci/ui: adapt to rancher 2.7.2 (latest stable)

### DIFF
--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: 'latest'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,7 +37,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'stable'

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: 'latest'
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: 'latest'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -34,7 +34,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       elemental_ui_version:
         description: Version of the elemental ui which will be installed
-        default: '1.0.0'
+        default: 'latest'
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
@@ -35,7 +35,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || '1.0.0' }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.24.8+rke2r1
       rancher_channel: 'stable'

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -19,7 +19,6 @@ import filterTests from '~/support/filterTests.js';
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();
   describe('Install Elemental plugin', () => {
-    const elemental_ui_version = Cypress.env('elemental_ui_version');
     const topLevelMenu         = new TopLevelMenu();
   
     beforeEach(() => {
@@ -57,13 +56,6 @@ filterTests(['main', 'upgrade'], () => {
       cy.get('.plugin')
         .contains('Install')
         .click();
-      cy.contains('Install Extension elemental');
-      if (elemental_ui_version != 'latest') {
-        cy.get('.labeled-select')
-          .click();
-        cy.contains(elemental_ui_version)
-          .click();
-      }
       cy.clickButton('Install');
       cy.contains('Installing');
       cy.contains('Extensions changed - reload required', {timeout: 40000});

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -24,7 +24,6 @@ describe('Upgrade tests', () => {
   const clusterName        = "mycluster"
   const checkK3s: RegExp   = /k3s/
   const elemental          = new Elemental();
-  const elementalUIVersion = Cypress.env('elemental_ui_version')
   const elementalUser      = "elemental-user"
   const k8sVersion         = Cypress.env('k8s_version')
   const topLevelMenu       = new TopLevelMenu();
@@ -89,30 +88,24 @@ describe('Upgrade tests', () => {
         .click();
       cy.contains(clusterName)
         .click();
-      // TODO: REMOVE FIRST 'IF' BLOCK AFTER NEXT STABLE VERSION (> 1.0.0)
-      // Following 'if' code will be removed once we get a new stable version
-      if (elementalUIVersion == '1.0.0') {
-        cy.typeValue({label: 'OS Image', value: upgradeImage});
+      if (!checkK3s.test(k8sVersion)) {
+        cy.getBySel('upgrade-choice-selector')
+          .parent()
+          .contains('Use image from registry')
+          .click();
+        cy.getBySel('os-image-box')
+          .type(upgradeImage)
       } else {
-        if (!checkK3s.test(k8sVersion)) {
-          cy.getBySel('upgrade-choice-selector')
-            .parent()
-            .contains('Use image from registry')
-            .click();
-          cy.getBySel('os-image-box')
-            .type(upgradeImage)
-        } else {
-          cy.getBySel('upgrade-choice-selector')
-            .parent()
-            .contains('Use Managed OS version')
-            .click();
-          cy.getBySel('os-version-box')
-            .click()
-          cy.getBySel('os-version-box')
-            .parents()
-            .contains('staging')
-            .click();
-        };
+        cy.getBySel('upgrade-choice-selector')
+          .parent()
+          .contains('Use Managed OS version')
+          .click();
+        cy.getBySel('os-version-box')
+          .click()
+        cy.getBySel('os-version-box')
+          .parents()
+          .contains('staging')
+          .click();
       };
       cy.getBySel('form-save')
       .contains('Create')

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -56,11 +56,7 @@ export class Elemental {
 
   // Make sure Elemental logo appears
   elementalIcon() {
-    // TODO: REMOVE 'IF' BLOCK AFTER NEXT STABLE VERSION (> 1.0.0)
-    if (Cypress.env('elemental_ui_version') != '1.0.0') {
-      return cy.get('.option .icon.group-icon.icon-elemental');
-    }
-    return cy.get('.option .icon.group-icon.icon-os-management');
+    return cy.get('.option .icon.group-icon.icon-elemental');
   } 
   
   // Handle first login in Rancher


### PR DESCRIPTION
Fix #782 

## Verification runs
[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4676694270) :heavy_check_mark: 
[RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4676710824) :heavy_check_mark: 

[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4676712327) ❌
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4676713448) ❌
Upgrade tests don't work but that's expected because operator stable is still the old one, so it is not compatible with `RM 2.7.2` and `elemental-ui 1.2`. There will pass once next stable released.

`elemental_ui_version` variable will be completely removed later, when we will remove the `cypress/1.0.0` folder.