### PR TITLE
ci: reduce number of deployed nodes for scalability test

### DIFF
--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard RKE2"
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
-      node_number: 100
+      node_number: 60
       rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4


### PR DESCRIPTION
As we increased the memory size of VM to 8GB, we have to reduce th number of deployed nodes for the scalability test.

Verification run:
- [CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5204361353)