### PR TITLE
ci: use SeedImage to create ISOs

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -247,6 +247,10 @@ jobs:
         run: |
           mkdir -p build
           wget -v -L -c ${ISO_TO_TEST} -O build/elemental-${TAG}.iso
+      - name: Create symbolic link to ISO for SeedImage
+        run: |
+          ISO=$(ls build/elemental-*.iso 2> /dev/null)
+          ln -sf ${ISO} base-image.iso
       - name: Extract iPXE artifacts from ISO
         run: |
           # Extract TAG

--- a/tests/assets/seedImage.yaml
+++ b/tests/assets/seedImage.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: seed-image-%POOL_TYPE%-%CLUSTER_NAME%
+  # namespace: fleet-default
+spec:
+  baseImage: %BASE_IMAGE%
+  cloud-config:
+    write_files:
+      - append: true
+        content: |
+          SeedImage cloud-config-test
+        path: /etc/elemental-test
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: machine-registration-%POOL_TYPE%-%CLUSTER_NAME%
+    namespace: fleet-default

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -44,6 +44,7 @@ const (
 	osListYaml            = "../assets/managedOSVersionChannel.yaml"
 	registrationYaml      = "../assets/machineRegistration.yaml"
 	restoreYaml           = "../assets/restore.yaml"
+	seedimageYaml         = "../assets/seedImage.yaml"
 	selectorYaml          = "../assets/selector.yaml"
 	upgradeSkelYaml       = "../assets/upgrade_skel.yaml"
 	userName              = "root"


### PR DESCRIPTION
Fix #771 

Use SeedImage instead of using the homemade script to add the registration file to the ISO.

## Verification run
[CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/5326438083) ✔️ 
[CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5322224077/jobs/9638391437) ✔️ 
[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5322226719/jobs/9638395848) ✔️ 

- [x] Build ISO with SeedImage
- [x] Use internal webserver to serve base image
- [x] Add cloud-config in seedimage
Will be done in a separate PR because https://github.com/rancher/elemental-operator/issues/467 blocks me