### PR TITLE
e2e/ui fix extension installation in head

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
-import { isUIVersion } from '../../support/utils';
+import { isUIVersion, isRancherManagerVersion } from '../../support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 
 filterTests(['main', 'upgrade'], () => {
@@ -32,7 +32,7 @@ filterTests(['main', 'upgrade'], () => {
     
     it('Enable extension support', () => {
       cypressLib.burgerMenuOpenIfClosed();
-      isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false);
+      isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false, isRancherManagerVersion("head"));
     });
   
     it('Install Elemental plugin', () => {

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -27,7 +27,7 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
     "dotenv": "^10.0.0",
-    "@rancher-ecp-qa/cypress-library": "1.0.1",
+    "@rancher-ecp-qa/cypress-library": "1.0.4",
     "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
Fixed by https://github.com/rancher-sandbox/rancher-ecp-qa/commit/d9f3e8b6c1022f7d9834560aad35cf702857c4d6
So we need to bump cypress-lib to 1.0.4

Will fix #917 

## Verification runs
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5588638240) 🕐 
[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5588907187/jobs/10216409540) 🕐 