### PR TITLE
ci: fix ca_type variable for RKE2 hardened

### DIFF
--- a/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
@@ -14,7 +14,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened RKE2"
-      ca_private: private
+      ca_type: private
       cluster_name: cluster-rke2
       cluster_type: hardened
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
@@ -14,7 +14,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened RKE2"
-      ca_private: private
+      ca_type: private
       cluster_name: cluster-rke2
       cluster_type: hardened
       k8s_version_to_provision: v1.25.7+rke2r1


### PR DESCRIPTION
Replace `ca_private` by `ca_type`

## Verification run
[CLI-RKE2-Hardened-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5408760655?pr=886) ✔️ 