### PR TITLE
ci/ui: add label size regression test (#706)

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -144,6 +144,14 @@ describe('Machine registration testing', () => {
       cy.verifyDownload('download-yaml-test.yaml');
     });
 
+    it('Check machine registration label name size', () => {
+      cy.checkLabelSize({sizeToCheck: 'name'});
+    });
+
+    it('Check machine registration label value size', () => {
+      cy.checkLabelSize({sizeToCheck: 'value'});
+    });
+
   // This test must stay the last one because we use this machine registration when we test adding a node.
   // It also tests using a custom cloud config by using read from file button.
     it('Create Machine registration we will use to test adding a node', () => {

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -26,6 +26,7 @@ declare global {
       addMachRegLabel(labelName: string, labelValue: string):Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       checkFilter(filterName: string, testFilterOne: boolean, testFilterTwo: boolean, shouldNotMatch: boolean): Chainable<Element>;
+      checkLabelSize(sizeToCheck: string): Chainable<Element>;
       checkMachInvAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;
       checkMachInvLabel(machRegName: string, labelName: string, labelValue: string, useHardwareLabels: boolean, afterBoot: boolean):Chainable<Element>;
       checkMachRegAnnotation(machRegName: string, annotationName: string, annotationValue: string):Chainable<Element>;

--- a/tests/cypress/latest/support/functions.ts
+++ b/tests/cypress/latest/support/functions.ts
@@ -529,3 +529,21 @@ Cypress.Commands.add('checkFilter', ({
     (testFilterTwo) ? cy.contains('test-filter-two').should('exist') : cy.contains('test-filter-two').should('not.exist');
     (shouldNotMatch) ? cy.contains('shouldnotmatch').should('exist') : cy.contains('shouldnotmatch').should('not.exist');
 });
+
+Cypress.Commands.add('checkLabelSize', ({
+  sizeToCheck}) => {
+    cy.clickNavMenu(["Dashboard"]);
+    cy.getBySel('button-create-registration-endpoint')
+      .click();
+    if (sizeToCheck == "name") {
+      cy.addMachInvLabel({labelName: 'labeltoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', labelValue: 'mylabelvalue', useHardwareLabels: false});
+    } else if (sizeToCheck == "value") {
+      cy.addMachInvLabel({labelName: 'mylabelname', labelValue: 'valuetoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', useHardwareLabels: false});
+    }
+    // A banner should appear alerting you about the size exceeded
+    cy.get('.banner > span');
+    // Create button should be disabled
+    cy.getBySel('form-save').should(($input) => {
+      expect($input).to.have.attr('disabled')
+    })
+});


### PR DESCRIPTION
Fix #706 

The PR tests if we get a warning banner and if the Create button is disabled when we exceed the label max size.
![image](https://github.com/rancher/elemental/assets/6025636/a7f84c91-961b-4f0c-89b6-8ff812ad1d72)
![image](https://github.com/rancher/elemental/assets/6025636/c4312f4f-f406-4c72-aeee-0d9a24f99b87)

## Verification run

Local:
<img width="471" alt="Screenshot 2023-06-07 at 15 00 23" src="https://github.com/rancher/elemental/assets/6025636/2ba91c3e-b751-49d8-9395-80b09317e118">


[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5200304558) ✔️ 
<img width="821" alt="Screenshot 2023-06-07 at 15 26 45" src="https://github.com/rancher/elemental/assets/6025636/157babe6-0d82-4046-89af-db28cf8fe6c9">

