### PR TITLE
Fix image/iso build

### DIFF
--- a/.github/elemental-iso-build
+++ b/.github/elemental-iso-build
@@ -7,32 +7,30 @@ TAG=${TAG:-main}
 
 build() {
   TEMPDIR=$(mktemp -d)
-  mkdir "$TEMPDIR"/iso
+  mkdir ${TEMPDIR}/iso
   # passing a config file? Copy it to the target that will get copied inside the build
-  if [[ -n "$CLOUD_CONFIG_FILE" ]]; then
-    echo "Using custom registration from $CLOUD_CONFIG_FILE"
-    cp "$CLOUD_CONFIG_FILE" "${TEMPDIR}/iso/config"
+  if [[ -n "${CLOUD_CONFIG_FILE}" ]]; then
+    echo "Using custom registration from ${CLOUD_CONFIG_FILE}"
+    cp ${CLOUD_CONFIG_FILE} ${TEMPDIR}/iso/config
   fi
-  curl https://raw.githubusercontent.com/rancher/elemental/"${TAG}"/Dockerfile.iso -fsSL -o "$TEMPDIR"/Dockerfile
-  curl https://raw.githubusercontent.com/rancher/elemental/"${TAG}"/iso/manifest.yaml -fsSL -o "${TEMPDIR}/iso/manifest.yaml"
+  curl https://raw.githubusercontent.com/rancher/elemental/${TAG}/Dockerfile.iso -fsSL -o ${TEMPDIR}/Dockerfile
+  curl https://raw.githubusercontent.com/rancher/elemental/${TAG}/iso/manifest.yaml -fsSL -o ${TEMPDIR}/iso/manifest.yaml
   # Did we copy the custom cloud config? Then no need to download the default one
-  if [[ -z "$CLOUD_CONFIG_FILE" ]]; then
+  if [[ -z "${CLOUD_CONFIG_FILE}" ]]; then
     echo "No custom registration set, using default"
-    curl https://raw.githubusercontent.com/rancher/elemental/"${TAG}"/iso/config -fsSL -o "$TEMPDIR"/iso/config
+    curl https://raw.githubusercontent.com/rancher/elemental/${TAG}/iso/config -fsSL -o ${TEMPDIR}/iso/config
   fi
 
-  pushd "$TEMPDIR" || exit 1
-  docker build -f "$TEMPDIR"/Dockerfile -t elemental/iso:latest .
+  pushd ${TEMPDIR} || exit 1
+  docker build -f ${TEMPDIR}/Dockerfile -t elemental/iso:latest .
   popd || exit 1
 
-  rm -Rf "$TEMPDIR"
-  ISONAME="elemental-${TAG}-$(date "+%FT%TZ")"
-  docker run --rm -v "$PWD":/mnt elemental/iso:latest --config-dir . build-iso -o /mnt -n "$ISONAME" --overlay-iso overlay dir:rootfs
-  echo "Iso generated at $ISONAME.iso"
+  rm -Rf ${TEMPDIR}
+  ISO="elemental-teal.$(uname -m)-${TAG}-$(date "+%FT%TZ").iso"
+  docker run --rm -v ${PWD}:/mnt elemental/iso:latest cp elemental-iso/elemental-teal.$(uname -m)-latest.iso /mnt/${ISO}
+  echo "INFO: ISO generated at ${ISO}"
 }
 
 CLOUD_CONFIG_FILE=${1:-}
 
 build
-
-

--- a/.obs/dockerfile/slem4r-os/Dockerfile
+++ b/.obs/dockerfile/slem4r-os/Dockerfile
@@ -76,8 +76,8 @@ ARG IMAGE_TAG=%VERSION%-%RELEASE%
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"           >> /etc/os-release && \
     echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \
-    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release
-RUN echo GRUB_ENTRY_NAME=\"Elemental\" >> /etc/os-release
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"   >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"Elemental\"        >> /etc/os-release
 
 # Ensure /tmp is mounted as tmpfs by default
 RUN if [ -e /usr/share/systemd/tmp.mount ]; then \
@@ -93,5 +93,5 @@ RUN zypper clean --all && \
 # Rebuild initrd to setup dracut with the boot configurations
 RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
     # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
-    kernel=$(ls /boot/Image-* | head -n1) && \
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi

--- a/.obs/dockerfile/teal-os/Dockerfile
+++ b/.obs/dockerfile/teal-os/Dockerfile
@@ -33,8 +33,8 @@ ARG IMAGE_TAG=%VERSION%-%RELEASE%
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"           >> /etc/os-release && \
     echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \
-    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release
-RUN echo GRUB_ENTRY_NAME=\"Elemental\" >> /etc/os-release
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"   >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"Elemental\"        >> /etc/os-release
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.rancher.elemental
@@ -63,6 +63,5 @@ RUN zypper clean --all && \
 # Rebuild initrd to setup dracut with the boot configurations
 RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
     # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
-    kernel=$(ls /boot/Image-* | head -n1) && \
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi
-

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -2,7 +2,7 @@
 ARG OPERATOR_IMAGE=quay.io/costoolkit/elemental-operator-ci:latest
 ARG REGISTER_IMAGE=quay.io/costoolkit/elemental-register-ci:latest
 ARG SYSTEM_AGENT_IMAGE=rancher/system-agent:v0.2.9
