### PR TITLE
ci/ui: fix ui upgrade workflow

### DIFF
--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -27,5 +27,5 @@ jobs:
       rancher_version: latest/devel
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
-      upgrade_os_channel: latest-dev
+      upgrade_os_channel: dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -28,5 +28,5 @@ jobs:
       rancher_version: stable/latest
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
-      upgrade_os_channel: latest-dev
+      upgrade_os_channel: dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -406,6 +406,7 @@ jobs:
             /workdir/e2e/unit_tests/upgrade.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
+          UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
         run: cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Advanced)
         if: failure() && inputs.test_type == 'ui'

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -28,9 +28,9 @@ on:
         description: Rancher Manager channel/version to use for installation
         default: stable/latest
         type: string
-      upgrade_os_channel:
-        description: Channel to use for the Elemental OS upgrade
-        default: dev
+      upgrade_image:
+        description: Upgrade image to use
+        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
         type: string
 
 jobs:
@@ -53,6 +53,4 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-dev-channel/5.4:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
-      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
+      upgrade_image: ${{ inputs.upgrade_image }}

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -41,4 +41,5 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_os_channel: dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -42,7 +42,9 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.7+rke2r1
+      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_os_channel: dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -50,7 +50,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-dev-channel/5.4:latest
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: v1.26.7+rke2r1

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -34,8 +34,18 @@ describe('Machine registration testing', () => {
     // Click on the Elemental's icon
     cypressLib.accesMenu('OS Management');
 
-    // In upgrade scenario, we want to build ISO from stable channel
-    utils.isCypressTag('upgrade') ? cy.addOsVersionChannel('stable'): null;
+    // In upgrade scenario, we need to add extra channels
+    if (utils.isCypressTag('upgrade')) {
+      if (utils.isOperatorVersion('stable')) {
+        cy.addOsVersionChannel('dev');
+        cy.addOsVersionChannel('staging');
+      } else if (utils.isOperatorVersion('staging')) {
+        cy.addOsVersionChannel('dev');
+        cy.addOsVersionChannel('stable'); // Not sure it is needed
+      } else {
+        cy.addOsVersionChannel('stable');
+      }
+    }
   });
 
   beforeEach(() => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -21,12 +21,13 @@ import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 Cypress.config();
 describe('Upgrade tests', () => {
-  const channelName   = "mychannel"
-  const clusterName   = "mycluster"
-  const elementalUser = "elemental-user"
-  const uiAccount     = Cypress.env('ui_account');
-  const uiPassword    = "rancherpassword"
-  const upgradeImage  = Cypress.env('upgrade_image')
+  const channelName      = "mychannel"
+  const clusterName      = "mycluster"
+  const elementalUser    = "elemental-user"
+  const uiAccount        = Cypress.env('ui_account');
+  const uiPassword       = "rancherpassword"
+  const upgradeImage     = Cypress.env('upgrade_image')
+  const upgradeOsChannel = Cypress.env('upgrade_os_channel')
 
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
@@ -83,10 +84,18 @@ describe('Upgrade tests', () => {
             .click();
           cy.getBySel('os-version-box')
             .click()
-          cy.getBySel('os-version-box')
-            .parents()
-            .contains('dev')
-            .click();
+          // TODO: remove hardcoded staging version
+          if (upgradeOsChannel == "staging") {
+            cy.getBySel('os-version-box')
+              .parents()
+              .contains('v1.2.1')
+              .click();
+          } else {
+            cy.getBySel('os-version-box')
+              .parents()
+              .contains('latest-'+upgradeOsChannel)
+              .click();
+          }
         }
 
         cy.getBySel('form-save')

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -40,8 +40,8 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.proxy                = process.env.PROXY;
   config.env.rancher_version      = process.env.RANCHER_VERSION;
   config.env.ui_account           = process.env.UI_ACCOUNT;
-  config.env.upgrade_channel_list = process.env.UPGRADE_CHANNEL_LIST;
   config.env.upgrade_image        = process.env.UPGRADE_IMAGE;
+  config.env.upgrade_os_channel   = process.env.UPGRADE_OS_CHANNEL;
   config.env.username             = process.env.RANCHER_USER;
 
   return config;

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -130,7 +130,7 @@ Cypress.Commands.add('createMachReg', (
         expect($input).to.have.attr('disabled')
       })
       // Download button is enabled once ISO building done
-      cy.getBySel('download-iso-btn', { timeout: 300000 }).should(($input) => {
+      cy.getBySel('download-iso-btn', { timeout: 600000 }).should(($input) => {
         expect($input).to.not.have.attr('disabled')
       })
       cy.getBySel('download-iso-btn')

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -32,6 +32,7 @@ docker run -v $PWD:/workdir -w /workdir                     \
     -e RANCHER_USER=$RANCHER_USER                           \
     -e UI_ACCOUNT=$UI_ACCOUNT                               \
     -e UPGRADE_IMAGE=$UPGRADE_IMAGE                         \
+    -e UPGRADE_OS_CHANNEL=$UPGRADE_OS_CHANNEL               \
     --add-host host.docker.internal:host-gateway            \
     --ipc=host                                              \
     $CYPRESS_DOCKER                                         \


### PR DESCRIPTION
## Verification run:

### K3S
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5964988633) ✅ 
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5973856814) ✅ 
[UI-K3s-OS-Upgrade - Stable => Dev](https://github.com/rancher/elemental/actions/runs/5965754964) (default inputs) ✅ 
[UI-K3s-OS-Upgrade - Stable => Staging](https://github.com/rancher/elemental/actions/runs/5965063173) ✅ 
[UI-K3s-OS-Upgrade - Staging => Dev](https://github.com/rancher/elemental/actions/runs/5965766049) ✅ 

### RKE2
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5975463953) ✅ 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/5975467352) ✅ 
[UI-RKE2-OS-Upgrade - Stable => Dev](https://github.com/rancher/elemental/actions/runs/5976199123) (default inputs) ✅ 
[UI-RKE2-OS-Upgrade - Stable => Staging](https://github.com/rancher/elemental/actions/runs/5976191221) ❌
It does not work because the image brought by the staging operator is wrong `registry.opensuse.org/isv/rancher/elemental/staging/teal53/15.4/rancher/elemental-teal-channel:1.3.1` it should be 
 `registry.opensuse.org/isv/rancher/elemental/staging/containers/rancher/elemental-teal-channel:1.3.1`
[UI-RKE2-OS-Upgrade - Staging => Dev](https://github.com/rancher/elemental/actions/runs/5976212548) ✅ 