### PR TITLE
ci/e2e: split backup/restore test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -68,13 +68,14 @@ generate-readme:
 e2e-bootstrap-node: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
 e2e-backup-restore: deps
-	ginkgo --label-filter backup-restore -r -v ./e2e
+	ginkgo --label-filter test-backup-restore -r -v ./e2e
 e2e-configure-rancher: deps
 	ginkgo --label-filter configure -r -v ./e2e
 e2e-get-logs: deps
 	ginkgo --label-filter logs -r -v ./e2e
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e
+	ginkgo --label-filter install-backup-restore -r -v ./e2e
 e2e-ui-rancher: deps
 	ginkgo --label-filter ui -r -v ./e2e
 e2e-uninstall-operator:

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rancher/elemental/tests/e2e/helpers/misc"
 )
 
-var _ = Describe("E2E - Test Backup/Restore", Label("backup-restore"), func() {
+var _ = Describe("E2E - Install Backup/Restore Operator", Label("install-backup-restore"), func() {
 	// Create kubectl context
 	// Default timeout is too small, so New() cannot be used
 	k := &kubectl.Kubectl{
@@ -33,10 +33,6 @@ var _ = Describe("E2E - Test Backup/Restore", Label("backup-restore"), func() {
 		PollTimeout:  misc.SetTimeout(300 * time.Second),
 		PollInterval: 500 * time.Millisecond,
 	}
-
-	// Variable(s)
-	backupResourceName := "elemental-backup"
-	restoreResourceName := "elemental-restore"
 
 	It("Install Backup/Restore Operator", func() {
 		// Default chart
@@ -90,6 +86,12 @@ var _ = Describe("E2E - Test Backup/Restore", Label("backup-restore"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
+})
+
+var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func() {
+	// Variable(s)
+	backupResourceName := "elemental-backup"
+	restoreResourceName := "elemental-restore"
 
 	It("Do a backup", func() {
 		By("Adding a backup resource", func() {


### PR DESCRIPTION
Installation of backup/restore operator should be done right after Rancher Manager.

Verification run:
- [OBS-Stable-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4743442874)