### PR TITLE
Ensure names are unique for all stages

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -51,7 +51,7 @@ stages:
         PERSISTENT_STATE_BIND: "true"
     - if: '[ -f "/run/cos/recovery_mode" ]'
       # omit the persistent partition on recovery mode
-      name: "Layout configuration"
+      name: "Layout configuration for recovery"
       environment_file: /run/cos/cos-layout.env
       environment:
         OVERLAY: "tmpfs:25%"


### PR DESCRIPTION
We are suffering from a small yip regression. Since v1.0.0 yip uses a DAG (Directed Acyclic Graph) to _sort_ and relate all the required executions, allowing parallel executions (we have not played with it so far). However one of the side effects is that the dag structures items in a map internally using the step name if provided, hence having two steps with the same name causes the step overwrite.

Exactly this is what is happening in the layout setup, we have two steps for that (recovery and non recovery) with the same name, so one of the two gets ignored...

Fixes #829