### PR TITLE
ci/ui: automate the reset feature test

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -405,6 +405,7 @@ jobs:
           SPEC: |
             /workdir/e2e/unit_tests/machine_selector.spec.ts
             /workdir/e2e/unit_tests/machine_inventory.spec.ts
+            /workdir/e2e/unit_tests/reset.spec.ts
             /workdir/e2e/unit_tests/deploy_app.spec.ts
             /workdir/e2e/unit_tests/upgrade.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
-import { isRancherManagerVersion } from '../../support/utils';
+import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
@@ -81,61 +81,7 @@ describe('Machine inventory testing', () => {
   filterTests(['main', 'upgrade'], () => {
     qase(30,
       it('Create Elemental cluster', () => {
-        cy.getBySel('button-create-elemental-cluster')
-          .click();
-        cy.getBySel('name-ns-description-name')
-          .type(clusterName);
-        cy.getBySel('name-ns-description-description')
-          .type('My Elemental testing cluster');
-        cy.contains('Show deprecated Kubernetes')
-          .click();
-        cy.contains('Kubernetes Version')
-          .click();
-        cy.contains(k8sVersion)
-          .click();
-        // Configure proxy if proxy is set to elemental
-        if ( Cypress.env('proxy') == "elemental") {
-          cy.contains('Agent Environment Vars')
-            .click();
-          cy.get('#agentEnv > .key-value')
-            .contains('Add')
-            .click();
-          cy.get('.key > input')
-            .type('HTTP_PROXY');
-          cy.get('.no-resize')
-            .type(proxy);
-          cy.get('#agentEnv > .key-value')
-            .contains('Add')
-            .click();
-          cy.get(':nth-child(7) > input')
-            .type('HTTPS_PROXY');
-          if (isRancherManagerVersion('-head')) {
-            cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
-          } else {
-            cy.get(':nth-child(8) > .no-resize').type(proxy);
-          }
-          cy.get('#agentEnv > .key-value')
-            .contains('Add')
-            .click();
-          cy.get(':nth-child(10) > input')
-            .type('NO_PROXY');
-          if (isRancherManagerVersion('-head')) {
-            cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
-              .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
-          } else {
-            cy.get(':nth-child(11) > .no-resize')
-            .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
-          }
-        }
-        cy.clickButton('Create');
-        // This wait can be replaced by something cleaner
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(3000);
-        cypressLib.checkClusterStatus(clusterName, 'Updating', 300000);
-        cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
-        // Ugly but needed unfortunately to make sure the cluster stops switching status
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(240000);
+        utils.createCluster(clusterName, k8sVersion, proxy);
       })
     );
   });

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -186,7 +186,7 @@ describe('Machine registration testing', () => {
           true,
           //checkIsoBuilding
           true,
-          'custom_cloud-config.yaml',
+          'custom_cloud-config_with_reset.yaml',
           //checkDefaultCloudConfig
           false);
         cy.checkMachInvLabel('machine-registration', 'myInvLabel1', 'myInvLabelValue1', false);

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -186,7 +186,7 @@ describe('Machine registration testing', () => {
           true,
           //checkIsoBuilding
           true,
-          'custom_cloud-config_with_reset.yaml',
+          utils.isK8sVersion('k3s') ? 'custom_cloud-config_with_reset.yaml' : 'custom_cloud-config.yaml',
           //checkDefaultCloudConfig
           false);
         cy.checkMachInvLabel('machine-registration', 'myInvLabel1', 'myInvLabelValue1', false);

--- a/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import { Elemental } from '~/support/elemental';
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';

--- a/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import { Elemental } from '~/support/elemental';
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -1,0 +1,113 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import '~/support/commands';
+import filterTests from '~/support/filterTests.js';
+import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+filterTests(['main'], () => {
+  Cypress.config();
+  describe('Reset testing', () => {
+    const clusterName   = "mycluster"
+    const elementalUser = "elemental-user"
+    const k8sVersion    = Cypress.env('k8s_version');
+    const proxy         = "http://172.17.0.1:3128" 
+    const uiAccount     = Cypress.env('ui_account');
+    const uiPassword    = "rancherpassword"
+  
+    beforeEach(() => {
+      (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
+      cy.visit('/');
+      cypressLib.burgerMenuOpenIfClosed();
+      cypressLib.accesMenu('OS Management');
+    });
+  
+    qase(2,
+      it('Reset node by deleting the cluster', () => {
+        cy.viewport(1920, 1080);
+        //cypressLib.burgerMenuOpenIfClosed();
+        //cypressLib.accesMenu('OS Management');
+        cy.getBySel('button-manage-elemental-clusters').click();
+        cy.getBySel('sortable-cell-0-0').click();
+        cy.clickButton('Delete');
+        cy.getBySel('prompt-remove-input')
+          .type('mycluster');
+        cy.getBySel('prompt-remove-confirm-button').click();
+        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.accesMenu('OS Management');
+        cy.clickNavMenu(["Inventory of Machines"]);
+        cy.contains('There are no rows to show.');
+        cy.getBySel('sortable-table-0-row', { timeout: 180000 })
+          .contains('Active', { timeout: 180000 });
+    }));
+
+    it('Create Elemental cluster', () => {
+      cy.getBySel('button-create-elemental-cluster')
+        .click();
+      cy.getBySel('name-ns-description-name')
+        .type(clusterName);
+      cy.getBySel('name-ns-description-description')
+        .type('My Elemental testing cluster');
+      cy.contains('Show deprecated Kubernetes')
+        .click();
+      cy.contains('Kubernetes Version')
+        .click();
+      cy.contains(k8sVersion)
+        .click();
+      // Configure proxy if proxy is set to elemental
+      if ( Cypress.env('proxy') == "elemental") {
+        cy.contains('Agent Environment Vars')
+          .click();
+        cy.get('#agentEnv > .key-value')
+          .contains('Add')
+          .click();
+        cy.get('.key > input')
+          .type('HTTP_PROXY');
+        cy.get('.no-resize')
+          .type(proxy);
+        cy.get('#agentEnv > .key-value')
+          .contains('Add')
+          .click();
+        cy.get(':nth-child(7) > input')
+          .type('HTTPS_PROXY');
+        if (isRancherManagerVersion('-head')) {
+          cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
+        } else {
+          cy.get(':nth-child(8) > .no-resize').type(proxy);
+        }
+        cy.get('#agentEnv > .key-value')
+          .contains('Add')
+          .click();
+        cy.get(':nth-child(10) > input')
+          .type('NO_PROXY');
+        if (isRancherManagerVersion('-head')) {
+          cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
+            .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
+        } else {
+          cy.get(':nth-child(11) > .no-resize')
+          .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
+        }
+      }
+      cy.clickButton('Create');
+      // This wait can be replaced by something cleaner
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(3000);
+      cypressLib.checkClusterStatus(clusterName, 'Updating', 300000);
+      cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
+      // Ugly but needed unfortunately to make sure the cluster stops switching status
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(240000);
+    })
+  });
+});

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as utils from "~/support/utils";

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -33,7 +33,21 @@ filterTests(['main'], () => {
       cypressLib.burgerMenuOpenIfClosed();
       cypressLib.accesMenu('OS Management');
     });
-  
+    
+    if (utils.isK8sVersion('rke')) {
+      it('Enable reset in machine inventory', () => {
+        cy.clickNavMenu(["Inventory of Machines"]);
+        cy.getBySel('sortable-table-0-action-button').click();
+        cy.contains('Edit YAML').click();
+        cy.contains('annotations').as('anno')
+        cy.get('@anno').click(0,0)
+        cy.get('@anno').type('{end}{enter}  elemental.cattle.io/resettable: \'true\'');
+        cy.getBySel('action-button-async-button')
+        .contains('Save')
+        .click();
+      });
+    }
+
     qase(2,
       it('Reset node by deleting the cluster', () => {
         cy.viewport(1920, 1080);

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -13,6 +13,7 @@ limitations under the License.
 */
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
+import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
@@ -53,61 +54,7 @@ filterTests(['main'], () => {
     }));
 
     it('Create Elemental cluster', () => {
-      cy.getBySel('button-create-elemental-cluster')
-        .click();
-      cy.getBySel('name-ns-description-name')
-        .type(clusterName);
-      cy.getBySel('name-ns-description-description')
-        .type('My Elemental testing cluster');
-      cy.contains('Show deprecated Kubernetes')
-        .click();
-      cy.contains('Kubernetes Version')
-        .click();
-      cy.contains(k8sVersion)
-        .click();
-      // Configure proxy if proxy is set to elemental
-      if ( Cypress.env('proxy') == "elemental") {
-        cy.contains('Agent Environment Vars')
-          .click();
-        cy.get('#agentEnv > .key-value')
-          .contains('Add')
-          .click();
-        cy.get('.key > input')
-          .type('HTTP_PROXY');
-        cy.get('.no-resize')
-          .type(proxy);
-        cy.get('#agentEnv > .key-value')
-          .contains('Add')
-          .click();
-        cy.get(':nth-child(7) > input')
-          .type('HTTPS_PROXY');
-        if (isRancherManagerVersion('-head')) {
-          cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
-        } else {
-          cy.get(':nth-child(8) > .no-resize').type(proxy);
-        }
-        cy.get('#agentEnv > .key-value')
-          .contains('Add')
-          .click();
-        cy.get(':nth-child(10) > input')
-          .type('NO_PROXY');
-        if (isRancherManagerVersion('-head')) {
-          cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
-            .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
-        } else {
-          cy.get(':nth-child(11) > .no-resize')
-          .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
-        }
-      }
-      cy.clickButton('Create');
-      // This wait can be replaced by something cleaner
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(3000);
-      cypressLib.checkClusterStatus(clusterName, 'Updating', 300000);
-      cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
-      // Ugly but needed unfortunately to make sure the cluster stops switching status
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(240000);
-    })
+      utils.createCluster(clusterName, k8sVersion, proxy);
+    });
   });
 });

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -35,24 +35,23 @@ filterTests(['main'], () => {
     });
     
     if (utils.isK8sVersion('rke')) {
-      it('Enable reset in machine inventory', () => {
-        cy.clickNavMenu(["Inventory of Machines"]);
-        cy.getBySel('sortable-table-0-action-button').click();
-        cy.contains('Edit YAML').click();
-        cy.contains('annotations').as('anno')
-        cy.get('@anno').click(0,0)
-        cy.get('@anno').type('{end}{enter}  elemental.cattle.io/resettable: \'true\'');
-        cy.getBySel('action-button-async-button')
-        .contains('Save')
-        .click();
-      });
-    }
+      qase(54,
+        it('Enable reset in machine inventory', () => {
+          cy.clickNavMenu(["Inventory of Machines"]);
+          cy.getBySel('sortable-table-0-action-button').click();
+          cy.contains('Edit YAML').click();
+          cy.contains('annotations').as('anno')
+          cy.get('@anno').click(0,0)
+          cy.get('@anno').type('{end}{enter}  elemental.cattle.io/resettable: \'true\'');
+          cy.getBySel('action-button-async-button')
+          .contains('Save')
+          .click();
+      }));
+    };
 
