### PR TITLE
ci/cli: use Stable image from IBS

### DIFF
--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-RKE2-OBS_Stable
+name: CLI-K3s-IBS_Stable
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ on:
         type: string
 
 concurrency:
-  group: e2e-rke2-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -33,14 +33,12 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard K3s"
       qase_run_id: ${{ inputs.qase_run_id }}
-      ca_type: private
-      cluster_name: cluster-rke2
+      cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      k8s_version_to_provision: v1.26.7+k3s1
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -19,11 +19,11 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: latest/devel
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -19,11 +19,11 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       iso_to_test:
         description: ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
         type: string
       operator_repo:
         description: Operator version to use for initial deployment
-        default: stable
+        default: oci://registry.opensuse.org/rancher
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
@@ -57,7 +57,7 @@ jobs:
       k8s_version_to_provision: v1.26.7+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.operator_repo }}/charts/rancher
+      operator_repo: ${{ inputs.operator_repo }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal-channel:latest

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-K3s-OBS_Stable
+name: CLI-RKE2-IBS_Stable
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ on:
         type: string
 
 concurrency:
-  group: e2e-k3s-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: e2e-rke2-obs-stable-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -33,12 +33,14 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      test_description: "Manual - CLI - Parallel - Deployment test with Standard K3s"
+      test_description: "Manual - CLI - Parallel - Deployment test with Standard RKE2"
       qase_run_id: ${{ inputs.qase_run_id }}
-      cluster_name: cluster-k3s
+      ca_type: private
+      cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+k3s1
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      k8s_version_to_provision: v1.26.7+rke2r1
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
+      upstream_cluster_version: v1.26.7+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -20,11 +20,11 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       rancher_version: latest/devel
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -20,11 +20,11 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.7+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/rancher
+      operator_repo: oci://registry.suse.com/rancher
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal-channel:latest

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       iso_to_test:
         description: ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Stable:/Teal53/media/iso/elemental-teal.x86_64.iso
+        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
         type: string
       operator_repo:
         description: Operator version to use for initial deployment
-        default: stable
+        default: oci://registry.opensuse.org/rancher
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
@@ -58,7 +58,7 @@ jobs:
       k8s_version_to_provision: v1.26.7+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
-      operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.operator_repo }}/charts/rancher
+      operator_repo: ${{ inputs.operator_repo }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_channel_list: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal-channel:latest

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -453,9 +453,8 @@ jobs:
           [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
           # Disable EMULATE_TPM in case of upgrade test
           # This is because we don't know the version in advance, so easier to not use it
-          if ${{ inputs.upgrade_image != '' }}      || \
-             ${{ inputs.upgrade_os_channel != '' }} || \
-             ${{ contains(inputs.iso_to_test, '/Stable:/') }}; then
+          if ${{ inputs.upgrade_image != '' }} || \
+             ${{ inputs.upgrade_os_channel != '' }}; then
             unset EMULATE_TPM
           fi
           # Execute bootstrapping test


### PR DESCRIPTION
On OBS there is now only Dev and Staging images.
Related to https://github.com/rancher/elemental/pull/1000.

Verification runs:
- [CLI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6186725925)
- [CLI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6186741299)

Note: VRs are failing with message `Error from server (NotFound): managedosversions.elemental.cattle.io "latest-dev" not found` because the OS Version Channel has been changed once again... But not related to this PR.