### PR TITLE
ci: ignore case distinctions for grep command

### DIFF
--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -264,7 +264,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 						// Check that the installation is completed before halting the VM
 						Eventually(func() error {
-							_, err := cl.RunSSH("journalctl -u elemental-register.service --no-pager | grep 'elemental installation completed'")
+							_, err := cl.RunSSH("journalctl -u elemental-register.service --no-pager | grep -i 'elemental installation completed'")
 							return err
 						}, misc.SetTimeout(8*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))
 


### PR DESCRIPTION
CLI-RKE2 tests are broken since yesterday: https://github.com/rancher/elemental/actions/workflows/cli-rke2-rancher_latest.yaml

`cmd/register/main.go:		[log.Info](http://log.info/)("elemental installation completed, please reboot")
`
became
`pkg/install/install.go:	[log.Info](http://log.info/)("Elemental installation completed, please reboot")
`
## Verification run
https://github.com/rancher/elemental/actions/runs/5600266399/jobs/10242431613?pr=925