### PR TITLE
ci: add hardened rke2 badges in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CI with latest stable Rancher Manager:
 [![CLI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_stable.yaml)
 
 [![CLI-K3s-Hardened-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_stable.yaml)
+[![CLI-RKE2-Hardened-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-hardened-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-hardened-rancher_stable.yaml)
 
 [![CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-scalability-rancher_stable.yaml)
 
@@ -32,6 +33,7 @@ CI with latest devel Rancher Manager:
 [![CLI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-os-upgrade-rancher_latest.yaml)
 
 [![CLI-K3s-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-hardened-rancher_latest.yaml)
+[![CLI-RKE2-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/cli-rke2-hardened-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-rke2-hardened-rancher_latest.yaml)
 
 [![UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-rancher_latest.yaml)
 [![UI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_latest.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-rancher_latest.yaml)


### PR DESCRIPTION
This PR adds 2 news badges to track hardened RKE2 cluster tests results.