### PR TITLE
ci/e2e: add option to keep runner in scalability test

### DIFF
--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -6,6 +6,11 @@ name: CLI-RKE2-Scalability-Rancher_Stable
 # the workflow on each push on main.
 on:
   workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
   schedule:
     # Every Sunday at 3am
     - cron: '0 3 * * 0'
@@ -20,6 +25,7 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       k8s_version_to_provision: v1.25.7+rke2r1
       node_number: 100
       rancher_version: stable/latest

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+k3s1

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -29,7 +29,7 @@ jobs:
     with:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1

--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -30,7 +30,7 @@ jobs:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-rancher_stable.yaml
@@ -30,7 +30,7 @@ jobs:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -33,7 +33,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: upgrade
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -30,7 +30,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: upgrade
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-rancher_latest.yaml
@@ -28,7 +28,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/.github/workflows/ui-rke2-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-rancher_stable.yaml
@@ -31,7 +31,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: ${{ inputs.destroy_runner && true }}
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}


### PR DESCRIPTION
Useful for debugging when it fails.

Verification run:
- [CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4828849696) - with `destroy_runner` set to `false`
- [UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4829078181) - with `destroy_runner` set to `true`
- [UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4829086480) - with `destroy_runner` set to `false`