### PR TITLE
ci: configure RKE2 as management node for UI upgrade tests ( RKE2)

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
@@ -31,4 +31,3 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       node_number: 3
       rancher_version: latest/devel
-      upstream_k3s_version: v1.25.7+k3s1

--- a/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
@@ -30,4 +30,3 @@ jobs:
         --kube-apiserver-arg=--anonymous-auth=false"
       k8s_version_to_provision: v1.25.7+k3s1
       node_number: 3
-      upstream_k3s_version: v1.25.7+k3s1

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -15,9 +15,6 @@ on:
         description: Rancher Manager channel/version to use for installation
         default: stable/latest
         type: string
-      upstream_k3s_version:
-        description: Cluster upstream K3s version where to install Rancher
-        type: string
 
 concurrency:
   group: e2e-k3s-obs-dev-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -39,4 +36,3 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_stable.yaml
+++ b/.github/workflows/cli-k3s-obs_stable.yaml
@@ -15,9 +15,6 @@ on:
         description: Rancher Manager channel/version to use for installation
         default: stable/latest
         type: string
-      upstream_k3s_version:
-        description: Cluster upstream K3s version where to install Rancher
-        type: string
 
 concurrency:
   group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -39,4 +36,3 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -15,9 +15,6 @@ on:
         description: Rancher Manager channel/version to use for installation
         default: stable/latest
         type: string
