### PR TITLE
ci/ui: ability to install ui from official chart

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -51,8 +51,8 @@ on:
         default: https://github.com/rancher/elemental-operator/releases/download/v1.1.4/elemental-support_1.1.4_linux_amd64
         type: string
       elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
+        description: Version of the elemental ui which will be installed (dev/stable)
+        default: dev
         type: string
       iso_to_test:
         description: ISO to test (default built one is empty)
@@ -294,7 +294,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots-basics-${{ inputs.cluster_name }}
-          path: tests/cypress/${{ inputs.elemental_ui_version }}/screenshots
+          path: tests/cypress/latest/screenshots
           retention-days: 7
           if-no-files-found: ignore
       - name: Upload Cypress videos (Basics)
@@ -303,7 +303,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-videos-basics-${{ inputs.cluster_name }}
-          path: tests/cypress/${{ inputs.elemental_ui_version }}/videos
+          path: tests/cypress/latest/videos
           retention-days: 7
       - name: Deploy a node to join Rancher manager
         if: inputs.test_type == 'ui'
@@ -315,7 +315,7 @@ jobs:
           cd tests && (
             # Removing 'downloads' is needed to avoid this error during 'make':
             # 'pattern all: open .../elemental/tests/cypress/downloads: permission denied'
-            sudo rm -rf cypress/${{ inputs.elemental_ui_version }}/downloads
+            sudo rm -rf cypress/latest/downloads
 
             make e2e-ui-rancher
           )
@@ -349,7 +349,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots-advanced-${{ inputs.cluster_name }}
-          path: tests/cypress/${{ inputs.elemental_ui_version }}/screenshots
+          path: tests/cypress/latest/screenshots
           retention-days: 7
           if-no-files-found: ignore
       - name: Upload Cypress videos (Advanced)
@@ -358,7 +358,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-videos-advanced-${{ inputs.cluster_name }}
-          path: tests/cypress/${{ inputs.elemental_ui_version }}/videos
+          path: tests/cypress/latest/videos
           retention-days: 7
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
@@ -458,7 +458,7 @@ jobs:
           cd tests && (
             # Removing 'downloads' is needed to avoid this error during 'make':
             # 'pattern all: open .../elemental/tests/cypress/downloads: permission denied'
-            sudo rm -rf cypress/${{ inputs.elemental_ui_version }}/downloads
+            sudo rm -rf cypress/latest/downloads
 
             make e2e-get-logs
           )

--- a/.github/workflows/ui-e2e-k3s-latest.yaml
+++ b/.github/workflows/ui-e2e-k3s-latest.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -38,7 +34,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'latest'

--- a/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Dev.yaml
@@ -7,10 +7,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -40,7 +36,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Stable.yaml
@@ -8,8 +8,8 @@ on:
         default: true
         type: boolean
       elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
+        description: Version of the elemental ui which will be installed (dev/stable)
+        default: stable
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-k3s-obs-Staging.yaml
@@ -7,10 +7,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -40,7 +36,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-e2e-k3s-stable.yaml
+++ b/.github/workflows/ui-e2e-k3s-stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: 'latest'
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -38,7 +34,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_channel: 'stable'

--- a/.github/workflows/ui-e2e-rke2-latest.yaml
+++ b/.github/workflows/ui-e2e-rke2-latest.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -36,7 +32,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest'}}
+      elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'latest'
       rancher_version: ${{ inputs.rancher_version || 'devel' }}

--- a/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Dev.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -39,7 +35,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Stable.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
+        description: Version of the elemental ui which will be installed (dev/stable)
+        default: stable
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)

--- a/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
+++ b/.github/workflows/ui-e2e-rke2-obs-Staging.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -39,7 +35,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: ${{ inputs.rancher_channel }}

--- a/.github/workflows/ui-e2e-rke2-stable.yaml
+++ b/.github/workflows/ui-e2e-rke2-stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: 'latest'
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -39,7 +35,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -15,10 +15,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -41,7 +37,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: 'latest'
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -34,7 +30,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       iso_to_test:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
@@ -48,7 +44,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -14,10 +14,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: devel
@@ -38,7 +34,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'latest'

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: 'latest'
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -35,7 +31,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version || 'latest' }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'stable'

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed
-        default: latest
-        type: string
       iso_to_test:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
@@ -49,7 +45,7 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      elemental_ui_version: dev
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+rke2r1
       proxy: ${{ inputs.proxy }}

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -27,12 +27,14 @@ filterTests(['main', 'upgrade'], () => {
     });
   
     it('Add elemental-ui repo', () => {
-      topLevelMenu.openIfClosed();
-      cy.contains('local')
-        .click();
-      cy.addHelmRepo({repoName: 'elemental-ui',
-        repoUrl: 'https://github.com/rancher/elemental-ui.git',
-        repoType: 'git'});
+      if ( Cypress.env('elemental_ui_version') != "stable") {
+        topLevelMenu.openIfClosed();
+        cy.contains('local')
+          .click();
+        cy.addHelmRepo({repoName: 'elemental-ui',
+          repoUrl: 'https://github.com/rancher/elemental-ui.git',
+          repoType: 'git'});
+      };
     });
     
     it('Enable extension support', () => {
@@ -41,8 +43,10 @@ filterTests(['main', 'upgrade'], () => {
         .click();
       cy.clickButton('Enable');
       cy.contains('Enable Extension Support?')
-      cy.contains('Add the Rancher Extension Repository')
-        .click();
+      if ( Cypress.env('elemental_ui_version') != "stable") {
+        cy.contains('Add the Rancher Extension Repository')
+          .click();
+      }
       cy.clickButton('OK');
       cy.get('.tabs', {timeout: 40000})
         .contains('Installed Available Updates All');

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -8,7 +8,7 @@ pushd ..
 setsid --fork ${HTTP_SRV_CMD} >/dev/null 2>&1
 popd
 
-pushd cypress/$ELEMENTAL_UI_VERSION
+pushd cypress/latest
 
 # Needed to install Cypress plugins
 npm install
@@ -35,7 +35,7 @@ popd
 
 # Move elemental.iso into the expected folder
 if [[ ${ISO_BOOT} == "true" ]]; then
-    sudo mv cypress/$ELEMENTAL_UI_VERSION/downloads/elemental.iso ../elemental-from-cypress.iso
+    sudo mv cypress/latest/downloads/elemental.iso ../elemental-from-cypress.iso
 fi
 
 # Kill the HTTP server


### PR DESCRIPTION
Fix #799 

## Verification runs
[OBS-Stable-K3s-UI_E2E-with-stable-UI](https://github.com/rancher/elemental/actions/runs/4763106258) :heavy_check_mark: 


Non-regression test:
[K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/runs/4763101300) :heavy_check_mark: 