### PR TITLE
ci/ui: fix rancher head tests

### DIFF
--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -30,7 +30,8 @@ jobs:
       test_description: "CI/Manual - UI - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       cypress_tags: main
-      destroy_runner: ${{ inputs.destroy_runner || true }}
+      #destroy_runner: ${{ inputs.destroy_runner || true }}
+      destroy_runner: false
       elemental_ui_version: dev
       k8s_version_to_provision: v1.25.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -36,7 +36,7 @@ filterTests(['main', 'upgrade'], () => {
     qase(12,
       it('Enable extension support', () => {
         cypressLib.burgerMenuOpenIfClosed();
-        isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false, isRancherManagerVersion("head"));
+        isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false, true);
       })
     );
   


### PR DESCRIPTION
Tests fail when the cluster is created, it's never switched to `Active` state.
I tried to increase the timeout but it still fails.