### PR TITLE
ci: minor modifications in client cluster deployment

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -4,6 +4,10 @@ name: CLI-OBS-Manual-Workflow
 on:
   workflow_dispatch:
     inputs:
+      ca_type:
+        description: CA type to use (selfsigned or private)
+        default: selfsigned
+        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -15,8 +19,8 @@ on:
         description: Defines the ISO to test
         default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
         type: string
-      k8s_version_to_provision:
-        description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
+      k8s_version:
+        description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
         default: v1.26.7+k3s1
         type: string
       node_number:
@@ -53,13 +57,15 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - CLI - IBS/OBS Deployment test"
+      ca_type: ${{ inputs.ca_type }}
       cluster_name: my-own-cluster
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_version_to_provision: ${{ inputs.k8s_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}
+      upstream_cluster_version: ${{ inputs.k8s_version }}

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -51,7 +51,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				count := 1
 				Eventually(func() error {
 					// Execute RKE2 installation
-					out, err := exec.Command("sudo", "sh", fileName).CombinedOutput()
+					out, err := exec.Command("sudo", "--preserve-env=INSTALL_RKE2_VERSION", "sh", fileName).CombinedOutput()
 					GinkgoWriter.Printf("RKE2 installation loop %d:\n%s\n", count, out)
 					count++
 					return err


### PR DESCRIPTION
Allow the use of RKE2 as upstream cluster in manual CLI workflow.
RKE2 upstream cluster installed was not the asked version, fix it.

Verification run:
- [CLI-OBS-Manual-Workflow 1](https://github.com/rancher/elemental/actions/runs/6185733132)
- [CLI-OBS-Manual-Workflow 2](https://github.com/rancher/elemental/actions/runs/6186389678)