### PR TITLE
ci: install as simple application

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -24,6 +24,6 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -25,6 +25,6 @@ jobs:
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
-        default: dev
+        default: latest-dev
         type: string
 
 concurrency:
@@ -43,10 +43,10 @@ jobs:
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+k3s1
       node_number: 5
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -4,6 +4,9 @@ name: CLI-RKE2-OBS_Dev
 on:
   workflow_dispatch:
     inputs:
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -28,6 +31,7 @@ jobs:
       test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
+      cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-obs_stable.yaml
+++ b/.github/workflows/cli-rke2-obs_stable.yaml
@@ -4,6 +4,9 @@ name: CLI-RKE2-OBS_Stable
 on:
   workflow_dispatch:
     inputs:
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -28,6 +31,7 @@ jobs:
       test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
+      cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -4,6 +4,9 @@ name: CLI-RKE2-OBS_Staging
 on:
   workflow_dispatch:
     inputs:
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -28,6 +31,7 @@ jobs:
       test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
+      cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging:/Teal53/media/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -25,7 +25,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: latest/devel
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -26,7 +26,7 @@ jobs:
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -22,7 +22,7 @@ on:
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
-        default: dev
+        default: latest-dev
         type: string
 
 concurrency:
@@ -44,11 +44,11 @@ jobs:
       iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.25.7+rke2r1
       node_number: 5
-      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
+      operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: v1.25.7+rke2r1

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -454,6 +454,9 @@ jobs:
           else
             cd tests && VM_INDEX=${VM_START} VM_NUMBERS=${VM_END} make e2e-bootstrap-node
           fi
+      - name: Install a simple application
+        if: inputs.test_type == 'cli' && contains(inputs.upstream_cluster_version, 'k3s')
+        run: cd tests && make e2e-install-app && make e2e-check-app
       - name: Upgrade Elemental Operator
         if: inputs.test_type == 'cli' && inputs.operator_upgrade != ''
         id: operator_upgrade
