### PR TITLE
ci/ui: use RKE2 as upstream cluster for all RKE2 UI tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -311,6 +311,8 @@ jobs:
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           ISO_BOOT: ${{ inputs.iso_boot }}
+          ISO_TO_TEST: ${{ inputs.iso_to_test }}
+          K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
           OPERATOR_VERSION: ${{ inputs.operator_version }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
@@ -321,6 +323,7 @@ jobs:
             /workdir/e2e/unit_tests/user.spec.ts
             /workdir/e2e/unit_tests/menu.spec.ts
             /workdir/e2e/unit_tests/machine_registration.spec.ts
+            /workdir/e2e/unit_tests/seed_image.spec.ts
             /workdir/e2e/unit_tests/advanced_filtering.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
         run: cd tests && make start-cypress-tests

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -28,8 +28,10 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
+      iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-obs_stable.yaml
+++ b/.github/workflows/ui-rke2-obs_stable.yaml
@@ -32,8 +32,10 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -28,8 +28,10 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
+      iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -42,6 +42,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
+      iso_boot: true
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+rke2r1
       operator_version: ${{ inputs.operator_version }}
@@ -51,3 +52,4 @@ jobs:
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-rancher_latest.yaml
@@ -30,6 +30,9 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_boot: true
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-rancher_stable.yaml
@@ -33,6 +33,9 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_boot: true
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -1,0 +1,52 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { TopLevelMenu } from '~/support/toplevelmenu';
+import '~/support/functions';
+import filterTests from '~/support/filterTests.js';
+
+Cypress.config();
+describe('SeedImage testing', () => {
+  const isoToTest     = Cypress.env('iso_to_test');
+  const seedImageFile = "myseedimage.yaml"
+  const topLevelMenu  = new TopLevelMenu();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+
+    // Open the navigation menu
+    topLevelMenu.openIfClosed();
+  });
+
+  filterTests(['main'], () => {
+    it('Create SeedImage with custom base image', () => {
+      if (typeof isoToTest !== 'undefined') {
+        cy.exec(`sed -i "s|baseImage:.*|baseImage: ${isoToTest}|g" fixtures/${seedImageFile}`);
+      }
+        cy.contains('local')
+        .click();
+      cy.get('.header-buttons > :nth-child(1)')
+        .click();
+      cy.clickButton('Read from File');
+      cy.get('input[type="file"]')
+        .attachFile({filePath: seedImageFile});
+      cy.clickButton('Import');
+      cy.get('.badge-state')
+        .contains('Active');
+      cy.clickButton('Close');
+      cy.exec('ls');
+    });
+  });
+});

--- a/tests/cypress/latest/fixtures/myseedimage.yaml
+++ b/tests/cypress/latest/fixtures/myseedimage.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: mycustomseedimage
+  namespace: fleet-default
+spec:
+  baseImage: %BASE_IMAGE_URL%
+  cloud-config:
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: machine-registration
+    namespace: fleet-default
+

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -31,6 +31,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.cluster              = process.env.CLUSTER_NAME;
   config.env.cypress_tags         = process.env.CYPRESS_TAGS;
   config.env.elemental_ui_version = process.env.ELEMENTAL_UI_VERSION;
+  config.env.iso_to_test          = process.env.ISO_TO_TEST;
   config.env.k8s_version          = process.env.K8S_VERSION_TO_PROVISION;
   config.env.operator_version     = process.env.OPERATOR_VERSION;
   config.env.password             = process.env.RANCHER_PASSWORD;

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -2,6 +2,8 @@
 
 set -evx
 
+ELEMENTAL_ISO="/home/gh-runner/actions-runner/_work/elemental/elemental/elemental-from-cypress.iso"
+
 # Start a simple HTTP server for sharing some config files
 HTTP_SRV_CMD="python3 -m http.server"
 pushd ..
@@ -15,15 +17,17 @@ npm install
 
 # Start Cypress tests with docker
 docker run -v $PWD:/workdir -w /workdir                     \
-    -e RANCHER_USER=$RANCHER_USER                           \
+    -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
+    -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION           \
+    -e ISO_TO_TEST=$ISO_TO_TEST                             \
+    -e K8S_UPSTREAM_VERSION=$K8S_UPSTREAM_VERSION           \
+    -e K8S_VERSION_TO_PROVISION=$K8S_VERSION_TO_PROVISION   \
+    -e OPERATOR_VERSION=$OPERATOR_VERSION                   \
+    -e PROXY=$PROXY                                         \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
     -e RANCHER_URL=$RANCHER_URL                             \
-    -e K8S_VERSION_TO_PROVISION=$K8S_VERSION_TO_PROVISION   \
+    -e RANCHER_USER=$RANCHER_USER                           \
     -e UI_ACCOUNT=$UI_ACCOUNT                               \
-    -e OPERATOR_VERSION=$OPERATOR_VERSION                   \
-    -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION           \
-    -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
-    -e PROXY=$PROXY                                         \
     -e UPGRADE_CHANNEL_LIST=$UPGRADE_CHANNEL_LIST           \
     -e UPGRADE_IMAGE=$UPGRADE_IMAGE                         \
     --add-host host.docker.internal:host-gateway            \
@@ -34,10 +38,19 @@ docker run -v $PWD:/workdir -w /workdir                     \
 [[ -d downloads ]] && sudo chown -R gh-runner:users downloads videos
 
 # Move elemental.iso into the expected folder
-if [[ ${ISO_BOOT} == "true" ]]; then
-    mv downloads/*.iso ../../../elemental-from-cypress.iso
+if [[ ! -f ${ELEMENTAL_ISO} ]]; then
+  # Upgrade scenario
+  # We start from stable ISO built within RegistrationEndpoint menu
+  # Because we have to test the download feature but we can only build from stable for now
+  if [[ ${CYPRESS_TAGS} == "upgrade" ]]; then
+    mv downloads/*.iso ${ELEMENTAL_ISO}
+  # RKE2 as upstream cluster
+  # We cannot use PXE boot so we have to boot from ISO but we cannot use stable ISO
+  # We need to use a custom ISO and the menu doesn't allow to do it now.
+  elif grep rke <<< ${K8S_UPSTREAM_VERSION}; then
+    wget $(kubectl get seedimage mycustomseedimage -n fleet-default -o=jsonpath='{.status.downloadURL}') --no-check-certificate -O ${ELEMENTAL_ISO}
+  fi
 fi
-
 popd
 
 # Kill the HTTP server


### PR DESCRIPTION
Second part of https://github.com/rancher/elemental/issues/648

## Verification runs
[UI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5003093027) :heavy_check_mark: 
[UI-RKE2-OBS_Stable](https://github.com/rancher/elemental/actions/runs/5003093868) ❌ (not related to this PR, rancher 2.7.5-rc1)
[UI-RKE2-OBS_Staging](https://github.com/rancher/elemental/actions/runs/5003950318) :clock1: 

[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5003095047) :heavy_check_mark: 
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5003104304) :heavy_check_mark: 

[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5003680585) :heavy_check_mark: 
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5003682638) :heavy_check_mark: