### PR TITLE
e2e: retry installation of Elemental Operator if needed

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -364,12 +364,13 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 						continue
 					}
 				}
-				err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart,
-					operatorRepo+"/"+chart+"-chart",
-					"--namespace", "cattle-elemental-system",
-					"--create-namespace",
-				)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart,
+						operatorRepo+"/"+chart+"-chart",
+						"--namespace", "cattle-elemental-system",
+						"--create-namespace",
+					)
+				}, misc.SetTimeout(1*time.Minute), 10*time.Second).Should(BeNil())
 			}
 
 			err := k.WaitForNamespaceWithPod("cattle-elemental-system", "app=elemental-operator")


### PR DESCRIPTION
Sometimes Rancher Manager is not completely up and running when we try to install Elemental Operator, so it  better to retry with Eventually.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5240648694)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5240567211)
- [CLI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/5240563520)