### PR TITLE
Add build-iso-next to OBS workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,6 +9,9 @@ push_workflow:
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: build-iso
+    - trigger_services:
+        project: isv:Rancher:Elemental:Dev
+        package: build-iso-next
   filters:
     branches:
       only:


### PR DESCRIPTION
The current [Dockerfile](https://github.com/rancher/elemental/blob/main/.obs/dockerfile/teal-iso/Dockerfile) for `build-iso` is very `Elemental Teal` specific and parameterizing it further would make it even more confusing.

Therefore a new [build-iso-next](https://build.opensuse.org/package/show/isv:Rancher:Elemental:Dev/build-iso-next) was added to build the "SLE Micro for Rancher 5.5" ISOs.

This PR adds `build-iso-next` to the OBS targets requiring a `_service` run when rancher/elemental changes.