### PR TITLE
e2e/ui: bump cypress library to 1.0.6

### DIFF
--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -27,7 +27,7 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
     "dotenv": "^10.0.0",
-    "@rancher-ecp-qa/cypress-library": "1.0.4",
+    "@rancher-ecp-qa/cypress-library": "1.0.6",
     "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
Bump the Cypress library to the latest release which includes:
- unit tests
- new functions
- improvements in existing functions

More details [here](https://github.com/rancher-sandbox/rancher-ecp-qa/pull/2) 

## Verification runs
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5642554235/job/15282659548) ✅ 
[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5642556100/job/15282669141) ✅ 
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5642557098/job/15282647908) ✅ 