### PR TITLE
ci/ui: make sure we are on the extension screen

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -41,6 +41,8 @@ filterTests(['main', 'upgrade'], () => {
       topLevelMenu.openIfClosed();
       cy.contains('Extensions')
         .click();
+      // Make sure we are on the Extensions page
+      cy.contains('.message-icon', 'Extension support is not enabled');
       cy.clickButton('Enable');
       cy.contains('Enable Extension Support?')
       if ( Cypress.env('elemental_ui_version') != "stable") {


### PR DESCRIPTION
Fix #859 

## Verification run
![image](https://github.com/rancher/elemental/assets/6025636/c0835b7f-300d-4075-adbe-bfeee87b0cbf)

[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5197701991) ✔️ 
[UI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5197703014) ✔️ 