### PR TITLE
ci: add missing DynamicSchemas if needed

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -25,7 +25,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -25,7 +25,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: stable/latest
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -43,7 +43,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -26,7 +26,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -26,7 +26,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: stable/latest
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -44,7 +44,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-8-v4
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -268,6 +268,13 @@ jobs:
           PUBLIC_DOMAIN: bc.googleusercontent.com
           TEST_TYPE: ${{ inputs.test_type }}
         run: cd tests && PUBLIC_DNS=${{ needs.create-runner.outputs.public_dns }} make e2e-install-rancher
+      - name: Workaround for DynamicSchemas (if needed)
+        run: |
+          # Check if DynamicSchemas for MachineInventorySelectorTemplate exists
+          if ! kubectl get dynamicschema machineinventoryselectortemplate >/dev/null 2>&1; then
+            # If not we have to add it to avoid weird issues!
+            kubectl apply -f tests/assets/add_missing_dynamicschemas.yaml
+          fi
       - name: Install backup-restore components (K3s only for now)
         if: contains(inputs.upstream_cluster_version, 'k3s')
         run: cd tests && make e2e-install-backup-restore

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -359,7 +359,8 @@ jobs:
         env:
           ISO_BOOT: ${{ inputs.iso_boot }} 
           VM_INDEX: 1
-          HOST_MEMORY_RESERVED: 50331648
+          VM_MEM: 8192
+          HOST_MEMORY_RESERVED: 49152
         run: |
           cd tests && (
             # Removing 'downloads' is needed to avoid this error during 'make':
@@ -413,6 +414,7 @@ jobs:
         env:
           EMULATE_TPM: true
           POOL: master
+          VM_MEM: 8192
           VM_START: 1
           VM_END: 3
         run: |
@@ -478,6 +480,7 @@ jobs:
         env:
           ISO_BOOT: true
           POOL: worker
+          VM_MEM: 8192
           VM_START: 4
           VM_END: ${{ inputs.node_number }}
         run: |

--- a/tests/assets/add_missing_dynamicschemas.yaml
+++ b/tests/assets/add_missing_dynamicschemas.yaml
@@ -1,0 +1,6 @@
+apiVersion: management.cattle.io/v3
+kind: DynamicSchema
+metadata:
+  labels:
+    cattle.io/creator: norman
+  name: machineinventoryselectortemplate

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -84,7 +84,7 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 
 		By("Creating and installing VM", func() {
 			// Install VM
-			out, err := exec.Command(installVMScript, vmName, macAdrs, "UI").CombinedOutput()
+			out, err := exec.Command(installVMScript, vmName, macAdrs).CombinedOutput()
 			GinkgoWriter.Printf("%s\n", out)
 			Expect(err).To(Not(HaveOccurred()))
 		})

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -22,7 +22,7 @@ if (( NR_HUGEPAGES == 0 && USE_HUGEPAGES != 0 )); then
   # Number of hugepages (with hugepagesize set to 2MB)
   # NOTE: keep 24GB by default for the hypervisor/Rancher Manager Server
   # And this value can be modified with HOST_MEMORY_RESERVED variable
-  (( VALUE = (MEMTOTAL_KB - (${HOST_MEMORY_RESERVED:-24576} * 1024) / 2048 ))
+  (( VALUE = (MEMTOTAL_KB - ${HOST_MEMORY_RESERVED:-24576} * 1024) / 2048 ))
 
   # Set nr_hugepage
   (( VALUE > 0 )) \

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -9,8 +9,9 @@ ARCH=$(uname -m)
 FW_CODE=/usr/share/qemu/ovmf-${ARCH}-smm-suse-code.bin
 FW_VARS=$(realpath ../assets/ovmf-template-vars.fd)
 EMULATED_TPM="none"
-# Give more memory to VM if UI is tested (only one VM for now)
-[[ $3 == "UI" ]] && VM_MEM=8192 || VM_MEM=3072
+
+# Set default VM memory if not defined
+[[ -z "${VM_MEM}" ]] && VM_MEM=3072
 
 # Configure hugepages if needed
 NR_HUGEPAGES=$(</proc/sys/vm/nr_hugepages)
@@ -21,7 +22,7 @@ if (( NR_HUGEPAGES == 0 && USE_HUGEPAGES != 0 )); then
   # Number of hugepages (with hugepagesize set to 2MB)
   # NOTE: keep 24GB by default for the hypervisor/Rancher Manager Server
   # And this value can be modified with HOST_MEMORY_RESERVED variable
-  (( VALUE = ((MEMTOTAL_KB - ${HOST_MEMORY_RESERVED:-25165824}) / 2048) ))
+  (( VALUE = (MEMTOTAL_KB - (${HOST_MEMORY_RESERVED:-24576} * 1024) / 2048 ))
 
   # Set nr_hugepage
   (( VALUE > 0 )) \


### PR DESCRIPTION
If DynamicSchemas for MachineInventorySelectorTemplate is missing we have to add it.

See https://github.com/rancher/rancher/issues/41145.

Verification run:
- [CLI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/5198027369)
- [UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5198386013)