### PR TITLE
ci/ui: remove iso tests from ui

### DIFF
--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -40,7 +40,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -36,7 +36,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -36,7 +36,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/containers/iso/elemental-teal.x86_64.iso
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -38,7 +38,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -31,7 +31,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -12,10 +12,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      iso_to_test:
-        description: ISO to test
-        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-        type: string
       operator_repo:
         description: Elemental operator repository to use
         default: oci://registry.suse.com/rancher
@@ -47,7 +43,7 @@ jobs:
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
-      iso_to_test: ${{ inputs.iso_to_test }}
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -32,6 +32,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}

--- a/.github/workflows/ui-k3s-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-rancher_stable.yaml
@@ -32,6 +32,7 @@ jobs:
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
+      iso_boot: true
       k8s_version_to_provision: v1.26.7+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -15,10 +15,6 @@ on:
         description: Elemental UI version to use
         default: dev
         type: string
-      iso_to_test:
-        description: Defines the ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev:/Teal53/media/iso/elemental-teal.x86_64.iso
-        type: string
       k8s_version_to_provision:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
         default: v1.26.7+k3s1
@@ -53,7 +49,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
-      iso_to_test: ${{ inputs.iso_to_test }}
+      iso_boot: true
       k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add('createMachReg', (
       .contains(/https:\/\/.*elemental\/registration/);
 
     // Test ISO building feature
-    if (checkIsoBuilding && utils.isK8sVersion('rke2')) {
+    if (checkIsoBuilding) {
       // Build the ISO according to the elemental operator version
       // Most of the time, it uses the latest dev version but sometimes
       // before releasing, we want to test staging/stable artifacts 

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -40,9 +40,7 @@ docker run -v $PWD:/workdir -w /workdir                     \
 
 [[ -d downloads ]] && sudo chown -R gh-runner:users downloads videos
 
-# RKE2 as upstream cluster
-# We cannot use PXE boot so we have to boot from ISO
-if [[ ! -f ${ELEMENTAL_ISO} ]] && grep rke <<< ${K8S_UPSTREAM_VERSION}; then
+if [[ ! -f ${ELEMENTAL_ISO} ]]; then
   # Move elemental.iso into the expected folder
   mv downloads/*.iso ${ELEMENTAL_ISO}
 fi


### PR DESCRIPTION
Address https://github.com/rancher/elemental/issues/1002 partially (only for the UI)
Remove all tests which use ISO and use seedimage builder instead

## Verification runs
[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6186077585) ✅ 
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6187194649/job/16796549058)✅ 
[UI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6186080069)✅ 
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6187196558/job/16796544984)✅ 