### PR TITLE
ci: adds differents fixes

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
@@ -30,6 +30,5 @@ jobs:
         --kube-apiserver-arg=--anonymous-auth=false"
       k8s_version_to_provision: v1.25.7+k3s1
       node_number: 3
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel
       upstream_k3s_version: v1.25.7+k3s1

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Stable-K3s-E2E
+name: CLI-K3s-OBS_Dev
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-k3s-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -35,13 +35,13 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard K3s"
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -11,13 +11,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upstream_k3s_version:
         description: Cluster upstream K3s version where to install Rancher
@@ -42,6 +38,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_stable.yaml
+++ b/.github/workflows/cli-k3s-obs_stable.yaml
@@ -1,9 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Staging-RKE2-UI_E2E
+name: CLI-K3s-OBS_Stable
 
 on:
   workflow_dispatch:
     inputs:
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -16,25 +19,29 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
+      upstream_k3s_version:
+        description: Cluster upstream K3s version where to install Rancher
+        type: string
+
+concurrency:
+  group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
 
 jobs:
-  ui:
+  cli:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
-      ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
-      cypress_tags: main
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard K3s"
+      cluster_name: cluster-k3s
+      cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+k3s1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      test_type: ui
+      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_stable.yaml
+++ b/.github/workflows/cli-k3s-obs_stable.yaml
@@ -11,13 +11,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upstream_k3s_version:
         description: Cluster upstream K3s version where to install Rancher
@@ -42,6 +38,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -11,13 +11,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upstream_k3s_version:
         description: Cluster upstream K3s version where to install Rancher
@@ -42,6 +38,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Dev-K3s-E2E
+name: CLI-K3s-OBS_Staging
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ on:
         type: string
 
 concurrency:
-  group: e2e-k3s-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-k3s-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -35,13 +35,13 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard K3s"
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -24,8 +24,7 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -24,8 +24,7 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: stable
-      rancher_version: latest
+      rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -12,13 +12,9 @@ on:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -46,7 +42,6 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-k3s-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-rancher_latest.yaml
@@ -1,14 +1,12 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s-E2E-Stable_RM
+name: CLI-K3s-Rancher_Latest
 
+# This worflow is scheduled *after* build-ci to be sure that we have
+# the lastest version built. The scheduling is also to avoid running
+# the workflow on each push on main.
 on:
-  workflow_run:
-    workflows:
-      - build-ci
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   cli:
@@ -18,8 +16,8 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI - E2E CLI - Parallel - Deployment test with Standard K3s"
+      test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.25.7+k3s1
-      start_condition: ${{ github.event.workflow_run.conclusion }}
-      workflow_download: ${{ github.event.workflow_run.workflow_id }}
+      rancher_channel: latest
+      rancher_version: devel

--- a/.github/workflows/cli-k3s-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-rancher_latest.yaml
@@ -19,5 +19,4 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.25.7+k3s1
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel

--- a/.github/workflows/cli-k3s-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-rancher_stable.yaml
@@ -1,12 +1,14 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s-E2E-Latest_RM
+name: CLI-K3s-Rancher_Stable
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
-  schedule:
-    - cron: '0 1 * * *'
+  workflow_run:
+    workflows:
+      - build-ci
+    branches:
+      - main
+    types:
+      - completed
 
 jobs:
   cli:
@@ -16,8 +18,8 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI - E2E CLI - Parallel - Deployment test with Standard K3s"
+      test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.25.7+k3s1
-      rancher_channel: latest
-      rancher_version: devel
+      start_condition: ${{ github.event.workflow_run.conclusion }}
+      workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
@@ -20,6 +20,5 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.25.7+k3s1
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel
       sequential: true

--- a/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
@@ -20,6 +20,5 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.25.7+k3s1
-      rancher_channel: stable
-      rancher_version: latest
+      rancher_version: stable/latest
       sequential: true

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -27,13 +27,9 @@ on:
         description: Elemental operator version to use
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       runner_template:
         description: Runner template to use
