### PR TITLE
ci/ui: fix upgrade tests

### DIFF
--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -38,6 +38,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       iso_boot: true
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -36,6 +36,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -167,7 +167,7 @@ describe('Machine registration testing', () => {
       cy.createMachReg({machRegName: 'machine-registration',
         checkInventoryLabels: true,
         checkInventoryAnnotations: true,
-        checkIsoBuilding: true,
+        checkIsoBuilding: false,
         customCloudConfig: 'custom_cloud-config.yaml',
         checkDefaultCloudConfig: false});
       cy.checkMachInvLabel({machRegName: 'machine-registration',

--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -30,23 +30,21 @@ describe('SeedImage testing', () => {
     topLevelMenu.openIfClosed();
   });
 
-  filterTests(['main'], () => {
-    it('Create SeedImage with custom base image', () => {
-      if (typeof isoToTest !== 'undefined') {
-        cy.exec(`sed -i "s|baseImage:.*|baseImage: ${isoToTest}|g" fixtures/${seedImageFile}`);
-      }
-        cy.contains('local')
-        .click();
-      cy.get('.header-buttons > :nth-child(1)')
-        .click();
-      cy.clickButton('Read from File');
-      cy.get('input[type="file"]')
-        .attachFile({filePath: seedImageFile});
-      cy.clickButton('Import');
-      cy.get('.badge-state')
-        .contains('Active');
-      cy.clickButton('Close');
-      cy.exec('ls');
-    });
+  it('Create SeedImage with custom base image', () => {
+    if (typeof isoToTest !== 'undefined') {
+      cy.exec(`sed -i "s|baseImage:.*|baseImage: ${isoToTest}|g" fixtures/${seedImageFile}`);
+    }
+      cy.contains('local')
+      .click();
+    cy.get('.header-buttons > :nth-child(1)')
+      .click();
+    cy.clickButton('Read from File');
+    cy.get('input[type="file"]')
+      .attachFile({filePath: seedImageFile});
+    cy.clickButton('Import');
+    cy.get('.badge-state')
+      .contains('Active');
+    cy.clickButton('Close');
+    cy.exec('ls');
   });
 });

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -23,9 +23,7 @@ describe('Upgrade tests', () => {
   const channelName              = "mychannel"
   const clusterName              = "mycluster"
   const checkK3s: RegExp         = /k3s/
-  const checkStable: RegExp      = /stable/g
   const elemental                = new Elemental();
-  const elementalOperatorVersion = Cypress.env('operator_version')
   const elementalUser            = "elemental-user"
   const k8sVersion               = Cypress.env('k8s_version')
   const topLevelMenu             = new TopLevelMenu();
@@ -66,9 +64,6 @@ describe('Upgrade tests', () => {
 
     it('Check OS Versions', () => {
       let osVersionsTab = ["Active dev", "Active dev-rt", "Active stable", "Active stable-rt", "Active staging", "Active staging-rt"]
-      if (!checkStable.test(elementalOperatorVersion)) {
-        osVersionsTab.push("Active latest-dev");
-      };
       cy.clickNavMenu(["Advanced", "OS Versions"]);
       for (let i = 0; i < osVersionsTab.length; i++) {
         cy.contains(osVersionsTab[i], {timeout: 120000});

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -84,7 +84,7 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 
 		By("Creating and installing VM", func() {
 			// Install VM
-			out, err := exec.Command(installVMScript, vmName, macAdrs).CombinedOutput()
+			out, err := exec.Command(installVMScript, vmName, macAdrs, "UI").CombinedOutput()
 			GinkgoWriter.Printf("%s\n", out)
 			Expect(err).To(Not(HaveOccurred()))
 		})

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -9,7 +9,8 @@ ARCH=$(uname -m)
 FW_CODE=/usr/share/qemu/ovmf-${ARCH}-smm-suse-code.bin
 FW_VARS=$(realpath ../assets/ovmf-template-vars.fd)
 EMULATED_TPM="none"
-VM_MEM=3072
+# Give more memory to VM if UI is tested (only one VM for now)
+[[ $3 == "UI" ]] && VM_MEM=8192 || VM_MEM=3072
 
 # Configure hugepages if needed
 NR_HUGEPAGES=$(</proc/sys/vm/nr_hugepages)

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -40,14 +40,15 @@ docker run -v $PWD:/workdir -w /workdir                     \
 # Move elemental.iso into the expected folder
 if [[ ! -f ${ELEMENTAL_ISO} ]]; then
   # Upgrade scenario
-  # We start from stable ISO built within RegistrationEndpoint menu
-  # Because we have to test the download feature but we can only build from stable for now
-  if [[ ${CYPRESS_TAGS} == "upgrade" ]]; then
-    mv downloads/*.iso ${ELEMENTAL_ISO}
+  # We need to build the ISO with stable base image
+  # It can not be done from the UI for now
+  
   # RKE2 as upstream cluster
   # We cannot use PXE boot so we have to boot from ISO but we cannot use stable ISO
   # We need to use a custom ISO and the menu doesn't allow to do it now.
-  elif grep rke <<< ${K8S_UPSTREAM_VERSION}; then
+  if [[ ${CYPRESS_TAGS} == "upgrade" ]] || grep rke <<< ${K8S_UPSTREAM_VERSION}; then
+    # Wait a bit to let the ISO be built (could be improved)
+    sleep 180
     wget $(kubectl get seedimage mycustomseedimage -n fleet-default -o=jsonpath='{.status.downloadURL}') --no-check-certificate -O ${ELEMENTAL_ISO}
   fi
 fi


### PR DESCRIPTION
Fix #851

## Verification runs
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5138039358/jobs/9246928859) ✔️ 
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5143153835/jobs/9257833216) ✔️ 

[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5141983111/jobs/9255161667) ✔️ 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5144147327/jobs/9260086806) ✔️ 

[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5143920162/jobs/9259557697) ✔️ 
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5141262343/jobs/9253568692) ✔️ 

I also added more memory to the VM if we test UI, tests look more reliable and it does not impact anything because we use only one VM in UI tests.