### PR TITLE
ci/ui: fix error 500 when deploying app (#863)

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -27,21 +27,28 @@ filterTests(['main'], () => {
     });
     
     it('Deploy Alerting Drivers application', () => {
+      // Unfortunately, this wait is needed mainly with RKE2 because the cluster
+      // is switching status and it is hard to catch in automated way...
+      cy.wait(180000);
       topLevelMenu.openIfClosed();
+      cy.contains('Home')
+        .click();
+      cy.get('[data-node-id="fleet-default/'+clusterName+'"]')
+        .contains('Active',  {timeout: 300000});
       cy.contains(clusterName)
         .click();
       cy.contains('Apps')
         .click();
       cy.contains('Charts')
         .click();
-      cy.contains('Alerting Drivers')
+      cy.contains('Alerting Drivers', {timeout:30000})
         .click();
-      cy.contains('.name-logo-install', 'Alerting Drivers', {timeout:20000});
+      cy.contains('.name-logo-install', 'Alerting Drivers', {timeout:30000});
       cy.clickButton('Install');
       cy.contains('.outer-container > .header', 'Alerting Drivers');
       cy.clickButton('Next');
       cy.clickButton('Install');
-      cy.contains('SUCCESS: helm install', {timeout:30000});
+      cy.contains('SUCCESS: helm install', {timeout:120000});
       cy.reload;
       cy.contains('Deployed rancher-alerting-drivers');
     });
@@ -59,7 +66,7 @@ filterTests(['main'], () => {
         .click();
       cy.clickButton('Delete');
       cy.confirmDelete();
-      cy.contains('SUCCESS: helm uninstall', {timeout:30000});
+      cy.contains('SUCCESS: helm uninstall', {timeout:60000});
       cy.contains('.apps', 'rancher-alerting-drivers')
         .should('not.exist');
     });

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -130,7 +130,7 @@ describe('Machine inventory testing', () => {
         .click();
       // The new cluster must be in active state
       cy.get('[data-node-id="fleet-default/'+clusterName+'"]')
-        .contains('Active');
+        .contains('Active',  {timeout: 300000});
       // Go into the dedicated cluster page
       topLevelMenu.openIfClosed();
       cy.contains(clusterName)


### PR DESCRIPTION
Fix #863 

Well, after investigations, sometimes, RKE2 cluster becomes active and then, switches to updating again and you cannot access its app menu, that's why we got HTTP 500. It is very hard to handle in automated test.

## Verification run
[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5246059341) ✔️ 
[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5246061940/jobs/9474389159) ✔️ 
[UI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5245400889) ✔️ 