### PR TITLE
ci/ui: fix stable version in ui tests

### DIFF
--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-RKE2-OBS_Stable
+name: UI-K3s-IBS_Stable
 
 on:
   workflow_dispatch:
@@ -16,9 +16,13 @@ on:
         description: Version of the elemental ui which will be installed (dev/stable)
         default: stable
         type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
       rancher_version:
         description: Rancher Manager channel/version to use for installation
-        default: latest/devel
+        default: stable/latest
         type: string
 
 jobs:
@@ -30,17 +34,15 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
-      ui_account: user
+      test_description: "Manual - Fully customizable - UI - IBS Deployment test with Standard K3s"
       qase_run_id: ${{ inputs.qase_run_id }}
-      ca_type: private
-      cluster_name: cluster-rke2
+      cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      k8s_version_to_provision: v1.26.7+k3s1
+      operator_repo: oci://registry.suse.com/rancher
+      proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -38,7 +38,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -31,9 +31,9 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+k3s1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       iso_to_test:
         description: ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
         type: string
       operator_repo:
         description: Elemental operator repository to use
-        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+        default: oci://registry.suse.com/rancher
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-K3s-OBS_Stable
+name: UI-RKE2-IBS_Stable
 
 on:
   workflow_dispatch:
@@ -16,13 +16,9 @@ on:
         description: Version of the elemental ui which will be installed (dev/stable)
         default: stable
         type: string
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       rancher_version:
         description: Rancher Manager channel/version to use for installation
-        default: stable/latest
+        default: latest/devel
         type: string
 
 jobs:
@@ -34,15 +30,17 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
+      test_description: "Manual - Fully customizable - UI - IBS Deployment test with Standard RKE2"
+      ui_account: user
       qase_run_id: ${{ inputs.qase_run_id }}
-      cluster_name: cluster-k3s
+      ca_type: private
+      cluster_name: cluster-rke2
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+k3s1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
-      proxy: ${{ inputs.proxy }}
+      iso_boot: true
+      k8s_version_to_provision: v1.26.7+rke2r1
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -42,7 +42,7 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.7+rke2r1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -14,7 +14,7 @@ on:
         type: boolean
       operator_repo:
         description: Elemental operator repository to use
-        default: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+        default: oci://registry.suse.com/rancher
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -36,7 +36,7 @@ describe('Machine registration testing', () => {
 
     // In upgrade scenario, we need to add extra channels
     if (utils.isCypressTag('upgrade')) {
-      if (utils.isOperatorVersion('stable')) {
+      if (utils.isOperatorVersion('registry.suse.com')) {
         utils.isUpgradeOsChannel('dev') ? cy.addOsVersionChannel('dev') : cy.addOsVersionChannel('staging');
       } else if (utils.isOperatorVersion('staging')) {
         cy.addOsVersionChannel('dev');

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -43,8 +43,9 @@ describe('Upgrade tests', () => {
     qase(33,
       it('Check OS Versions', () => {
         cy.clickNavMenu(["Advanced", "OS Versions"]);
-        utils.isOperatorVersion('dev') ? cy.contains('Active latest-dev', {timeout: 120000}): null;
-        utils.isOperatorVersion('staging') ? cy.contains('Active latest-staging', {timeout: 120000}): null;
+        if (utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
+          cy.contains('Active latest', {timeout: 120000});
+        }
       })
     );
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -102,7 +102,7 @@ Cypress.Commands.add('createMachReg', (
     // Test ISO building feature
     if (checkIsoBuilding && utils.isK8sVersion('rke2')) {
       // Build the ISO according to the elemental operator version
-      // Most of the time, it uses the latest-dev version but sometimes
+      // Most of the time, it uses the latest dev version but sometimes
       // before releasing, we want to test staging/stable artifacts 
       cy.getBySel('select-os-version-build-iso')
       .click();
@@ -114,17 +114,14 @@ Cypress.Commands.add('createMachReg', (
           // In rare case, we might want to test upgrading from staging to dev
           utils.isUpgradeOsChannel('dev') ? cy.contains('Elemental Teal ISO x86_64 (latest)').click(): null;
         } else {
-            cy.contains('Elemental Teal ISO x86_64 v1.1.5')
+            cy.contains('Elemental Teal ISO x86_64 v1.2.2')
             .click();
         }
-      } else if (utils.isOperatorVersion('stable')) {
-        cy.contains('Elemental Teal ISO x86_64 v1.1.5')
+      } else if (utils.isOperatorVersion('registry.suse.com')) {
+        cy.contains('Elemental Teal ISO x86_64 v1.2.2')
           .click();
-      } else if (utils.isOperatorVersion('staging')) {
-        cy.contains('Elemental Teal ISO x86_64 (latest)')
-            .click();
       } else {
-        cy.contains('Elemental Teal ISO x86_64 latest-dev')
+        cy.contains('Elemental Teal ISO x86_64 (latest)')
           .click();
       }
       cy.getBySel('build-iso-btn')


### PR DESCRIPTION
Address #998 
Use IBS artifacts as stable instead of OBS.

## Verification runs
[UI-K3S-IBS_Stable](https://github.com/rancher/elemental/actions/runs/6183822497) ✅ 
[UI-RKE2-IBS_Stable](https://github.com/rancher/elemental/actions/runs/6183823614) ✅ 

[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6183824954)✅ 
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6183826170)✅ 
[UI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6183808285)✅ 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6183827355)✅ 
