### PR TITLE
ci: increase timeout for the scalability CI test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,7 +15,7 @@ export CLOUD_INIT_ISO?=$(ROOT_DIR)/build/ci.iso
 # Define Ginkgo timeout for the bootstrapping test
 GINKGO_TIMEOUT?=3600
 ifdef VM_NUMBERS
-	ifeq ($(shell expr $(VM_NUMBERS) \> 100), 1)
+	ifeq ($(shell expr $(VM_NUMBERS) \> 80), 1)
 		GINKGO_TIMEOUT=6000
 	endif
 endif


### PR DESCRIPTION
The weekly CI test is failing regularly with a timeout after 1h, so it could be good to increase it.