### PR TITLE
ci/ui: use ISO in upgrade scenario

### DIFF
--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -39,7 +39,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      iso_boot: true
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -38,7 +38,7 @@ docker run -v $PWD:/workdir -w /workdir                     \
 [[ -d downloads ]] && sudo chown -R gh-runner:users downloads videos
 
 # RKE2 as upstream cluster
-# We cannot use PXE boot so we have to boot from ISO 
+# We cannot use PXE boot so we have to boot from ISO
 if [[ ! -f ${ELEMENTAL_ISO} ]] && grep rke <<< ${K8S_UPSTREAM_VERSION}; then
   # Move elemental.iso into the expected folder
   mv downloads/*.iso ${ELEMENTAL_ISO}


### PR DESCRIPTION
I forgot to remove iso_boot for K3s latest upgrade test in https://github.com/rancher/elemental/pull/884

Fix https://github.com/rancher/elemental/actions/runs/5470884780/jobs/9964026894

`iso_boot` should not be true for K3s test because we use PXE boot there.

## Verification run
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5472866047) ✔️ 
We can see we booted from PXE instead of looking for an ISO.