### PR TITLE
Fix elemental-register systemd service

### DIFF
--- a/framework/files/usr/lib/systemd/system/elemental-register.service
+++ b/framework/files/usr/lib/systemd/system/elemental-register.service
@@ -8,14 +8,13 @@ StartLimitIntervalSec=5min
 StartLimitBurst=5
 # No need to manually reset failed state
 CollectMode=inactive-or-failed
-# Use active state for Type=oneshot (used for Timer trigger)
-RemainAfterExit=true
 
 [Service]
 EnvironmentFile=-/etc/default/elemental
 EnvironmentFile=-/etc/sysconfig/proxy
 Type=oneshot
+# Use active state for Type=oneshot (used for Timer trigger)
+RemainAfterExit=true
 ExecStart=/usr/sbin/elemental-register --debug
 Restart=on-failure
 RestartSec=5
-


### PR DESCRIPTION
RemainAfterExit should be defined in Unit section.

This PR should fix this error I saw on node:
![Screenshot from 2023-08-17 14-53-23](https://github.com/rancher/elemental/assets/25102165/e4418a09-d92c-4e79-ac1e-bb69269f1111)
