### PR TITLE
Separate elemental-register --install

### DIFF
--- a/framework/files/system/oem/05_motd_and_autologin.yaml
+++ b/framework/files/system/oem/05_motd_and_autologin.yaml
@@ -7,7 +7,7 @@ stages:
       content: |
 
         Installation is in progress.
-        You can "journalctl -f -u elemental-register" to view progress
+        You can "journalctl -f -t elemental-register" to view progress
          
       permissions: 0644
     - path: /etc/systemd/system/serial-getty@ttyS0.service.d/override.conf

--- a/framework/files/system/oem/05_motd_and_autologin.yaml
+++ b/framework/files/system/oem/05_motd_and_autologin.yaml
@@ -7,7 +7,7 @@ stages:
       content: |
 
         Installation is in progress.
-        You can "journalctl -f -t elemental-register" to view progress
+        You can "journalctl -f -u elemental-register-install" to view progress
          
       permissions: 0644
     - path: /etc/systemd/system/serial-getty@ttyS0.service.d/override.conf

--- a/framework/files/system/oem/99_elemental-register-install.yaml
+++ b/framework/files/system/oem/99_elemental-register-install.yaml
@@ -3,4 +3,4 @@ stages:
   network.after:
     - if: '[ -f /run/cos/live_mode ]'
       commands:
-        - elemental-register --debug --install
+        - systemd-cat -t elemental-register elemental-register --debug --install 

--- a/framework/files/system/oem/99_elemental-register-install.yaml
+++ b/framework/files/system/oem/99_elemental-register-install.yaml
@@ -1,0 +1,6 @@
+name: "Elemental Register install"
+stages:
+  network.after:
+    - if: '[ -f /run/cos/live_mode ]'
+      commands:
+        - elemental-register --debug --install

--- a/framework/files/system/oem/99_elemental-register-install.yaml
+++ b/framework/files/system/oem/99_elemental-register-install.yaml
@@ -3,4 +3,4 @@ stages:
   network.after:
     - if: '[ -f /run/cos/live_mode ]'
       commands:
-        - systemd-cat -t elemental-register elemental-register --debug --install 
+        - systemctl start elemental-register-install

--- a/framework/files/system/oem/99_elemental-register-timer.yaml
+++ b/framework/files/system/oem/99_elemental-register-timer.yaml
@@ -1,0 +1,6 @@
+name: "Elemental Register start"
+stages:
+  network.after:
+    - if: '[ ! -f /run/cos/live_mode ] && [ ! -f /run/cos/recovery_mode ]'
+      commands:
+        - systemctl start elemental-register.timer

--- a/framework/files/system/oem/99_elemental-register.yaml
+++ b/framework/files/system/oem/99_elemental-register.yaml
@@ -1,5 +1,0 @@
-name: "Elemental operator bootstrap"
-stages:
-  network.after:
-    - commands:
-        - systemctl start elemental-register.timer

--- a/framework/files/system/oem/99_elemental_system_agent.yaml
+++ b/framework/files/system/oem/99_elemental_system_agent.yaml
@@ -1,6 +1,6 @@
 name: "Elemental system agent bootstrap"
 stages:
   network.after:
-    - if: '[ ! -f /run/cos/live_mode ]'
+    - if: '[ ! -f /run/cos/live_mode ] && [ ! -f /run/cos/recovery_mode ]'
       commands:
         - systemctl start elemental-system-agent.service

--- a/framework/files/system/oem/99_elemental_system_agent.yaml
+++ b/framework/files/system/oem/99_elemental_system_agent.yaml
@@ -1,6 +1,6 @@
 name: "Elemental system agent bootstrap"
 stages:
   network.after:
-    - if: '[ ! -f /etc/systemd/system/rancher-system-agent.service ] && [ ! -f /run/cos/live_mode ] && [ ! -f /run/cos/recovery_mode ]'
+    - if: '[ ! -f /run/cos/live_mode ]'
       commands:
         - systemctl start elemental-system-agent.service

--- a/framework/files/usr/lib/systemd/system/elemental-register-install.service
+++ b/framework/files/usr/lib/systemd/system/elemental-register-install.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Elemental Register Install
+Documentation=https://elemental.docs.rancher.com
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/elemental
+EnvironmentFile=-/etc/sysconfig/proxy
+Type=oneshot
+ExecStart=/usr/sbin/elemental-register --debug --install
+Restart=on-failure
+RestartSec=5

--- a/framework/files/usr/lib/systemd/system/elemental-system-agent.service
+++ b/framework/files/usr/lib/systemd/system/elemental-system-agent.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 After=network-online.target
 After=time-sync.target
 ConditionPathExists=!/run/cos/live_mode
-ConditionPathExists=!/etc/systemd/system/rancher-system-agent.service
 
 [Service]
 EnvironmentFile=-/etc/default/elemental


### PR DESCRIPTION
Resolves rancher/elemental#526

Create a separate cloud-init to run only from live systems, to exploit the `elemental-register` `--install` argument.