### PR TITLE
Enable cloud-config from removable devices

### DIFF
--- a/framework/files/system/oem/02_datasources.yaml
+++ b/framework/files/system/oem/02_datasources.yaml
@@ -1,0 +1,6 @@
+name: "Elemental cloud-config from a removable device"
+stages:
+  initramfs:
+  - datasource:
+      providers: ["cdrom"]
+      path: "/oem"


### PR DESCRIPTION
If cloud-init data is provided as the `user-data` file in an eligible device this data is copied to both `/oem/userdata.yaml` and `/oem/userdata`. Since `/oem` is an analyzed path for custom cloud-init files this will be taken into accound on later `elemental run-stage` calls.