### PR TITLE
ui/ci: never boot from dev iso in upgrade tests

### DIFF
--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -42,7 +42,6 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.25.7+rke2r1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/teal53/15.4/rancher/elemental-teal-channel/5.3:latest

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -36,11 +36,8 @@ describe('Machine registration testing', () => {
     // Click on the Elemental's icon
     elemental.accessElementalMenu(); 
 
-    // Create OS Version Channels from which to build the ISO
-    // No need to create one if we test stable because it is already created
-    // by the elemental-operator
-    utils.isOperatorVersion('dev') ? cy.addOsVersionChannel('dev'): null;
-    utils.isOperatorVersion('staging') ? cy.addOsVersionChannel('staging'): null;
+    // In upgrade scenario, we want to build ISO from stable channel
+    utils.isCypressTag('upgrade') ? cy.addOsVersionChannel('stable'): null;
   });
 
   beforeEach(() => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -42,11 +42,6 @@ describe('Upgrade tests', () => {
     elemental.accessElementalMenu(); 
   });
   filterTests(['upgrade'], () => {
-    it('Create an OS Version Channels', () => {
-      // System was built with stable ISO, so we can upgrade either to staging or dev
-      utils.isOperatorVersion('staging') ? cy.addOsVersionChannel('staging'): cy.addOsVersionChannel('dev');
-    });
-
     it('Check OS Versions', () => {
       cy.clickNavMenu(["Advanced", "OS Versions"]);
       utils.isOperatorVersion('dev') ? cy.contains('Active latest-dev', {timeout: 120000}): null;
@@ -54,6 +49,17 @@ describe('Upgrade tests', () => {
     });
 
     it('Upgrade one node (different methods if rke2 or k3s)', () => {
+      // TODO: Make function to check cluster status
+      // Will come in the refactoring PR
+      topLevelMenu.openIfClosed();
+      cy.contains('Home')
+        .click();
+      // The new cluster must be in active state
+      cy.get('[data-node-id="fleet-default/'+clusterName+'"]')
+        .contains('Active',  {timeout: 600000});
+      topLevelMenu.openIfClosed();
+      elemental.accessElementalMenu();
+      /////////////////////////////////////////
       // K3s cluster upgraded with OS Image
       // RKE2 cluster upgraded with OS version channel
       cy.clickNavMenu(["Advanced", "Update Groups"]);
@@ -145,34 +151,6 @@ describe('Upgrade tests', () => {
       cy.getBySel('cluster-target')
         .click();
       cy.contains('Sorry, no matching options');
-    });
-
-    it('Delete OS Versions', () => {
-      cy.clickNavMenu(["Advanced", "OS Versions"]);
-      // TODO: COULD BE IMPROVED / SIMPLIFIED
-      if (utils.isOperatorVersion('dev')) {
-        cy.contains('latest-dev')
-          .parent()
-          .parent()
-          .click();
-        cy.getBySel('sortable-table-promptRemove')
-        .contains('Delete')
-          .click()
-        cy.confirmDelete();
-        cy.contains('latest-dev')
-          .should('not.exist');
-      } else if (utils.isOperatorVersion('staging')) {
-        cy.contains('latest-staging')
-          .parent()
-          .parent()
-          .click();
-        cy.getBySel('sortable-table-promptRemove')
-        .contains('Delete')
-          .click()
-        cy.confirmDelete();
-        cy.contains('latest-staging')
-          .should('not.exist');
-      }
     });
 
     it('Delete OS Versions Channels', () => {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -241,7 +241,12 @@ Cypress.Commands.add('createMachReg', (
       // before releasing, we want to test staging/stable artifacts 
       cy.getBySel('select-os-version-build-iso')
       .click();
-      if (utils.isOperatorVersion('stable')) {
+      // Never build from dev ISO in upgrade scenario
+      if (utils.isCypressTag('upgrade')) {
+        // Stable operator version is hardcoded for now
+        // Will try to improve it in next version
+        utils.isOperatorVersion('staging') ? cy.contains('Elemental Teal ISO x86_64 latest-staging').click() : cy.contains('Elemental Teal ISO x86_64 v1.1.5').click();
+      } else if (utils.isOperatorVersion('stable')) {
         cy.contains('Elemental Teal ISO x86_64 v1.1.5')
           .click();
       } else if (utils.isOperatorVersion('staging')) {


### PR DESCRIPTION
Fix #903 

## Verification runs
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5484094776/jobs/9991203945) ✔️ 

1. We add the stable channel at the beginning of the test:
![image](https://github.com/rancher/elemental/assets/6025636/520ae472-4c0c-44fd-bdbe-c66bf7f639c8)
![image](https://github.com/rancher/elemental/assets/6025636/5fc5cbe8-ac35-4107-8679-1fc173d2a2fa)

2. We build the ISO from `dev`
![image](https://github.com/rancher/elemental/assets/6025636/7d286bb8-145a-46ac-8834-773bc98ed56e)

3. We can see stable and `dev` artifacts on the OS Versions screen
![image](https://github.com/rancher/elemental/assets/6025636/ca28f787-a09c-4dd6-8e83-f7571f4ed2fe)

4. We select `latest-dev` for the upgrade
![image](https://github.com/rancher/elemental/assets/6025636/2218e191-52ae-4fa1-bcd2-46cc2df28789)


[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5483997172/jobs/9990981125) ✔️ 
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5484096133/jobs/9991205031) ✔️ 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5483995738/jobs/9990979798) ✔️ 