-      upstream_k3s_version:
-        description: Cluster upstream K3s version where to install Rancher
-        type: string
 
 concurrency:
   group: e2e-k3s-obs-staging-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -39,4 +36,3 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_k3s_version: ${{ inputs.upstream_k3s_version }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -124,8 +124,12 @@ on:
       upgrade_type:
         description: Type of upgrade to use for the Elemental OS upgrade
         type: string
-      upstream_k3s_version:
-        description: Cluster upstream K3s version where to install Rancher
+      upstream_cluster_distribution:
+        description: Cluster upstream distribution where to install Rancher (K3s or RKE2)
+        default: k3s
+        type: string
+      upstream_cluster_version:
+        description: Cluster upstream version where to install Rancher (K3s or RKE2)
         default: v1.25.7+k3s1
         type: string
       workflow_download:
@@ -203,21 +207,24 @@ jobs:
     needs: create-runner
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     env:
-      TIMEOUT_SCALE: 3
       ARCH: amd64
       CERT_MANAGER_VERSION: ${{ inputs.cert-manager_version }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default
       CLUSTER_TYPE: ${{ inputs.cluster_type }}
-      # For K3s installation used to host Rancher Manager
+    # K3S / RKE2 flags to use for installation
       INSTALL_K3S_EXEC: ${{ inputs.k3s_flags }}
-      INSTALL_K3S_VERSION: ${{ inputs.upstream_k3s_version }}
       INSTALL_K3S_SKIP_ENABLE: true
+      INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
+      INSTALL_RKE2_VERSION: ${{ inputs.upstream_cluster_version }}
       K3S_KUBECONFIG_MODE: 0644
-      # For Rancher Manager
-      RANCHER_VERSION: ${{ inputs.rancher_version }}
+      # Distribution to use to host Rancher Manager (K3s or RKE2)
+      K8S_UPSTREAM_DISTRIBUTION: ${{ inputs.upstream_cluster_distribution }}
       # For K8s cluster to provision with Rancher Manager
       K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
+      # For Rancher Manager
+      RANCHER_VERSION: ${{ inputs.rancher_version }}
+      TIMEOUT_SCALE: 3
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -268,6 +275,9 @@ jobs:
           PUBLIC_DOMAIN: bc.googleusercontent.com
           TEST_TYPE: ${{ inputs.test_type }}
         run: cd tests && PUBLIC_DNS=${{ needs.create-runner.outputs.public_dns }} make e2e-install-rancher
+      - name: Install backup-restore components (K3s only for now)
+        if: inputs.upstream_cluster_distribution == 'k3s'
+        run: cd tests && make e2e-install-backup-restore
       - name: Extracts component versions/informations
         id: component
         run: |

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -124,10 +124,6 @@ on:
       upgrade_type:
         description: Type of upgrade to use for the Elemental OS upgrade
         type: string
-      upstream_cluster_distribution:
-        description: Cluster upstream distribution where to install Rancher (K3s or RKE2)
-        default: k3s
-        type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
         default: v1.25.7+k3s1
@@ -212,14 +208,14 @@ jobs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: fleet-default
       CLUSTER_TYPE: ${{ inputs.cluster_type }}
-    # K3S / RKE2 flags to use for installation
+      # K3S / RKE2 flags to use for installation
       INSTALL_K3S_EXEC: ${{ inputs.k3s_flags }}
       INSTALL_K3S_SKIP_ENABLE: true
       INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
       INSTALL_RKE2_VERSION: ${{ inputs.upstream_cluster_version }}
       K3S_KUBECONFIG_MODE: 0644
       # Distribution to use to host Rancher Manager (K3s or RKE2)
-      K8S_UPSTREAM_DISTRIBUTION: ${{ inputs.upstream_cluster_distribution }}
+      K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
       # For K8s cluster to provision with Rancher Manager
       K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
       # For Rancher Manager
@@ -276,7 +272,7 @@ jobs:
           TEST_TYPE: ${{ inputs.test_type }}
         run: cd tests && PUBLIC_DNS=${{ needs.create-runner.outputs.public_dns }} make e2e-install-rancher
       - name: Install backup-restore components (K3s only for now)
-        if: inputs.upstream_cluster_distribution == 'k3s'
+        if: contains(inputs.upstream_cluster_version, 'k3s')
         run: cd tests && make e2e-install-backup-restore
       - name: Extracts component versions/informations
         id: component

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -42,5 +42,4 @@ jobs:
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upstream_cluster_distribution: rke2
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -3,8 +3,9 @@ name: UI-RKE2-OS-Upgrade-Rancher_Latest
 # We test upgrade with: 
 # - Iso stable to dev
 # - Elemental-operator dev
+# - RKE2 as management node
+# - Rancher latest devel
 #
-# Main reason of dev operator is to test ISO building.
 # Later it will be moved to main scenario when we will be able to choose the ISO
 # because for now, we can only build ISO with stable ISO
 on:
@@ -41,3 +42,5 @@ jobs:
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upstream_cluster_distribution: rke2
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -48,5 +48,4 @@ jobs:
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upstream_cluster_distribution: rke2
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -1,5 +1,13 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-RKE2-OS-Upgrade-Rancher_Stable
+# We test upgrade with: 
+# - Iso stable to dev
+# - Elemental-operator stable
+# - RKE2 as management node
+# - Rancher latest stable
+#
+# Later it will be moved to main scenario when we will be able to choose the ISO
+# because for now, we can only build ISO with stable ISO
 
 on:
   workflow_dispatch:
@@ -33,9 +41,12 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upstream_cluster_distribution: rke2
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,7 @@ e2e-get-logs: deps
 	ginkgo --label-filter logs -r -v ./e2e
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e
+e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
 e2e-ui-rancher: deps
 	ginkgo --label-filter ui -r -v ./e2e

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -40,7 +40,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 	localKubeconfig := os.Getenv("HOME") + "/.kube/config"
 
 	It("Install Rancher Manager", func() {
-		if k8sUpstreamDistribution == "rke2" {
+		if strings.Contains(k8sUpstreamVersion, "rke2") {
 			By("Installing RKE2", func() {
 				// Get RKE2 installation script
 				fileName := "rke2-install.sh"

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -52,38 +52,38 @@ const (
 )
 
 var (
-	arch                    string
-	backupRestoreVersion    string
-	caType                  string
-	CertManagerVersion      string
-	clusterName             string
-	clusterNS               string
-	clusterType             string
-	elementalSupport        string
-	emulateTPM              bool
-	rancherHostname         string
-	imageVersion            string
-	isoBoot                 string
-	k8sVersion              string
-	k8sUpstreamDistribution string
-	numberOfVMs             int
-	operatorUpgrade         string
-	operatorVersion         string
-	osImage                 string
-	poolType                string
-	proxy                   string
-	rancherChannel          string
-	rancherLogCollector     string
-	rancherVersion          string
-	sequential              bool
-	testType                string
-	upgradeChannelList      string
-	upgradeImage            string
-	upgradeOsChannel        string
-	upgradeType             string
-	usedNodes               int
-	vmIndex                 int
-	vmName                  string
+	arch                 string
+	backupRestoreVersion string
+	caType               string
+	CertManagerVersion   string
+	clusterName          string
+	clusterNS            string
+	clusterType          string
+	elementalSupport     string
+	emulateTPM           bool
+	rancherHostname      string
+	imageVersion         string
+	isoBoot              string
+	k8sUpstreamVersion   string
+	k8sVersion           string
+	numberOfVMs          int
+	operatorUpgrade      string
+	operatorVersion      string
+	osImage              string
+	poolType             string
+	proxy                string
+	rancherChannel       string
+	rancherLogCollector  string
+	rancherVersion       string
+	sequential           bool
+	testType             string
+	upgradeChannelList   string
+	upgradeImage         string
+	upgradeOsChannel     string
+	upgradeType          string
+	usedNodes            int
+	vmIndex              int
+	vmName               string
 )
 
 func CheckClusterState(ns, cluster string) {
@@ -147,7 +147,7 @@ var _ = BeforeSuite(func() {
 	rancherHostname = os.Getenv("PUBLIC_DNS")
 	index := os.Getenv("VM_INDEX")
 	isoBoot = os.Getenv("ISO_BOOT")
-	k8sUpstreamDistribution = os.Getenv("K8S_UPSTREAM_DISTRIBUTION")
+	k8sUpstreamVersion = os.Getenv("K8S_UPSTREAM_VERSION")
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	number := os.Getenv("VM_NUMBERS")
 	operatorUpgrade = os.Getenv("OPERATOR_UPGRADE")

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -52,37 +52,38 @@ const (
 )
 
 var (
-	arch                 string
-	backupRestoreVersion string
-	caType               string
-	CertManagerVersion   string
-	clusterName          string
-	clusterNS            string
-	clusterType          string
-	elementalSupport     string
-	emulateTPM           bool
-	rancherHostname      string
-	imageVersion         string
-	isoBoot              string
-	k8sVersion           string
-	numberOfVMs          int
-	operatorUpgrade      string
-	operatorVersion      string
-	osImage              string
-	poolType             string
-	proxy                string
-	rancherChannel       string
-	rancherLogCollector  string
-	rancherVersion       string
-	sequential           bool
-	testType             string
-	upgradeChannelList   string
-	upgradeImage         string
-	upgradeOsChannel     string
-	upgradeType          string
-	usedNodes            int
-	vmIndex              int
-	vmName               string
+	arch                    string
+	backupRestoreVersion    string
+	caType                  string
+	CertManagerVersion      string
+	clusterName             string
+	clusterNS               string
+	clusterType             string
+	elementalSupport        string
+	emulateTPM              bool
+	rancherHostname         string
+	imageVersion            string
+	isoBoot                 string
+	k8sVersion              string
+	k8sUpstreamDistribution string
+	numberOfVMs             int
+	operatorUpgrade         string
+	operatorVersion         string
+	osImage                 string
+	poolType                string
+	proxy                   string
+	rancherChannel          string
+	rancherLogCollector     string
+	rancherVersion          string
+	sequential              bool
+	testType                string
+	upgradeChannelList      string
+	upgradeImage            string
+	upgradeOsChannel        string
+	upgradeType             string
+	usedNodes               int
+	vmIndex                 int
+	vmName                  string
 )
 
 func CheckClusterState(ns, cluster string) {
@@ -146,6 +147,7 @@ var _ = BeforeSuite(func() {
 	rancherHostname = os.Getenv("PUBLIC_DNS")
 	index := os.Getenv("VM_INDEX")
 	isoBoot = os.Getenv("ISO_BOOT")
+	k8sUpstreamDistribution = os.Getenv("K8S_UPSTREAM_DISTRIBUTION")
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	number := os.Getenv("VM_NUMBERS")
 	operatorUpgrade = os.Getenv("OPERATOR_UPGRADE")


### PR DESCRIPTION
Fix #830 

## Verification runs
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4989183710) :heavy_check_mark: 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4989576107) ❌ - issue not related to this PR.

[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4989185301) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Latest ](https://github.com/rancher/elemental/actions/runs/4989186096) :heavy_check_mark: 

[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/4989186998) :heavy_check_mark: 
[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/4989188001) :heavy_check_mark: 

[CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/4989866835) :heavy_check_mark: 
[CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/4990358499) :heavy_check_mark: 