### PR TITLE
ci: test reset feature in cli tests

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: boolean
       iso_to_test:
         description: Defines the ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
+        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
         type: string
       k8s_version:
         description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -467,6 +467,9 @@ jobs:
       - name: Install a simple application
         if: inputs.test_type == 'cli' && contains(inputs.upstream_cluster_version, 'k3s')
         run: cd tests && make e2e-install-app && make e2e-check-app
+      - name: Reset a node in the cluster
+        if: inputs.test_type == 'cli' && inputs.rancher_upgrade == ''
+        run: cd tests && make e2e-reset && make e2e-check-app
       - name: Upgrade Elemental Operator
         if: inputs.test_type == 'cli' && inputs.operator_upgrade != ''
         id: operator_upgrade

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -73,6 +73,8 @@ e2e-check-app: deps
 	ginkgo --label-filter check-app -r -v ./e2e
 e2e-configure-rancher: deps
 	ginkgo --label-filter configure -r -v ./e2e
+e2e-reset: deps
+	ginkgo --label-filter reset -r -v ./e2e
 e2e-get-logs: deps
 	ginkgo --label-filter logs -r -v ./e2e
 e2e-install-rancher: deps

--- a/tests/assets/reset_machine_inventory.yaml
+++ b/tests/assets/reset_machine_inventory.yaml
@@ -1,0 +1,3 @@
+metadata:
+  annotations:
+    elemental.cattle.io/resettable: "true"

--- a/tests/e2e/reset_test.go
+++ b/tests/e2e/reset_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+)
+
+var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
+	It("Reset one node in the cluster", func() {
+		// Get the machine inventory name list
+		machineInventory, err := kubectl.Run("get", "machineinventory", "-A", "-o", "jsonpath='{.items[*].metadata.name}'")
+		Expect(err).To(Not(HaveOccurred()))
+		firstMachineInventory := strings.Split(machineInventory, " ")[1]
+
+		By("Configuring reset at machine inventory level", func() {
+			// Patch the first machine inventory to enable reset
+			_, err = kubectl.Run("patch", "machineinventory", firstMachineInventory, "--namespace", clusterNS, "--type", "merge", "--patch-file", resetMachineInv)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Deleting and removing the node from the cluster", func() {
+			out, err := exec.Command("bash", "-c", "kubectl get machines -A | awk '/"+firstMachineInventory+"/ {print $2}'").CombinedOutput()
+			Expect(err).To(Not(HaveOccurred()))
+			machineToRemove := strings.Trim(string(out), "\n")
+			_, err = kubectl.Run("delete", "machines", machineToRemove, "-n", "fleet-default")
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Checking that machine inventory is deleted", func() {
+			Eventually(func() string {
+				out, _ := kubectl.Run("get", "MachineInventory",
+					"--namespace", clusterNS,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				return out
+			}, tools.SetTimeout(5*time.Minute), 5*time.Second).ShouldNot(ContainSubstring(firstMachineInventory))
+		})
+
+		By("Checking that machine inventory is back after the reset", func() {
+			Eventually(func() string {
+				out, _ := kubectl.Run("get", "MachineInventory",
+					"--namespace", clusterNS,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				return out
+			}, tools.SetTimeout(8*time.Minute), 5*time.Second).Should(ContainSubstring(firstMachineInventory))
+		})
+
+		By("Checking cluster state", func() {
+			CheckClusterState(clusterNS, clusterName)
+		})
+	})
+})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -46,6 +46,7 @@ const (
 	netDefaultFileName    = "../assets/net-default.xml"
 	numberOfNodesMax      = 30
 	registrationYaml      = "../assets/machineRegistration.yaml"
+	resetMachineInv       = "../assets/reset_machine_inventory.yaml"
 	restoreYaml           = "../assets/restore.yaml"
 	seedimageYaml         = "../assets/seedImage.yaml"
 	selectorYaml          = "../assets/selector.yaml"


### PR DESCRIPTION
Fix #952 

This PR adds a test for the reset feature in the CLI CI.
* It patches a machine inventory to enable the reset
* Reset the node
* Check that the associated machine inventory is deleted 
* Check that the associated machine inventory comes back
* Check that the cluster is healthy

## Verification run
[CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/6264724481/job/17012071820) with k3s and staging ✅ 
[CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/6275310203/job/17042551939) with k3s and dev ✅  

With the system agent fix: https://github.com/rancher/elemental/actions/runs/6278123526/job/17051261008