### PR TITLE
ci/ui: specify the branch to use for the UI

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -29,7 +29,7 @@ filterTests(['main', 'upgrade'], () => {
   
     qase(11,
       it('Add elemental-ui repo', () => {
-        !isUIVersion('stable') ? cypressLib.addRepository('elemental-ui', 'https://github.com/rancher/elemental-ui.git', 'git') : null;
+        !isUIVersion('stable') ? cypressLib.addRepository('elemental-ui', 'https://github.com/rancher/elemental-ui.git', 'git', 'gh-pages') : null;
       })
     );
     

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/rancher/elemental#readme",
   "dependencies": {
-    "@rancher-ecp-qa/cypress-library": "1.0.6",
+    "@rancher-ecp-qa/cypress-library": "1.0.7",
     "cy-verify-downloads": "^0.1.8",
     "cypress": "^10.0.0",
     "cypress-dark": "^1.8.3",


### PR DESCRIPTION
The change has been done in the Cypress library https://github.com/rancher-sandbox/rancher-ecp-qa/pull/5

So this PR adds the `gh-pages` branch as an argument and bumps the cypress library to 1.0.7 to get the latest function version.

## Verification run
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/5997454480/job/16263887139) ✅ 