-    qase(2,
+    qase(['54', '55'],
       it('Reset node by deleting the cluster', () => {
         cy.viewport(1920, 1080);
-        //cypressLib.burgerMenuOpenIfClosed();
-        //cypressLib.accesMenu('OS Management');
         cy.getBySel('button-manage-elemental-clusters').click();
         cy.getBySel('sortable-cell-0-0').click();
         cy.clickButton('Delete');
@@ -67,8 +66,9 @@ filterTests(['main'], () => {
           .contains('Active', { timeout: 180000 });
     }));
 
-    it('Create Elemental cluster', () => {
-      utils.createCluster(clusterName, k8sVersion, proxy);
-    });
+    qase(30,
+      it('Create Elemental cluster', () => {
+        utils.createCluster(clusterName, k8sVersion, proxy);
+      }));
   });
 });

--- a/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
@@ -1,0 +1,18 @@
+config:
+  cloud-config:
+    users:
+    - name: root
+      passwd: root
+  elemental:
+    install:
+      poweroff: true
+      device: /dev/sda
+      debug: true
+    reset:
+      debug: true
+      enabled: true
+      reset-persistent: true
+      reset-oem: true
+      power-off: false
+      reboot: true
+machineName: my-machine

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -1,3 +1,5 @@
+import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+
 // Check the Cypress tags
 // Implemented but not used yet
 export const isCypressTag = (tag: string) => {
@@ -28,4 +30,63 @@ export const isUIVersion = (version: string) => {
 // Check the upgrade target
 export const isUpgradeOsChannel = (channel: string) => {
   return (new RegExp(channel)).test(Cypress.env("upgrade_os_channel"));
+}
+
+// Create Elemental cluster
+export const createCluster = (clusterName: string, k8sVersion: string, proxy: string) => {
+  cy.getBySel('button-create-elemental-cluster')
+    .click();
+  cy.getBySel('name-ns-description-name')
+    .type(clusterName);
+  cy.getBySel('name-ns-description-description')
+    .type('My Elemental testing cluster');
+  cy.contains('Show deprecated Kubernetes')
+    .click();
+  cy.contains('Kubernetes Version')
+    .click();
+  cy.contains(k8sVersion)
+    .click();
+  // Configure proxy if proxy is set to elemental
+  if ( Cypress.env('proxy') == "elemental") {
+    cy.contains('Agent Environment Vars')
+      .click();
+    cy.get('#agentEnv > .key-value')
+      .contains('Add')
+      .click();
+    cy.get('.key > input')
+      .type('HTTP_PROXY');
+    cy.get('.no-resize')
+      .type(proxy);
+    cy.get('#agentEnv > .key-value')
+      .contains('Add')
+      .click();
+    cy.get(':nth-child(7) > input')
+      .type('HTTPS_PROXY');
+    if (isRancherManagerVersion('-head')) {
+      cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
+    } else {
+      cy.get(':nth-child(8) > .no-resize').type(proxy);
+    }
+    cy.get('#agentEnv > .key-value')
+      .contains('Add')
+      .click();
+    cy.get(':nth-child(10) > input')
+      .type('NO_PROXY');
+    if (isRancherManagerVersion('-head')) {
+      cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
+        .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
+    } else {
+      cy.get(':nth-child(11) > .no-resize')
+      .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
+    }
+  }
+  cy.clickButton('Create');
+  // This wait can be replaced by something cleaner
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(3000);
+  cypressLib.checkClusterStatus(clusterName, 'Updating', 300000);
+  cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
+  // Ugly but needed unfortunately to make sure the cluster stops switching status
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(240000);
 }


### PR DESCRIPTION
Partially address #952 

Tests only use [the default values](http://elemental.docs.rancher.com/next/machineregistration-reference#configelementalreset) for the reset feature. 

- [x] Enable reset at machine registration level, create a one-node cluster, delete it, and check if reset works as expected, then create a new cluster with the reset node. Only for K3S
- [x] Enable reset at machine inventory level, create a one-node cluster, delete it, and check if reset works as expected, then create a new cluster with the reset node. Only for RKE2
- [x] New tests added to QASE (53 and 54)

## Verification runs
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6119301486/job/16608983739) ✅ 
[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6119302718/job/16608998525) ✅ 