### PR TITLE
812 several fixes for upgrade tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -55,21 +55,20 @@ describe('Upgrade tests', () => {
       cy.getBySel('form-save')
         .contains('Create')
         .click();
-      // Status changes a lot right after the creation so let's wait 60 secondes
+      // Status changes a lot right after the creation so let's wait 10 secondes
       // before checking
-      cy.wait(60000);
+      cy.wait(10000);
       cy.getBySel('sortable-cell-0-0')
-        .contains('Active');
+        .contains('Active', {timeout: 50000});
     });
 
     it('Check OS Versions', () => {
+      let osVersionsTab = ["Active dev", "Active dev-rt", "Active stable", "Active stable-rt", "Active staging", "Active staging-rt"]
       cy.clickNavMenu(["Advanced", "OS Versions"]);
-      cy.getBySel('sortable-table-0-row')
-        .contains('Active dev', {timeout: 120000});
-      cy.getBySel('sortable-table-1-row')
-        .contains('Active stable');
-      cy.getBySel('sortable-table-2-row')
-        .contains('Active staging');
+      for (let i = 0; i < osVersionsTab.length; i++) {
+        cy.getBySel(`sortable-table-${i}-row`)
+          .contains(osVersionsTab[i], {timeout: 120000});
+      };
     });
 
     it('Upgrade one node (different methods if rke2 or k3s)', () => {
@@ -168,7 +167,7 @@ describe('Upgrade tests', () => {
 
     it('Delete OS Versions', () => {
       cy.clickNavMenu(["Advanced", "OS Versions"]);
-      cy.contains('dev')
+      cy.contains('dev-rt')
         .parent()
         .parent()
         .click();
@@ -176,7 +175,7 @@ describe('Upgrade tests', () => {
       .contains('Delete')
         .click()
       cy.confirmDelete();
-      cy.contains('dev')
+      cy.contains('dev-rt')
         .should('not.exist');
     });
 

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -148,9 +148,9 @@ describe('Upgrade tests', () => {
       cy.get('.primaryheader')
         .contains('Active');
       cy.get('.primaryheader')
-        .contains('Updating', {timeout: 360000});
+        .contains('Active', {timeout: 420000}).should('not.exist');
       cy.get('.primaryheader')
-        .contains('Active', {timeout: 360000});
+        .contains('Active', {timeout: 420000});
     });
 
     it('Cannot create two upgrade groups targeting the same cluster', () => {

--- a/tests/cypress/latest/support/functions.ts
+++ b/tests/cypress/latest/support/functions.ts
@@ -270,7 +270,7 @@ Cypress.Commands.add('createMachReg', ({
         expect($input).to.have.attr('disabled')
       })
       // Download button is enabled once ISO building done
-      cy.getBySel('download-iso-btn', { timeout: 180000 }).should(($input) => {
+      cy.getBySel('download-iso-btn', { timeout: 300000 }).should(($input) => {
         expect($input).to.not.have.attr('disabled')
       })
       cy.getBySel('download-iso-btn')

--- a/tests/cypress/latest/support/functions.ts
+++ b/tests/cypress/latest/support/functions.ts
@@ -275,7 +275,7 @@ Cypress.Commands.add('createMachReg', ({
       })
       cy.getBySel('download-iso-btn')
         .click()
-      cy.verifyDownload('elemental.iso', { timeout: 180000, interval: 5000 });
+      cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
     }
   
       // Check Cloud configuration

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -31,12 +31,14 @@ docker run -v $PWD:/workdir -w /workdir                     \
     $CYPRESS_DOCKER                                         \
     -s $SPEC
 
-popd
+[[ -d downloads ]] && sudo chown -R gh-runner:users downloads videos
 
 # Move elemental.iso into the expected folder
 if [[ ${ISO_BOOT} == "true" ]]; then
-    sudo mv cypress/latest/downloads/elemental.iso ../elemental-from-cypress.iso
+    mv downloads/*.iso ../../../elemental-from-cypress.iso
 fi
+
+popd
 
 # Kill the HTTP server
 pkill -f "${HTTP_SRV_CMD}"


### PR DESCRIPTION
- Fix #812 
- Fix also that elemental ISO is now named with registration endpotin name + timestamp and not only elemental.iso anymore
- Change how we check if a node is rebooted when upgrading it

[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4819952997) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4819955724) :heavy_check_mark: 

[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4819956943):heavy_check_mark:
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4819958319) :heavy_check_mark: 
