### PR TITLE
ci: install CRDs chart for operator when needed

### DIFF
--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -34,5 +34,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_stable.yaml
+++ b/.github/workflows/cli-k3s-obs_stable.yaml
@@ -34,5 +34,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -34,5 +34,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -22,8 +22,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -22,8 +22,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -40,8 +40,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+k3s1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -23,9 +23,9 @@ on:
         description: Number of nodes (>3) to deploy on the provisioned cluster
         default: 5
         type: number
-      operator_version:
-        description: Elemental operator version to use
-        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_repo:
+        description: Elemental operator repository to use
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
         type: string
       rancher_version:
         description: Rancher Manager channel/version to use for installation
@@ -59,7 +59,7 @@ jobs:
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
       node_number: ${{ inputs.node_number }}
-      operator_version: ${{ inputs.operator_version }}
+      operator_repo: ${{ inputs.operator_repo }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -31,6 +31,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-obs_stable.yaml
+++ b/.github/workflows/cli-rke2-obs_stable.yaml
@@ -31,6 +31,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -31,6 +31,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -23,8 +23,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -23,8 +23,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -41,8 +41,8 @@ jobs:
       k8s_version_to_provision: v1.25.7+rke2r1
       # Force to only deploy the first 3 nodes
       node_number: 3
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher/elemental-operator-chart
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -71,13 +71,13 @@ on:
         description: Number of nodes to deploy on the provisioned cluster
         default: 5
         type: string
+      operator_repo:
+        description: Elemental operator repository to use
+        type: string
+        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_upgrade:
         description: Elemental operator version to upgrade to
         type: string
-      operator_version:
-        description: Elemental operator version to use
-        type: string
-        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
       proxy:
         description: Deploy a proxy
         type: string
@@ -263,7 +263,7 @@ jobs:
       - name: Install Rancher+Elemental components
         env:
           CA_TYPE: ${{ inputs.ca_type }}
-          OPERATOR_VERSION: ${{ inputs.operator_version }}
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
           PROXY: ${{ inputs.proxy }}
           PUBLIC_DOMAIN: bc.googleusercontent.com
           TEST_TYPE: ${{ inputs.test_type }}
@@ -317,7 +317,7 @@ jobs:
           ISO_BOOT: ${{ inputs.iso_boot }}
           ISO_TO_TEST: ${{ inputs.iso_to_test }}
           K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
-          OPERATOR_VERSION: ${{ inputs.operator_version }}
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
           RANCHER_USER: admin
@@ -368,7 +368,7 @@ jobs:
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
-          OPERATOR_VERSION: ${{ inputs.operator_version }}
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
           PROXY: ${{ inputs.proxy }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ needs.create-runner.outputs.public_dns }}/dashboard
@@ -492,6 +492,8 @@ jobs:
           BACKUP_RESTORE_VERSION: ${{ inputs.backup_restore_version }}
         run: cd tests && make e2e-backup-restore
       - name: Uninstall Elemental Operator
+        env:
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
         # Don't test Operator uninstall if we want to keep the runner for debugging purposes
         if: inputs.destroy_runner == true && inputs.test_type == 'cli'
         run: |

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -32,7 +32,7 @@ jobs:
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_stable.yaml
+++ b/.github/workflows/ui-k3s-obs_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -32,7 +32,7 @@ jobs:
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -12,9 +12,9 @@ on:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
         type: string
-      operator_version:
-        description: Elemental operator version to use
-        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo:
+        description: Elemental operator repository to use
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -43,7 +43,7 @@ jobs:
       elemental_ui_version: dev
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+k3s1
-      operator_version: ${{ inputs.operator_version }}
+      operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -31,7 +31,7 @@ jobs:
       iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-obs_stable.yaml
+++ b/.github/workflows/ui-rke2-obs_stable.yaml
@@ -35,7 +35,7 @@ jobs:
       iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -31,7 +31,7 @@ jobs:
       iso_boot: true
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -43,7 +43,7 @@ jobs:
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -12,9 +12,9 @@ on:
         description: ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
         type: string
-      operator_version:
-        description: Elemental operator version to use
-        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher/elemental-operator-chart
+      operator_repo:
+        description: Elemental operator repository to use
+        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -45,7 +45,7 @@ jobs:
       iso_boot: true
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_version: ${{ inputs.operator_version }}
+      operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -68,7 +68,7 @@ var (
 	k8sVersion           string
 	numberOfVMs          int
 	operatorUpgrade      string
-	operatorVersion      string
+	operatorRepo         string
 	osImage              string
 	poolType             string
 	proxy                string
@@ -151,7 +151,7 @@ var _ = BeforeSuite(func() {
 	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	number := os.Getenv("VM_NUMBERS")
 	operatorUpgrade = os.Getenv("OPERATOR_UPGRADE")
-	operatorVersion = os.Getenv("OPERATOR_VERSION")
+	operatorRepo = os.Getenv("OPERATOR_REPO")
 	poolType = os.Getenv("POOL")
 	proxy = os.Getenv("PROXY")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -15,6 +15,8 @@ limitations under the License.
 package e2e_test
 
 import (
+	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,11 +49,26 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 		})
 
 		By("Uninstalling Operator via Helm", func() {
-			err := kubectl.RunHelmBinaryWithCustomErr(
-				"uninstall", "elemental-operator",
-				"--namespace", "cattle-elemental-system",
-			)
-			Expect(err).To(Not(HaveOccurred()))
+			for _, chart := range []string{"elemental-operator", "elemental-operator-crds"} {
+				if strings.Contains(chart, "-crds") {
+					// Check if CRDs chart is available (not always the case in older versions)
+					chartList, err := exec.Command("helm",
+						"list",
+						"--no-headers",
+						"--namespace", "cattle-elemental-system",
+					).CombinedOutput()
+					Expect(err).To(Not(HaveOccurred()))
+
+					if !strings.Contains(string(chartList), chart) {
+						continue
+					}
+				}
+				err := kubectl.RunHelmBinaryWithCustomErr(
+					"uninstall", chart,
+					"--namespace", "cattle-elemental-system",
+				)
+				Expect(err).To(Not(HaveOccurred()))
+			}
 		})
 
 		By("Testing cluster resource availability AFTER operator uninstallation", func() {
@@ -84,15 +101,24 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 	It("Re-install Elemental Operator", func() {
 		By("Installing Operator via Helm", func() {
-			operatorChart := "oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart"
-			err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", "elemental-operator",
-				operatorChart,
-				"--namespace", "cattle-elemental-system",
-				"--create-namespace",
-			)
-			Expect(err).To(Not(HaveOccurred()))
+			for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
+				// Check if CRDs chart is available (not always the case in older versions)
+				// Anyway, if it is needed and missing the next chart installation will fail too
+				if strings.Contains(chart, "-crds") {
+					noChart := kubectl.RunHelmBinaryWithCustomErr("show", "readme", operatorRepo+"/"+chart+"-chart")
+					if noChart != nil {
+						continue
+					}
+				}
+				err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart,
+					operatorRepo+"/"+chart+"-chart",
+					"--namespace", "cattle-elemental-system",
+					"--create-namespace",
+				)
+				Expect(err).To(Not(HaveOccurred()))
+			}
 
-			err = k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")
+			err := k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")
 			Expect(err).To(Not(HaveOccurred()))
 		})
 


### PR DESCRIPTION
Elemental Operator chart has been split, so newer versions should install all charts.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5092311471)
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5091386989)
- [UI-K3s-OBS_Stable](https://github.com/rancher/elemental/actions/runs/5091802366)