### PR TITLE
ci: fix rke2 hardened cluster

### DIFF
--- a/tests/assets/hardened_cluster/psa.yaml
+++ b/tests/assets/hardened_cluster/psa.yaml
@@ -20,6 +20,7 @@ plugins:
       namespaces:
       - ingress-nginx
       - kube-system
+      - fleet-default
       - cattle-system
       - cattle-epinio-system
       - cattle-fleet-system


### PR DESCRIPTION
Fix #882 

After debugging, the `fleet-default` namespace has to be added in the psa file.

# Verification run
[CLI-RKE2-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5378841550/jobs/9759227577) ✔️ 