### PR TITLE
ci/e2e: fix RKE2 tests

### DIFF
--- a/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
@@ -14,6 +14,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened RKE2"
+      ca_private: private
       cluster_name: cluster-rke2
       cluster_type: hardened
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
@@ -14,6 +14,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened RKE2"
+      ca_private: private
       cluster_name: cluster-rke2
       cluster_type: hardened
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -19,8 +19,10 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard RKE2"
+      ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
       node_number: 60
       rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
@@ -18,7 +18,9 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
+      ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: latest/devel
       sequential: true
+      upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
@@ -18,7 +18,9 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
+      ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.25.7+rke2r1
       rancher_version: stable/latest
       sequential: true
+      upstream_cluster_version: v1.25.7+rke2r1


### PR DESCRIPTION
Client clusters configured with RKE2 should be deployed from a Rancher Manager installed on RKE2 host cluster.

Verification runs:
- [CLI-RKE2-Scalability-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5401283346)
- [CLI-RKE2-Sequential-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5401291295)
- [CLI-RKE2-Sequential-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5401298042)

Some tests have been killed because of the SPOT functionality on GCP. Anyway this PR is validated on the green ones.