### PR TITLE
ci: temporary workaround to fix upgrade to Staging

### DIFF
--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -62,4 +62,4 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest
-      upgrade_os_channel: latest-${{ inputs.upgrade_os_channel }}
+      upgrade_os_channel: latest

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -28,5 +28,5 @@ jobs:
       rancher_version: latest/devel
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -29,5 +29,5 @@ jobs:
       rancher_version: stable/latest
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
-      upgrade_os_channel: dev
+      upgrade_os_channel: latest-dev
       upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -63,5 +63,5 @@ jobs:
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest
-      upgrade_os_channel: latest-${{ inputs.upgrade_os_channel }}
+      upgrade_os_channel: latest
       upstream_cluster_version: v1.26.7+rke2r1


### PR DESCRIPTION
This is temporary to be able to validate Staging, all this part will be changed shortly to use the new OS channels.