### PR TITLE
ci: bump k8s to 1.25

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
@@ -28,7 +28,8 @@ jobs:
         --kube-apiserver-arg=--service-account-lookup=true 
         --kubelet-arg=make-iptables-util-chains=true 
         --kube-apiserver-arg=--anonymous-auth=false"
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       node_number: 3
       rancher_channel: latest
       rancher_version: devel
+      upstream_k3s_version: v1.24.11+k3s1

--- a/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
@@ -28,5 +28,6 @@ jobs:
         --kube-apiserver-arg=--service-account-lookup=true 
         --kubelet-arg=make-iptables-util-chains=true 
         --kube-apiserver-arg=--anonymous-auth=false"
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       node_number: 3
+      upstream_k3s_version: v1.24.11+k3s1

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -19,7 +19,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: latest

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -19,7 +19,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: stable

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -45,7 +45,7 @@ jobs:
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: latest
       rancher_version: devel
       sequential: true

--- a/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: stable
       rancher_version: latest
       sequential: true

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: string
       k8s_version_to_provision:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
-        default: v1.24.8+k3s1
+        default: v1.25.7+k3s1
         type: string
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -20,7 +20,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: latest

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -20,7 +20,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: stable

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -46,7 +46,7 @@ jobs:
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: latest
       rancher_version: devel
       sequential: true

--- a/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: stable
       rancher_version: latest
       sequential: true

--- a/.github/workflows/e2e-k3s-latest.yaml
+++ b/.github/workflows/e2e-k3s-latest.yaml
@@ -18,6 +18,6 @@ jobs:
     with:
       test_description: "CI - E2E CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: latest
       rancher_version: devel

--- a/.github/workflows/e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/e2e-k3s-obs-Dev.yaml
@@ -23,6 +23,9 @@ on:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
+      upstream_k3s_version:
+        description: Cluster upstream K3s version where to install Rancher
+        type: string
 
 concurrency:
   group: e2e-k3s-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -41,7 +44,8 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}
+      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/e2e-k3s-obs-Stable.yaml
@@ -23,6 +23,9 @@ on:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
         type: string
+      upstream_k3s_version:
+        description: Cluster upstream K3s version where to install Rancher
+        type: string
 
 concurrency:
   group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -41,7 +44,8 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}
+      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/e2e-k3s-obs-Staging.yaml
@@ -23,6 +23,9 @@ on:
         description: URL to elemental-operator version to upgrade to
         default: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
         type: string
+      upstream_k3s_version:
+        description: Cluster upstream K3s version where to install Rancher
+        type: string
 
 concurrency:
   group: e2e-k3s-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -41,7 +44,8 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}
+      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/e2e-k3s-stable.yaml
+++ b/.github/workflows/e2e-k3s-stable.yaml
@@ -20,6 +20,6 @@ jobs:
     with:
       test_description: "CI - E2E CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       start_condition: ${{ github.event.workflow_run.conclusion }}
       workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/e2e-rke2-latest.yaml
+++ b/.github/workflows/e2e-rke2-latest.yaml
@@ -19,6 +19,6 @@ jobs:
       test_description: "CI - E2E CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: latest
       rancher_version: devel

--- a/.github/workflows/e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/e2e-rke2-obs-Dev.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/e2e-rke2-obs-Stable.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/e2e-rke2-obs-Staging.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_operator: ${{ inputs.upgrade_operator }}

--- a/.github/workflows/e2e-rke2-stable.yaml
+++ b/.github/workflows/e2e-rke2-stable.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI - E2E CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       start_condition: ${{ github.event.workflow_run.conclusion }}
       workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -124,6 +124,10 @@ on:
       upgrade_type:
         description: Type of upgrade to use for the Elemental OS upgrade
         type: string
+      upstream_k3s_version:
+        description: Cluster upstream K3s version where to install Rancher
+        default: v1.25.7+k3s1
+        type: string
       workflow_download:
         description: build-ci workflow to use for artifacts
         default: build-ci.yaml
@@ -184,7 +188,7 @@ jobs:
       CLUSTER_TYPE: ${{ inputs.cluster_type }}
       # For K3s installation used to host Rancher Manager
       INSTALL_K3S_EXEC: ${{ inputs.k3s_flags }}
-      INSTALL_K3S_VERSION: v1.24.11+k3s1
+      INSTALL_K3S_VERSION: ${{ inputs.upstream_k3s_version }}
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
       # For Rancher Manager

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -39,7 +39,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -42,7 +42,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -42,7 +42,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -42,7 +42,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -39,7 +39,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}

--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -37,7 +37,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest'}}
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -41,7 +41,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -41,7 +41,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -41,7 +41,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -40,7 +40,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -43,7 +43,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_boot: true
-      k8s_version_to_provision: v1.24.11+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -50,7 +50,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.24.8+k3s1
+      k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -40,7 +40,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_boot: true
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -51,7 +51,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.24.8+rke2r1
+      k8s_version_to_provision: v1.25.7+rke2r1
       proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -156,6 +156,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				"--set", "extraEnv[1].name=CATTLE_BOOTSTRAP_PASSWORD",
 				"--set", "extraEnv[1].value=rancherpassword",
 				"--set", "replicas=1",
+				"--set", "global.cattle.psp.enabled=false",
 			}
 
 			// Set specified version if needed


### PR DESCRIPTION
Fix #795 

Bump k8s version for downstream cluster (K3s / RKE2)
I keep `v1.24.11+k3s1` for the hardened cluster test because it will involve more investigations/changes, let's do it in a separate PR.

[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4754787305) :heavy_check_mark: 
[RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4754791018) :heavy_check_mark: 

[K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4754794629) :heavy_check_mark: 
[RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/runs/4754692635) :heavy_check_mark: 

[OBS-Stable-K3s-E2E](https://github.com/rancher/elemental/actions/runs/4754775830) :heavy_check_mark: 
[OBS-Stable-RKE2-E2E](https://github.com/rancher/elemental/actions/runs/4754782641) :heavy_check_mark: 

[OBS-Stable-K3s-E2E-hardened](https://github.com/rancher/elemental/actions/runs/4755766633) :heavy_check_mark: 
