### PR TITLE
Disable service triggers on staging

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -24,20 +24,11 @@ push_workflow:
 tag_workflow:
   steps:
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: node-image
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: node-image
-    - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: build-iso
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: build-iso


### PR DESCRIPTION
Since all services are set to `manual` or `buildtime` in staging, triggering services has no effect. Staging has to be updated manually.

Related to rancher/elemental-operator#498 and rancher/elemental-toolkit#1817