### PR TITLE
ci/ui: use unstable instead of latest-dev tag

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -86,7 +86,7 @@ describe('Upgrade tests', () => {
             .click()
           cy.getBySel('os-version-box')
             .parents()
-            .contains('latest')
+            .contains('unstable')
             .click();
         } 
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -112,7 +112,7 @@ Cypress.Commands.add('createMachReg', (
         // Will try to improve it in next version
         if (utils.isOperatorVersion('staging')) {
           // In rare case, we might want to test upgrading from staging to dev
-          utils.isUpgradeOsChannel('dev') ? cy.contains('Elemental Teal ISO x86_64 (latest)').click(): null;
+          utils.isUpgradeOsChannel('dev') ? cy.contains('Elemental Teal ISO x86_64 (unstable)').click(): null;
         } else {
             cy.contains('Elemental Teal ISO x86_64 v1.2.2')
             .click();
@@ -121,7 +121,7 @@ Cypress.Commands.add('createMachReg', (
         cy.contains('Elemental Teal ISO x86_64 v1.2.2')
           .click();
       } else {
-        cy.contains('Elemental Teal ISO x86_64 (latest)')
+        cy.contains('Elemental Teal ISO x86_64 (unstable)')
           .click();
       }
       cy.getBySel('build-iso-btn')


### PR DESCRIPTION
Fix #1013 

[UI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6271539989/job/17031341691) ✅ 
[UI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6271541363/job/17031344500) ✅ 
[UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6272217714) ❌ unstable tag will be added by devs
[UI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6274675357) ✅ 