### PR TITLE
ci/ui: increase cluster check status timeout

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -117,7 +117,9 @@ describe('Machine inventory testing', () => {
       }
       cy.clickButton('Create');
       cy.contains('Updating ' + clusterName, {timeout: 360000});
-      cy.contains('Active ' + clusterName, {timeout: 480000});
+      // Increase timeout to 10 minutes to allow the cluster to be created
+      // If it fails again, try to reload the page instead of increasing the timeout 
+      cy.contains('Active ' + clusterName, {timeout: 600000});
     });
   });
   


### PR DESCRIPTION
Some tests are still failing when cluster is created, it doesn't show active before reaching the timeout, it look like to be a matter of seconds:

At 9:38, the cluster is not active:
![image](https://user-images.githubusercontent.com/6025636/235074812-4d84cb03-d9b8-49c0-b703-9a187454ed84.png)

20 seconds later, the cluster is active:
![image](https://user-images.githubusercontent.com/6025636/235075062-9fbfdbb3-5dfb-4512-abcc-7704d2b25504.png)

As mentioned in the comment, it the check fails again, let's try to reload the page and check the status.