### PR TITLE
ci/ui: fix how staging is tagged in UI

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -356,6 +356,7 @@ jobs:
             /workdir/e2e/unit_tests/machine_registration.spec.ts
             /workdir/e2e/unit_tests/advanced_filtering.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
+          UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
         run: cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure() && inputs.test_type == 'ui'

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -37,11 +37,9 @@ describe('Machine registration testing', () => {
     // In upgrade scenario, we need to add extra channels
     if (utils.isCypressTag('upgrade')) {
       if (utils.isOperatorVersion('stable')) {
-        cy.addOsVersionChannel('dev');
-        cy.addOsVersionChannel('staging');
+        utils.isUpgradeOsChannel('dev') ? cy.addOsVersionChannel('dev') : cy.addOsVersionChannel('staging');
       } else if (utils.isOperatorVersion('staging')) {
         cy.addOsVersionChannel('dev');
-        cy.addOsVersionChannel('stable'); // Not sure it is needed
       } else {
         cy.addOsVersionChannel('stable');
       }

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -27,7 +27,6 @@ describe('Upgrade tests', () => {
   const uiAccount        = Cypress.env('ui_account');
   const uiPassword       = "rancherpassword"
   const upgradeImage     = Cypress.env('upgrade_image')
-  const upgradeOsChannel = Cypress.env('upgrade_os_channel')
 
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
@@ -84,19 +83,11 @@ describe('Upgrade tests', () => {
             .click();
           cy.getBySel('os-version-box')
             .click()
-          // TODO: remove hardcoded staging version
-          if (upgradeOsChannel == "staging") {
-            cy.getBySel('os-version-box')
-              .parents()
-              .contains('v1.2.1')
-              .click();
-          } else {
-            cy.getBySel('os-version-box')
-              .parents()
-              .contains('latest-'+upgradeOsChannel)
-              .click();
-          }
-        }
+          cy.getBySel('os-version-box')
+            .parents()
+            .contains('latest')
+            .click();
+        } 
 
         cy.getBySel('form-save')
         .contains('Create')

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -110,12 +110,18 @@ Cypress.Commands.add('createMachReg', (
       if (utils.isCypressTag('upgrade')) {
         // Stable operator version is hardcoded for now
         // Will try to improve it in next version
-        utils.isOperatorVersion('staging') ? cy.contains('Elemental Teal ISO x86_64 latest-staging').click() : cy.contains('Elemental Teal ISO x86_64 v1.1.5').click();
+        if (utils.isOperatorVersion('staging')) {
+          // In rare case, we might want to test upgrading from staging to dev
+          utils.isUpgradeOsChannel('dev') ? cy.contains('Elemental Teal ISO x86_64 (latest)').click(): null;
+        } else {
+            cy.contains('Elemental Teal ISO x86_64 v1.1.5')
+            .click();
+        }
       } else if (utils.isOperatorVersion('stable')) {
         cy.contains('Elemental Teal ISO x86_64 v1.1.5')
           .click();
       } else if (utils.isOperatorVersion('staging')) {
-        cy.contains('Elemental Teal ISO x86_64 latest-staging')
+        cy.contains('Elemental Teal ISO x86_64 (latest)')
             .click();
       } else {
         cy.contains('Elemental Teal ISO x86_64 latest-dev')

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -24,3 +24,8 @@ export const isRancherManagerVersion = (version: string) => {
 export const isUIVersion = (version: string) => {
   return (new RegExp(version)).test(Cypress.env("elemental_ui_version"));
 }
+
+// Check the upgrade target
+export const isUpgradeOsChannel = (channel: string) => {
+  return (new RegExp(channel)).test(Cypress.env("upgrade_os_channel"));
+}


### PR DESCRIPTION
1) The test has to select the entry which contains `(latest)`
![image](https://github.com/rancher/elemental/assets/6025636/e45f7c6c-400f-437e-808d-c2e3029cdb5f)

2) OS version is now named `latest` instead of `latest-staging`

## Verification runs
UI-RKE2-OS-Upgrade - [upgrade to staging](https://github.com/rancher/elemental/actions/runs/6048218184) Videos checked ✅ 
UI-RKE2-OS-Upgrade - [upgrade to dev](https://github.com/rancher/elemental/actions/runs/6048866155) Videos checked ✅ 
[UI-RKE2-OBS_Staging](https://github.com/rancher/elemental/actions/runs/6048227105) Videos checked ✅ 

[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6048230829) Videos checked ✅ 
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6048844124) Videos checked ✅ 