-ARG TOOL_IMAGE=ghcr.io/rancher/elemental-toolkit/elemental-cli:v0.11.0
+ARG BUILDER_IMAGE=ghcr.io/rancher/elemental-toolkit/elemental-cli:v0.11.0
 
 # elemental-operator
 FROM $OPERATOR_IMAGE as elemental-operator
@@ -13,11 +13,11 @@ FROM $REGISTER_IMAGE as elemental-register
 # rancher-system-agent
 FROM $SYSTEM_AGENT_IMAGE as system-agent
 
-FROM $TOOL_IMAGE as elemental-cli
-
+# elemental-cli
+FROM $BUILDER_IMAGE as elemental-cli
 
 # Base os
-FROM registry.suse.com/suse/sle-micro-rancher/5.3:latest as default
+FROM registry.suse.com/suse/sle-micro-rancher/5.4:latest
 
 # Copy elemental-operator
 COPY --from=elemental-operator /usr/sbin/elemental-operator /usr/sbin/elemental-operator
@@ -34,32 +34,35 @@ COPY --from=elemental-cli /usr/bin/elemental /usr/bin/elemental
 COPY framework/files/ /
 
 # Enable services
-RUN systemctl enable NetworkManager sshd elemental-populate-node-labels systemd-timesyncd shutdown-containerd
+RUN systemctl enable elemental-populate-node-labels shutdown-containerd
 
 ARG IMAGE_TAG=latest
 ARG IMAGE_COMMIT=""
 ARG IMAGE_REPO=norepo
-RUN echo COMMIT=\"${IMAGE_COMMIT}\" >> /etc/os-release
-RUN echo IMAGE_REPO=\"${IMAGE_REPO}\" >> /etc/os-release
-RUN echo IMAGE_TAG=\"${IMAGE_TAG}\" >> /etc/os-release
-RUN echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release
-RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release
-RUN echo GRUB_ENTRY_NAME=\"Elemental\" >> /etc/os-release
+
+# IMPORTANT: Setup elemental-release used for versioning/upgrade. The
+# values here should reflect the tag of the image being built
+RUN echo COMMIT=\"${IMAGE_COMMIT}\"           >> /etc/os-release && \
+    echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
+    echo IMAGE_TAG=\"${IMAGE_TAG}\"           >> /etc/os-release && \
+    echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"   >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"Elemental\"        >> /etc/os-release
 
 # Ensure /tmp is mounted as tmpfs by default
 RUN if [ -e /usr/share/systemd/tmp.mount ]; then \
       cp /usr/share/systemd/tmp.mount /etc/systemd/system; \
     fi
 
-# Rebuild initrd to setup dracut with the boot configurations
-RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
-    # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
-    kernel=$(ls /boot/Image-* | head -n1) && \
-    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi
-
-COPY framework/files/etc/cos/bootargs.cfg /etc/cos/bootargs.cfg
-
 # Save some space
 RUN rm -rf /var/log/update* && \
     >/var/log/lastlog && \
     rm -rf /boot/vmlinux*
+
+# Rebuild initrd to setup dracut with the boot configurations
+RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
+    # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
+    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi
+
+COPY framework/files/etc/cos/bootargs.cfg /etc/cos/bootargs.cfg

--- a/Dockerfile.iso
+++ b/Dockerfile.iso
@@ -1,16 +1,24 @@
-ARG OS_IMAGE=registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-teal/5.3:latest
-ARG TOOL_IMAGE=registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-builder-image/5.3:latest
+ARG OS_IMAGE=registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+ARG BUILDER_IMAGE=registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
 
 FROM $OS_IMAGE AS os
-FROM $TOOL_IMAGE as tools
+FROM $BUILDER_IMAGE as builder
 
-FROM tools AS default
 WORKDIR /iso
-COPY --from=os / rootfs
-ARG CLOUD_CONFIG_FILE=iso/config
+
 ARG MANIFEST_FILE=iso/manifest.yaml
+ARG CLOUD_CONFIG_FILE=iso/config
+COPY $MANIFEST_FILE manifest.yaml
 COPY $CLOUD_CONFIG_FILE overlay/livecd-cloud-config.yaml
-COPY $MANIFEST_FILE /iso/manifest.yaml
-ARG ELEMENTAL_VERSION=""
-RUN echo $ELEMENTAL_VERSION
-ENTRYPOINT ["/usr/bin/elemental"]
+COPY --from=os / rootfs
+
+ARG VERSION=latest
+RUN elemental --debug --config-dir . build-iso -o /output -n "elemental-teal.$(uname -m)-${VERSION}" --overlay-iso overlay dir:rootfs
+
+# Only keep the ISO as a result
+FROM registry.opensuse.org/bci/bci-busybox:latest
+COPY --from=builder /output /elemental-iso
+
+# By default run a shell
+ENTRYPOINT ["busybox"]
+CMD ["sh"]


### PR DESCRIPTION
Image/iso built on CI should be based on the same version as the one built on OBS.

Not perfect but these changes should make the GH artifacts close to the OBS one. This is more a workaround until some changes currently tested by @davidcassany should help us to synchronise Dev build with CI.