### PR TITLE
ci/ui: change deployed app to fix namespace issue

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -26,7 +26,7 @@ filterTests(['main'], () => {
       cy.visit('/');
     });
     
-    it('Deploy CIS Benchmark application', () => {
+    it('Deploy Alerting Drivers application', () => {
       topLevelMenu.openIfClosed();
       cy.contains(clusterName)
         .click();
@@ -34,18 +34,19 @@ filterTests(['main'], () => {
         .click();
       cy.contains('Charts')
         .click();
-      cy.contains('CIS Benchmark')
+      cy.contains('Alerting Drivers')
         .click();
-      cy.contains('.name-logo-install', 'CIS Benchmark', {timeout:20000});
+      cy.contains('.name-logo-install', 'Alerting Drivers', {timeout:20000});
       cy.clickButton('Install');
+      cy.contains('.outer-container > .header', 'Alerting Drivers');
       cy.clickButton('Next');
       cy.clickButton('Install');
-      cy.contains('SUCCESS: helm upgrade', {timeout:30000});
+      cy.contains('SUCCESS: helm install', {timeout:30000});
       cy.reload;
-      cy.contains('CIS Benchmark');
+      cy.contains('Deployed rancher-alerting-drivers');
     });
   
-    it('Remove CIS Benchmark application', () => {
+    it('Remove Alerting Drivers application', () => {
       topLevelMenu.openIfClosed();
       cy.contains(clusterName)
         .click();
@@ -54,19 +55,12 @@ filterTests(['main'], () => {
       cy.contains('Installed Apps')
         .click();
       cy.contains('.title', 'Installed Apps', {timeout:20000});
-      cy.get('.ns-dropdown > .icon')
-        .click()
-        .type('cis-operator');
-      cy.contains('cis-operator')
-        .click();
-      cy.get('.ns-dropdown > .icon-chevron-up')
-        .click();
       cy.get('[width="30"] > .checkbox-outer-container')
         .click();
       cy.clickButton('Delete');
       cy.confirmDelete();
       cy.contains('SUCCESS: helm uninstall', {timeout:30000});
-      cy.contains('.apps', 'CIS Benchmark')
+      cy.contains('.apps', 'rancher-alerting-drivers')
         .should('not.exist');
     });
   });


### PR DESCRIPTION
This PR switches the app which is deployed at the end of tests, it deploys the Alerting Drivers app in the default namespace instead of the CIS benchmark in the system namespace.

## Verification run

[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5181607408/jobs/9337359486) ✔️ 
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5185192299) ✔️ 

![image](https://github.com/rancher/elemental/assets/6025636/842fc2f3-78c7-4b25-9205-96c200f9c2d8)

