### PR TITLE
ci: use rancher head version instead of rc version

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -225,7 +225,15 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			// Set specified version if needed
 			if rancherVersion != "" && rancherVersion != "latest" {
 				if rancherVersion == "devel" {
-					flags = append(flags, "--devel")
+					flags = append(flags,
+						"--devel",
+						"--set", "rancherImageTag=v2.7-head",
+					)
+				} else if strings.Contains(rancherVersion, "-rc") {
+					flags = append(flags,
+						"--devel",
+						"--version", rancherVersion,
+					)
 				} else {
 					flags = append(flags, "--version", rancherVersion)
 				}


### PR DESCRIPTION
Fix #720 

In the CI, we don't really test latest rancher version but release candidate version. 
It could be better to test latest updates, that's why we want to test `v2.7-head` by default.

### Older behavior
When we set `rancherVersion` to `latest/devel`, it installed latest rc version.

### New behavior
With `rancherVersion` equal to `latest/devel`, we install the head version (by default)
With `rancherVersion` equal to `latest/2.7.5-rc3`, we install 2.7.5 release candidate 3

PS: The head version is hardcoded but I don't know if we can make it better without adding a new variable, could be improve later.

## Verification runs
- With `rancherVersion` set to `latest/2.7.5-rc3` https://github.com/rancher/elemental/actions/runs/5141439434/jobs/9253956631
I checked the pod image and it was ok:
```
  containers:
  - args:
    - --http-listen-port=80
    - --https-listen-port=443
    - --add-local=true
    env:
    - name: CATTLE_NAMESPACE
      value: cattle-system
    - name: CATTLE_PEER_SERVICE
      value: rancher
    - name: CATTLE_SERVER_URL
      value: https://84.203.173.34.bc.googleusercontent.com
    - name: CATTLE_BOOTSTRAP_PASSWORD
      value: rancherpassword
    image: rancher/rancher:v2.7.5-rc3
```

[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5142374019/jobs/9256055544): failed because there is a login issue with `v2.7.5-rc3` but the logic is ok.

- With `rancherVersion` set to `latest/devel` (default choice)
https://github.com/rancher/elemental/actions/runs/5142244935/jobs/9255751656
```
  containers:
  - args:
    - --http-listen-port=80
    - --https-listen-port=443
    - --add-local=true
    env:
    - name: CATTLE_NAMESPACE
      value: cattle-system
    - name: CATTLE_PEER_SERVICE
      value: rancher
    - name: CATTLE_SERVER_URL
      value: https://64.144.192.35.bc.googleusercontent.com
    - name: CATTLE_BOOTSTRAP_PASSWORD
      value: rancherpassword
    image: rancher/rancher:v2.7-head
```

[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5142369351/jobs/9256046548): we can see that  v2.7-head was used.