@@ -64,7 +60,6 @@ jobs:
       k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
       node_number: ${{ inputs.node_number }}
       operator_version: ${{ inputs.operator_version }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -1,4 +1,5 @@
-name: OBS-Stable-K3s-UI_E2E
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-RKE2-OBS_Dev
 
 on:
   workflow_dispatch:
@@ -7,14 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed (dev/stable)
-        default: stable
-        type: string
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -24,23 +17,24 @@ on:
         default: latest
         type: string
 
+concurrency:
+  group: e2e-rke2-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
-  ui:
+  cli:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
-      cluster_name: cluster-k3s
-      cypress_tags: main
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
+      ca_type: private
+      cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      proxy: ${{ inputs.proxy }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+rke2r1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      test_type: ui

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -8,13 +8,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 concurrency:
@@ -36,5 +32,4 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-rke2-obs_stable.yaml
+++ b/.github/workflows/cli-rke2-obs_stable.yaml
@@ -8,13 +8,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 concurrency:
@@ -36,5 +32,4 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-rke2-obs_stable.yaml
+++ b/.github/workflows/cli-rke2-obs_stable.yaml
@@ -1,12 +1,9 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Staging-K3s-E2E
+name: CLI-RKE2-OBS_Stable
 
 on:
   workflow_dispatch:
     inputs:
-      cluster_type:
-        description: Cluster type (empty if normal or hardened)
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -19,12 +16,9 @@ on:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-      upstream_k3s_version:
-        description: Cluster upstream K3s version where to install Rancher
-        type: string
 
 concurrency:
-  group: e2e-k3s-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-rke2-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -35,13 +29,12 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard K3s"
-      cluster_name: cluster-k3s
-      cluster_type: ${{ inputs.cluster_type }}
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
+      ca_type: private
+      cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+rke2r1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -1,4 +1,5 @@
-name: OBS-Staging-K3s-UI_E2E
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-RKE2-OBS_Staging
 
 on:
   workflow_dispatch:
@@ -7,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -20,23 +17,24 @@ on:
         default: latest
         type: string
 
+concurrency:
+  group: e2e-rke2-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
-  ui:
+  cli:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
-      cluster_name: cluster-k3s
-      cypress_tags: main
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
+      ca_type: private
+      cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+k3s1
+      k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
-      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
-      test_type: ui

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -8,13 +8,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 concurrency:
@@ -36,5 +32,4 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -25,8 +25,7 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -25,8 +25,7 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: stable
-      rancher_version: latest
+      rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -12,13 +12,9 @@ on:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -47,7 +43,6 @@ jobs:
       node_number: 3
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher/elemental-operator-chart
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-rke2-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2-E2E-Latest_RM
+name: CLI-RKE2-Rancher_Latest
 
 # This worflow is scheduled *after* build-ci to be sure that we have
 # the lastest version built. The scheduling is also to avoid running
@@ -16,7 +16,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI - E2E CLI - Parallel - Deployment test with Standard RKE2"
+      test_description: "CI - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-rancher_latest.yaml
@@ -20,5 +20,4 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel

--- a/.github/workflows/cli-rke2-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2-E2E-Stable_RM
+name: CLI-RKE2-Rancher_Stable
 
 on:
   workflow_run:
@@ -18,7 +18,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI - E2E CLI - Parallel - Deployment test with Standard RKE2"
+      test_description: "CI - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -22,6 +22,5 @@ jobs:
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
       node_number: 100
-      rancher_channel: stable
-      rancher_version: latest
+      rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4

--- a/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
@@ -20,6 +20,5 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: latest
-      rancher_version: devel
+      rancher_version: latest/devel
       sequential: true

--- a/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
@@ -20,6 +20,5 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: stable
-      rancher_version: latest
+      rancher_version: stable/latest
       sequential: true

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -81,17 +81,13 @@ on:
       proxy:
         description: Deploy a proxy
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_log_collector:
         description: URL of the Rancher log collector script
         default: https://raw.githubusercontent.com/rancherlabs/support-tools/master/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
         type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       runner_template:
         description: Runner template to use
@@ -196,7 +192,6 @@ jobs:
       INSTALL_K3S_SKIP_ENABLE: true
       K3S_KUBECONFIG_MODE: 0644
       # For Rancher Manager
-      RANCHER_CHANNEL: ${{ inputs.rancher_channel }}
       RANCHER_VERSION: ${{ inputs.rancher_version }}
       # For K8s cluster to provision with Rancher Manager
       K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
@@ -512,8 +507,8 @@ jobs:
           echo "Type of cluster deployed: ${CLUSTER_TYPE:-normal}" >> ${GITHUB_STEP_SUMMARY}
           echo "Bootstrap method: ${BOOTSTRAP_METHOD}" >> ${GITHUB_STEP_SUMMARY}
           echo "## Versions used" >> ${GITHUB_STEP_SUMMARY}
-          echo "Rancher Manager Channel: ${{ env.RANCHER_CHANNEL }}/${{ env.RANCHER_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "Rancher Manager Version: ${{ steps.component.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Rancher Manager Image: ${{ steps.component.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental ISO used: ${ISO_USED}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental Operator Version: ${{ steps.component.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental Backup-Restore Operator Version: ${{ steps.component.outputs.backup_restore_version }}" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -253,6 +253,11 @@ jobs:
                                      --namespace cattle-resources-system \
                                      -l app.kubernetes.io/name=rancher-backup \
                                      -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Extract CertManager version
+          CERT_MANAGER_VERSION=$(kubectl get pod \
+                                   --namespace cert-manager \
+                                   -l app=cert-manager \
+                                   -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
           # Extract elemental-operator version
           OPERATOR_VERSION=$(kubectl get pod \
                              --namespace cattle-elemental-system \
@@ -265,6 +270,7 @@ jobs:
                          -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
           # Export values
           echo "backup_restore_version=${BACKUP_RESTORE_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
           echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
           echo "rm_version=${RM_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Cypress tests - Basics
@@ -509,9 +515,10 @@ jobs:
           echo "## Versions used" >> ${GITHUB_STEP_SUMMARY}
           echo "Rancher Manager Image: ${{ steps.component.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "CertManager Image: ${{ steps.component.outputs.cert_manager_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental ISO used: ${ISO_USED}" >> ${GITHUB_STEP_SUMMARY}
-          echo "Elemental Operator Version: ${{ steps.component.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "Elemental Backup-Restore Operator Version: ${{ steps.component.outputs.backup_restore_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Elemental Operator Image: ${{ steps.component.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Elemental Backup/Restore Operator Image: ${{ steps.component.outputs.backup_restore_version }}" >> ${GITHUB_STEP_SUMMARY}
           if ${{ inputs.elemental_ui_version != '' }}; then
             echo "Elemental UI Extension Version: ${{ inputs.elemental_ui_version }}" >> ${GITHUB_STEP_SUMMARY}
           fi
@@ -524,7 +531,7 @@ jobs:
           if ${{ inputs.upgrade_image != '' }} || ${{ inputs.upgrade_os_channel != '' }}; then
             echo "## Upgrade details" >> ${GITHUB_STEP_SUMMARY}
             echo "Elemental Operator Upgrade: ${{ steps.operator_upgrade.outputs.operator_upgrade }}" >> ${GITHUB_STEP_SUMMARY}
-            echo "Elemental Operator Version: ${{ steps.operator_upgrade.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
+            echo "Elemental Operator Image: ${{ steps.operator_upgrade.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Channel list: ${{ inputs.upgrade_channel_list }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Channel used: ${{ inputs.upgrade_os_channel }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Upgrade image: ${{ inputs.upgrade_image }}" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -173,9 +173,32 @@ jobs:
       - name: Get public dns name in GCP
         id: dns
         run: |
-          PUBLIC_IP=$(gcloud compute instances list | awk '/${{ steps.generator.outputs.runner }}/ {print $6}')
-          PUBLIC_DNS=$(host -l $PUBLIC_IP | awk '{sub(/\.$/, ""); print $5}')
+          # Do a timed out loop here, as gcloud can sometimes fail
+          typeset -i i=0
+          while true; do
+            # Get public IP
+            PUBLIC_IP=$(gcloud compute instances list 2> /dev/null \
+                        | awk '/${{ steps.generator.outputs.runner }}/ {print $6}')
+
+            # Exit if we reach the timeout or if IP is set
+            if (( ++i > 10 )) || [[ -n "${PUBLIC_IP}" ]]; then
+              break
+            fi
+
+            # Wait a little before retrying
+            sleep 2
+          done
+
+          # Get the public DNS
+          PUBLIC_DNS=$(host -l ${PUBLIC_IP} 2> /dev/null \
+                       | awk '{sub(/\.$/, ""); print $5}')
           echo "public_dns=${PUBLIC_DNS}" >> ${GITHUB_OUTPUT}
+
+          # Raise an error if either IP and/or DNS are empty
+          if [[ -z "${PUBLIC_IP}" || -z "${PUBLIC_DNS}" ]]; then
+            echo "PUBLIC_IP and/or PUBLIC_DNS are empty!" >&2
+            false
+          fi
   e2e:
     needs: create-runner
     runs-on: ${{ needs.create-runner.outputs.uuid }}
@@ -225,7 +248,7 @@ jobs:
       - name: Extract iPXE artifacts from ISO
         run: |
           # Extract TAG
-          ISO=$(ls build/elemental-*.iso 2>/dev/null)
+          ISO=$(ls build/elemental-*.iso 2> /dev/null)
           TAG=${ISO#*-}
           export TAG=${TAG%.iso}
           # Extract iPXE artifacts
@@ -498,7 +521,7 @@ jobs:
           if ${{ inputs.sequential == 'true' }}; then
             BOOTSTRAP_METHOD="Sequential"
           fi
-          ISO_USED=$(ls build/elemental-*.iso 2>/dev/null)
+          ISO_USED=$(ls build/elemental-*.iso 2> /dev/null)
           if ${{ inputs.iso_to_test != '' }}; then
             ISO_USED=${{ inputs.iso_to_test }}
           fi

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -12,13 +12,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 jobs:
@@ -38,6 +34,5 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       proxy: ${{ inputs.proxy }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Stable-RKE2-E2E
+name: UI-K3s-OBS_Dev
 
 on:
   workflow_dispatch:
@@ -8,6 +8,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -17,24 +21,23 @@ on:
         default: latest
         type: string
 
-concurrency:
-  group: e2e-rke2-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
-
 jobs:
-  cli:
+  ui:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard RKE2"
-      ca_type: private
-      cluster_name: cluster-rke2
+      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
+      cluster_name: cluster-k3s
+      cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      elemental_ui_version: dev
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+k3s1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
+      test_type: ui

--- a/.github/workflows/ui-k3s-obs_stable.yaml
+++ b/.github/workflows/ui-k3s-obs_stable.yaml
@@ -16,13 +16,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 jobs:
@@ -42,6 +38,5 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       proxy: ${{ inputs.proxy }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_stable.yaml
+++ b/.github/workflows/ui-k3s-obs_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Dev-RKE2-E2E
+name: UI-K3s-OBS_Stable
 
 on:
   workflow_dispatch:
@@ -8,6 +8,14 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed (dev/stable)
+        default: stable
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -17,24 +25,23 @@ on:
         default: latest
         type: string
 
-concurrency:
-  group: e2e-rke2-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
-
 jobs:
-  cli:
+  ui:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard RKE2"
-      ca_type: private
-      cluster_name: cluster-rke2
+      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
+      cluster_name: cluster-k3s
+      cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+k3s1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
+      test_type: ui

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -12,13 +12,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 jobs:
@@ -38,6 +34,5 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
       proxy: ${{ inputs.proxy }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Staging-RKE2-E2E
+name: UI-K3s-OBS_Staging
 
 on:
   workflow_dispatch:
@@ -8,6 +8,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
         default: stable
@@ -17,24 +21,23 @@ on:
         default: latest
         type: string
 
-concurrency:
-  group: e2e-rke2-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
-
 jobs:
-  cli:
+  ui:
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - E2E CLI - Parallel - Deployment test with Standard RKE2"
-      ca_type: private
-      cluster_name: cluster-rke2
+      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
+      cluster_name: cluster-k3s
+      cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
+      elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+rke2r1
+      k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      proxy: ${{ inputs.proxy }}
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
+      test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -20,8 +20,8 @@ on:
         default: elemental
         type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        description: Rancher Manager channel/version to use for installation
+        default: latest/devel
         type: string
   schedule:
     - cron: '0 1 * * *'
@@ -41,8 +41,7 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: 'latest'
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -13,8 +13,8 @@ on:
         default: elemental
         type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
   schedule:
     - cron: '0 1 * * *'
@@ -35,8 +35,7 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: 'stable'
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -20,13 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -49,7 +45,6 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: ${{ inputs.operator_version }}
       proxy: ${{ inputs.proxy }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -13,8 +13,8 @@ on:
         default: elemental
         type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        description: Rancher Manager channel/version to use for installation
+        default: latest/devel
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -34,6 +34,5 @@ jobs:
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: 'latest'
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s-UI_E2E-Latest_RM
+name: UI-K3s-Rancher_Latest
 
 on:
   workflow_dispatch:
@@ -27,7 +27,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI/Manual - E2E UI - Deployment test with Standard K3s"
+      test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}

--- a/.github/workflows/ui-k3s-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-rancher_stable.yaml
@@ -13,8 +13,8 @@ on:
         default: elemental
         type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -34,6 +34,5 @@ jobs:
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
-      rancher_channel: 'stable'
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2-UI_E2E-Latest_RM
+name: UI-K3s-Rancher_Stable
 
 on:
   workflow_dispatch:
@@ -8,9 +8,13 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -23,14 +27,13 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI/Manual - E2E UI - Deployment test with Standard RKE2"
-      ui_account: user
-      ca_type: private
-      cluster_name: cluster-rke2
+      test_description: "CI/Manual - UI - Deployment test with Standard K3s"
+      cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: 'latest'
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      k8s_version_to_provision: v1.25.7+k3s1
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_channel: 'stable'
+      rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -8,13 +8,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 jobs:
@@ -35,6 +31,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Stable-RKE2-UI_E2E
+name: UI-RKE2-OBS_Dev
 
 on:
   workflow_dispatch:
@@ -8,17 +8,13 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      elemental_ui_version:
-        description: Version of the elemental ui which will be installed (dev/stable)
-        default: stable
-        type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
+        default: stable
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        default: latest
         type: string
 
 jobs:
@@ -35,10 +31,10 @@ jobs:
       cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      elemental_ui_version: dev
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_stable.yaml
+++ b/.github/workflows/ui-rke2-obs_stable.yaml
@@ -1,4 +1,5 @@
-name: OBS-Dev-K3s-UI_E2E
+# This workflow calls the master E2E workflow with custom variables
+name: UI-RKE2-OBS_Stable
 
 on:
   workflow_dispatch:
@@ -7,17 +8,17 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
+      elemental_ui_version:
+        description: Version of the elemental ui which will be installed (dev/stable)
+        default: stable
         type: string
       rancher_channel:
         description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
+        default: latest
         type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        default: devel
         type: string
 
 jobs:
@@ -28,15 +29,16 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
-      cluster_name: cluster-k3s
+      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
+      ui_account: user
+      ca_type: private
+      cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      proxy: ${{ inputs.proxy }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      k8s_version_to_provision: v1.25.7+rke2r1
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_stable.yaml
+++ b/.github/workflows/ui-rke2-obs_stable.yaml
@@ -12,13 +12,9 @@ on:
         description: Version of the elemental ui which will be installed (dev/stable)
         default: stable
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: latest
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        description: Rancher Manager channel/version to use for installation
+        default: latest/devel
         type: string
 
 jobs:
@@ -39,6 +35,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: RKE2-UI_E2E-Stable_RM
+name: UI-RKE2-OBS_Staging
 
 on:
   workflow_dispatch:
@@ -8,12 +8,14 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      rancher_channel:
+        description: Rancher Manager channel to use for installation (alpha/latest/stable)
+        default: stable
+        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
         type: string
-  schedule:
-    - cron: '0 4 * * *'
 
 jobs:
   ui:
@@ -23,17 +25,16 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      # Fixed in elemental-ui 1.1.0
-      #ui_account: user
-      test_description: "CI/Manual - E2E UI - Deployment test with Standard RKE2"
+      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: 'stable'
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      rancher_channel: ${{ inputs.rancher_channel }}
+      rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -8,13 +8,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
 
 jobs:
@@ -35,6 +31,5 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -15,8 +15,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        description: Rancher Manager channel/version to use for installation
+        default: latest/devel
         type: string
   schedule:
     - cron: '0 1 * * *'
@@ -37,8 +37,7 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: 'latest'
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
   schedule:
     - cron: '0 1 * * *'
@@ -35,8 +35,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
-      rancher_channel: 'stable'
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -20,13 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -50,7 +46,6 @@ jobs:
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: ${{ inputs.operator_version }}
       proxy: ${{ inputs.proxy }}
-      rancher_channel: ${{ inputs.rancher_channel }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/ui-rke2-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-rancher_latest.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: devel
+        description: Rancher Manager channel/version to use for installation
+        default: latest/devel
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -31,6 +31,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: 'latest'
-      rancher_version: ${{ inputs.rancher_version || 'devel' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-rancher_latest.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: OBS-Dev-RKE2-UI_E2E
+name: UI-RKE2-Rancher_Latest
 
 on:
   workflow_dispatch:
@@ -8,14 +8,12 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      rancher_channel:
-        description: Rancher Manager channel to use for installation (alpha/latest/stable)
-        default: stable
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        default: devel
         type: string
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   ui:
@@ -25,16 +23,14 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
+      test_description: "CI/Manual - UI - Deployment test with Standard RKE2"
       ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner }}
+      destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      rancher_channel: ${{ inputs.rancher_channel }}
-      rancher_version: ${{ inputs.rancher_version }}
+      rancher_channel: 'latest'
+      rancher_version: ${{ inputs.rancher_version || 'devel' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-rancher_stable.yaml
@@ -9,8 +9,8 @@ on:
         default: true
         type: boolean
       rancher_version:
-        description: Rancher Manager version to use for installation (fixed version or latest)
-        default: latest
+        description: Rancher Manager channel/version to use for installation
+        default: stable/latest
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -34,6 +34,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
-      rancher_channel: 'stable'
-      rancher_version: ${{ inputs.rancher_version || 'latest' }}
+      rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-rancher_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: K3s-UI_E2E-Stable_RM
+name: UI-RKE2-Rancher_Stable
 
 on:
   workflow_dispatch:
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       rancher_version:
         description: Rancher Manager version to use for installation (fixed version or latest)
         default: latest
@@ -27,13 +23,17 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "CI/Manual - E2E UI - Deployment test with Standard K3s"
-      cluster_name: cluster-k3s
+      # Using user account has to be disable due to this bug
+      # https://github.com/rancher/elemental-ui/issues/64
+      # Fixed in elemental-ui 1.1.0
+      #ui_account: user
+      test_description: "CI/Manual - UI - Deployment test with Standard RKE2"
+      ca_type: private
+      cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      k8s_version_to_provision: v1.25.7+k3s1
-      proxy: ${{ inputs.proxy || 'elemental' }}
+      k8s_version_to_provision: v1.25.7+rke2r1
       rancher_channel: 'stable'
       rancher_version: ${{ inputs.rancher_version || 'latest' }}
       test_type: ui

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Elemental
 CI with latest stable Rancher Manager:
 
-[![K3s-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-stable.yaml)
-[![RKE2-E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-stable.yaml)
+[![CLI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-rancher_stable.yaml)
+[![CLI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-rancher_stable.yaml)
 
 [![CLI-K3s-Sequential-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-sequential-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-sequential-rancher_stable.yaml)
 [![CLI-RKE2-Sequential-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-sequential-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-sequential-rancher_stable.yaml)
@@ -14,16 +14,16 @@ CI with latest stable Rancher Manager:
 
 [![CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml)
 
-[![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
-[![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
+[![UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_stable.yaml)
+[![UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_stable.yaml)
 
 [![UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_stable.yaml)
 [![UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_stable.yaml)
 
 CI with latest devel Rancher Manager:
 
-[![K3s-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-k3s-latest.yaml)
-[![RKE2-E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/e2e-rke2-latest.yaml)
+[![CLI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-rancher_latest.yaml)
+[![CLI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-rancher_latest.yaml)
 
 [![CLI-K3s-Sequential-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-sequential-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-sequential-rancher_latest.yaml)
 [![CLI-RKE2-Sequential-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-sequential-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-sequential-rancher_latest.yaml)
@@ -33,8 +33,8 @@ CI with latest devel Rancher Manager:
 
 [![CLI-K3s-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml)
 
-[![K3s-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-latest.yaml)
-[![RKE2-UI_E2E-Latest_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-latest.yaml)
+[![UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_latest.yaml)
+[![UI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_latest.yaml)
 
 [![UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rancher_latest.yaml)
 [![UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rancher_latest.yaml)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ CI with latest stable Rancher Manager:
 
 [![CLI-K3s-Hardened-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml)
 
+[![CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml)
+
 [![K3s-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-k3s-stable.yaml)
 [![RKE2-UI_E2E-Stable_RM](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-e2e-rke2-stable.yaml)
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -17,6 +17,7 @@ package e2e_test
 import (
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -151,7 +152,6 @@ var _ = BeforeSuite(func() {
 	operatorVersion = os.Getenv("OPERATOR_VERSION")
 	poolType = os.Getenv("POOL")
 	proxy = os.Getenv("PROXY")
-	rancherChannel = os.Getenv("RANCHER_CHANNEL")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
 	seqString := os.Getenv("SEQUENTIAL")
@@ -202,6 +202,13 @@ var _ = BeforeSuite(func() {
 		sequential = true
 	default:
 		sequential = false
+	}
+
+	// Extract Rancher Manager channel/version to install
+	if rancherVersion != "" {
+		s := strings.Split(rancherVersion, "/")
+		rancherChannel = s[0]
+		rancherVersion = s[1]
 	}
 
 	// Start HTTP server


### PR DESCRIPTION
This PR adds:
- merge Rancher repo/version inputs in one
- rename tests to be more consistent
- add badge for the weekly scalability test

Verification runs:
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/4808709414) :hourglass_flowing_sand:
- [UI-K3s-OS-Upgrade ](https://github.com/rancher/elemental/actions/runs/4807698334)