@@ -461,6 +464,9 @@ jobs:
           OPERATOR_UPGRADE: ${{ inputs.operator_upgrade }}
         run: |
           cd tests && make e2e-upgrade-operator
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
           # Extract elemental-operator version
           OPERATOR_VERSION=$(kubectl get pod \
                              --namespace cattle-elemental-system \
@@ -480,6 +486,9 @@ jobs:
           RANCHER_UPGRADE: ${{ inputs.rancher_upgrade }}
         run: |
           cd tests && make e2e-upgrade-rancher-manager
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
           # Extract Rancher Manager version
           RM_VERSION=$(kubectl get pod \
                          --namespace cattle-system \
@@ -493,7 +502,11 @@ jobs:
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           UPGRADE_TYPE: osImage
           VM_INDEX: 1
-        run: cd tests && make e2e-upgrade-node
+        run: |
+          cd tests && make e2e-upgrade-node
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
       - name: Upgrade other nodes to specified OS version with managedOSVersionName
         if: inputs.test_type == 'cli' && inputs.upgrade_os_channel != ''
         env:
@@ -502,7 +515,11 @@ jobs:
           UPGRADE_TYPE: managedOSVersionName
           VM_INDEX: 2
           VM_NUMBERS: 3
-        run: cd tests && make e2e-upgrade-node
+        run: |
+          cd tests && make e2e-upgrade-node
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
       - name: Bootstrap additional nodes in pool "worker" (total of ${{ inputs.node_number }})
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
@@ -525,6 +542,10 @@ jobs:
           else
             cd tests && VM_INDEX=${VM_START} VM_NUMBERS=${VM_END} make e2e-bootstrap-node
           fi
+          # Check the installed application
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
       - name: List installed nodes
         if: inputs.test_type == 'cli'
         run: sudo virsh list
@@ -532,7 +553,11 @@ jobs:
         if: inputs.test_type == 'cli' && contains(inputs.upstream_cluster_version, 'k3s')
         env:
           BACKUP_RESTORE_VERSION: ${{ inputs.backup_restore_version }}
-        run: cd tests && make e2e-backup-restore
+        run: |
+          cd tests && make e2e-backup-restore
+          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
       - name: Uninstall Elemental Operator
         env:
           OPERATOR_REPO: ${{ inputs.operator_repo }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -48,5 +48,5 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -45,6 +45,6 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-dev-channel/5.3:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/teal53/15.4/rancher/elemental-teal/5.3:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal/5.3:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: v1.25.7+rke2r1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -69,12 +69,16 @@ e2e-bootstrap-node: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
 e2e-backup-restore: deps
 	ginkgo --label-filter test-backup-restore -r -v ./e2e
+e2e-check-app: deps
+	ginkgo --label-filter check-app -r -v ./e2e
 e2e-configure-rancher: deps
 	ginkgo --label-filter configure -r -v ./e2e
 e2e-get-logs: deps
 	ginkgo --label-filter logs -r -v ./e2e
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e
+e2e-install-app: deps
+	ginkgo --label-filter install-app -r -v ./e2e
 e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
 e2e-ui-rancher: deps

--- a/tests/assets/hello-world_app.yaml
+++ b/tests/assets/hello-world_app.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    workload.user.cattle.io/workloadselector: apps.deployment-default-hello-world
+    app: hello-world
+  name: hello-world
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      workload.user.cattle.io/workloadselector: apps.deployment-default-hello-world
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        workload.user.cattle.io/workloadselector: apps.deployment-default-hello-world
+    spec:
+      containers:
+      - image: rancher/hello-world
+        imagePullPolicy: Always
+        name: container-0
+        ports:
+        - containerPort: 80
+          name: 80tcp8080
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    field.cattle.io/targetWorkloadIds: '["default/hello-world"]'
+    management.cattle.io/ui-managed: "true"
+  name: hello-world
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: 80tcp8080
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    workload.user.cattle.io/workloadselector: apps.deployment-default-hello-world
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloudprovider.harvesterhci.io/ipam: dhcp
+    field.cattle.io/targetWorkloadIds: '["default/hello-world"]'
+    management.cattle.io/ui-managed: "true"
+  finalizers:
+  - service.kubernetes.io/load-balancer-cleanup
+  name: hello-world-loadbalancer
+spec:
+  allocateLoadBalancerNodePorts: true
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: 80tcp8080
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    workload.user.cattle.io/workloadselector: apps.deployment-default-hello-world
+  sessionAffinity: None
+  type: LoadBalancer

--- a/tests/e2e/app_test.go
+++ b/tests/e2e/app_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher/elemental/tests/e2e/helpers/misc"
+)
+
+var _ = Describe("E2E - Install a simple application", Label("install-app"), func() {
+	It("Install HelloWorld application", func() {
+		kubeConfig, err := misc.SetClientKubeConfig(clusterNS, clusterName)
+		defer os.Remove(kubeConfig)
+		Expect(err).To(Not(HaveOccurred()))
+
+		By("Installing application", func() {
+			err := kubectl.Apply("default", appYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+})
+
+var _ = Describe("E2E - Checking a simple application", Label("check-app"), func() {
+	It("Check HelloWorld application", func() {
+		appName := "hello-world"
+
+		// File where to host client cluster kubeconfig
+		kubeConfig, err := misc.SetClientKubeConfig(clusterNS, clusterName)
+		defer os.Remove(kubeConfig)
+		Expect(err).To(Not(HaveOccurred()))
+
+		By("Waiting for deployment to be rollout", func() {
+			// Wait for application to be started
+			status, err := kubectl.Run("rollout", "status", "deployment/"+appName)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(status).To(ContainSubstring("successfully rolled out"))
+		})
+
+		By("Checking application", func() {
+			// Get load balancer IPs
+			appIPs, err := kubectl.Run("get", "svc",
+				appName+"-loadbalancer",
+				"-o", "jsonpath={.status.loadBalancer.ingress[*].ip}")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(appIPs).To(Not(BeEmpty()))
+
+			// Loop on each IP to check the application
+			for _, ip := range strings.Fields(appIPs) {
+				GinkgoWriter.Printf("Checking node with IP %s...\n", ip)
+
+				// Retry if needed, could take some times if a pod is restarted for example
+				var htmlPage []byte
+				Eventually(func() error {
+					htmlPage, err = exec.Command("curl", "http://"+ip+":8080").CombinedOutput()
+					return err
+				}, misc.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
+
+				// Check HTML page content
+				Expect(string(htmlPage)).To(And(
+					ContainSubstring("Hello world!"),
+					ContainSubstring("My hostname is hello-world-"),
+					ContainSubstring(ip+":8080"),
+				), string(htmlPage))
+			}
+		})
+	})
+})

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2023 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -222,7 +222,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			// Check issuer for Private CA
 			if caType == "private" {
 				Eventually(func() error {
-					out, err := exec.Command("bash", "-c", "curl -vk https://"+rancherHostname).CombinedOutput()
+					out, err := exec.Command("curl", "-vk", "https://"+rancherHostname).CombinedOutput()
 					if err != nil {
 						// Show only if there's no error
 						GinkgoWriter.Printf("%s\n", out)
@@ -248,14 +248,12 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			// Getting Rancher Manager local cluster CA
 			// NOTE: loop until the cmd return something, it could take some time
 			var rancherCA string
-			cmd := []string{
-				"get", "secret",
-				"--namespace", "cattle-system",
-				"tls-rancher-ingress",
-				"-o", "jsonpath={.data.tls\\.crt}",
-			}
 			Eventually(func() error {
-				rancherCA, err = kubectl.Run(cmd...)
+				rancherCA, err = kubectl.Run("get", "secret",
+					"--namespace", "cattle-system",
+					"tls-rancher-ingress",
+					"-o", "jsonpath={.data.tls\\.crt}",
+				)
 				return err
 			}, misc.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	appYaml               = "../assets/hello-world_app.yaml"
 	clusterYaml           = "../assets/cluster.yaml"
 	backupYaml            = "../assets/backup.yaml"
 	emulateTPMYaml        = "../assets/emulateTPM.yaml"

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 - 2023 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Install a simple application and check it in different upgrade scenari.

NOTE: the test only runs on K3s for now, as there is no load-balancer installed by default on RKE2.

Should fix #700.

Verification runs:
- [CLI-K3s-OBS_Dev - with Hardened](https://github.com/rancher/elemental/actions/runs/5509110071)
- [CLI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/5508396251)

Regression tests, RKE2 shouldn't be impacted:
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5509125892)
- [CLI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/runs/5509137287)
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/5509158876)