### PR TITLE
ci: add test for seedimage cloud-config

### DIFF
--- a/tests/assets/seedImage.yaml
+++ b/tests/assets/seedImage.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   baseImage: %BASE_IMAGE%
   cloud-config:
+    users:
+      - name: root
+        passwd: r0s@pwd1
     write_files:
       - append: true
         content: |

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -54,6 +54,10 @@ if [[ ${ISO_BOOT} == "true" ]]; then
 
   # Force ISO boot
   INSTALL_FLAG+=" --cdrom ${VM_NAME}/${ISO##*/}"
+  
+  # Use noautoconsole to check SeedImage cloud-config
+  # because we need to ssh into the VM when it is installing
+  [[ ${POOL} == "master" ]] && INSTALL_FLAG+=" --noautoconsole"
 else
   # Create symlink for binary but only if it doesn't exist
   SYM_LINK=../../ipxe.efi


### PR DESCRIPTION
Fix #771 

This will make sure we won't hit this bug anymore https://github.com/rancher/elemental-operator/issues/467

The following cloud-config is added to SeedImage:
```
  cloud-config:
    users:
      - name: root
        passwd: r0s@pwd1
    write_files:
      - append: true
        content: |
          SeedImage cloud-config-test
        path: /etc/elemental-test
```
Then, when the ISO is booted, we check the ssh connexion with root account and also that the file `/etc/elemental-test` exists.

# Verification runs
[CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5376449775) ✔️ 
[CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5376460678) ✔️ 
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5376470264) ✔️  
[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5376477267) ✔️  
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5376482296) ✔️ 