### PR TITLE
Require elemental-toolkit instead of elemental-cli

### DIFF
--- a/.obs/specfile/elemental.spec
+++ b/.obs/specfile/elemental.spec
@@ -29,7 +29,7 @@ Source:         %{name}-%{version}.tar
 Source1:        LICENSE
 Source2:        README.md
 
-Requires:       elemental-cli
+Requires:       elemental-toolkit
 Requires:       elemental-register
 Requires:       elemental-system-agent
 Requires:       elemental-support


### PR DESCRIPTION
In OBS specfile.

Will rename the package in OBS as well.