### PR TITLE
Drop SLE Micro version references from code

### DIFF
--- a/.obs/dockerfile/teal-iso/Dockerfile
+++ b/.obs/dockerfile/teal-iso/Dockerfile
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: rancher/elemental-teal-iso:latest
 #!BuildTag: rancher/elemental-teal-iso:%VERSION%
 #!BuildTag: rancher/elemental-teal-iso:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10

--- a/.obs/dockerfile/teal-iso/Dockerfile
+++ b/.obs/dockerfile/teal-iso/Dockerfile
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: rancher/elemental-teal-iso/5.3:latest
-#!BuildTag: rancher/elemental-teal-iso/5.3:%VERSION%
-#!BuildTag: rancher/elemental-teal-iso/5.3:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-teal-iso:latest
+#!BuildTag: rancher/elemental-teal-iso:%VERSION%
+#!BuildTag: rancher/elemental-teal-iso:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
-FROM rancher/elemental-teal/5.3:latest AS os
-FROM rancher/elemental-builder-image/5.3:latest AS builder
+ARG SLE_VERSION
+
+FROM rancher/elemental-teal:latest AS os
+FROM rancher/elemental-builder-image:latest AS builder
 
 WORKDIR /iso
 
@@ -18,8 +20,11 @@ COPY --from=os / rootfs
 RUN elemental --debug --config-dir . build-iso -o /output -n "elemental-teal.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
 
 # Only keep the ISO as a result
-FROM bci/bci-busybox:latest
+FROM bci/bci-busybox:$SLE_VERSION
 COPY --from=builder /output /elemental-iso
+
+ARG BUILD_REPO=registry.suse.com
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.rancher.elemental
@@ -29,7 +34,7 @@ LABEL org.opencontainers.image.version="%VERSION%"
 LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
-LABEL org.opensuse.reference="%%IMG_REPO%%/rancher/elemental-teal-iso/5.3"
+LABEL org.opensuse.reference=$IMAGE_REPO
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="l3"
 # endlabelprefix

--- a/.obs/dockerfile/teal-iso/Dockerfile
+++ b/.obs/dockerfile/teal-iso/Dockerfile
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: rancher/elemental-teal-iso:%VERSION%
-#!BuildTag: rancher/elemental-teal-iso:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-teal-iso/%%SLEMICRO_VERSION%%:latest
+#!BuildTag: rancher/elemental-teal-iso/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: rancher/elemental-teal-iso/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
 ARG SLE_VERSION
+ARG SLEMICRO_VERSION
 
-FROM rancher/elemental-teal:latest AS os
-FROM rancher/elemental-builder-image:latest AS builder
+FROM rancher/elemental-teal/$SLEMICRO_VERSION:latest AS os
+FROM rancher/elemental-builder-image/$SLEMICRO_VERSION:latest AS builder
 
 WORKDIR /iso
 
@@ -22,8 +24,9 @@ RUN elemental --debug --config-dir . build-iso -o /output -n "elemental-teal.$(u
 FROM bci/bci-busybox:$SLE_VERSION
 COPY --from=builder /output /elemental-iso
 
-ARG BUILD_REPO=registry.suse.com
-ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal-iso/$SLEMICRO_VERSION
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.rancher.elemental

--- a/.obs/dockerfile/teal-os/Dockerfile
+++ b/.obs/dockerfile/teal-os/Dockerfile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-teal:%VERSION%
-#!BuildTag: rancher/elemental-teal:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-teal/%%SLEMICRO_VERSION%%:latest
+#!BuildTag: rancher/elemental-teal/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: rancher/elemental-teal/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 
 ARG SLEMICRO_VERSION
@@ -21,8 +22,9 @@ RUN zypper in -y -- \
 # Install extra useful utilities
 RUN zypper in -y k9s
 
-ARG BUILD_REPO=registry.suse.com
-ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal/$SLEMICRO_VERSION
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The

--- a/.obs/dockerfile/teal-os/Dockerfile
+++ b/.obs/dockerfile/teal-os/Dockerfile
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-teal/5.3:latest
-#!BuildTag: rancher/elemental-teal/5.3:%VERSION%
-#!BuildTag: rancher/elemental-teal/5.3:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-teal:latest
+#!BuildTag: rancher/elemental-teal:%VERSION%
+#!BuildTag: rancher/elemental-teal:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 
-FROM suse/sle-micro-rancher/5.3:latest
+ARG SLEMICRO_VERSION
+
+FROM suse/sle-micro-rancher/$SLEMICRO_VERSION:latest
 
 # Elemental Teal essentials
 # kernel-firmware-amdgpu installed here until 5.4 is released and includes it
@@ -20,11 +22,13 @@ RUN zypper in -y -- \
 # Install extra useful utilities
 RUN zypper in -y k9s
 
+ARG BUILD_REPO=registry.suse.com
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-teal
+ARG IMAGE_TAG=%VERSION%-%RELEASE%
+
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
 # values here should reflect the tag of the image being built
 # Also used by elemental-populate-labels
-ARG IMAGE_TAG=%VERSION%-%RELEASE%
-ARG IMAGE_REPO=%%IMG_REPO%%/rancher/elemental-teal/5.3
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"           >> /etc/os-release && \
     echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \
@@ -39,7 +43,7 @@ LABEL org.opencontainers.image.version="%VERSION%"
 LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
-LABEL org.opensuse.reference="%%IMG_REPO%%/rancher/elemental-teal/5.3"
+LABEL org.opensuse.reference=$IMAGE_REPO
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="l3"
 # endlabelprefix

--- a/.obs/dockerfile/teal-os/Dockerfile
+++ b/.obs/dockerfile/teal-os/Dockerfile
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-teal:latest
 #!BuildTag: rancher/elemental-teal:%VERSION%
 #!BuildTag: rancher/elemental-teal:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8


### PR DESCRIPTION
These are the changes required in this repository for the builds I prepared in [here](https://build.opensuse.org/project/show/home:dcassany:ElementalNewDev). 

Note this changes image and charts URLs, so this is likely to be a breaking change from CI perspective.

Part of #815