### PR TITLE
ci: use SeedImage for all CLI tests

### DIFF
--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      os_to_test: dev
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/containers/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
+      os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-K3s-OS-Upgrade-Rancher_Latest
 
-# This worflow is scheduled because it uses Dev artifacts from OBS and
-# not the ones built in the CI (build-ci workflow).
-# The scheduling is also to avoid running the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:
@@ -19,11 +16,11 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_version: latest/devel
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-K3s-OS-Upgrade-Rancher_Stable
 
-# This worflow is scheduled because it uses Dev artifacts from OBS and
-# not the ones built in the CI (build-ci workflow).
-# The scheduling is also to avoid running the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:
@@ -19,11 +16,11 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -12,10 +12,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      iso_to_test:
-        description: ISO to test
-        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-        type: string
       operator_repo:
         description: Operator version to use for initial deployment
         default: oci://registry.opensuse.org/rancher
@@ -53,11 +49,11 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest

--- a/.github/workflows/cli-k3s-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-K3s-Rancher_Latest
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-k3s-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-rancher_stable.yaml
@@ -3,13 +3,8 @@ name: CLI-K3s-Rancher_Stable
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - build-ci
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   cli:
@@ -22,5 +17,3 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       k8s_version_to_provision: v1.26.8+k3s1
-      start_condition: ${{ github.event.workflow_run.conclusion }}
-      workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-K3s-Sequential-Rancher_Latest
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-K3s-Sequential-Rancher_Stable
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -15,10 +15,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      iso_to_test:
-        description: Defines the ISO to test
-        default: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
-        type: string
       k8s_version:
         description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
         default: v1.26.8+k3s1
@@ -31,6 +27,10 @@ on:
         description: Elemental operator repository to use
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
         type: string
+      os_to_test:
+        description: OS repository to test (dev/staging/stable)
+        type: string
+        default: dev
       rancher_version:
         description: Rancher Manager channel/version to use for installation
         default: stable/latest
@@ -61,10 +61,10 @@ jobs:
       cluster_name: my-own-cluster
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: ${{ inputs.k8s_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: ${{ inputs.os_to_test }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      os_to_test: dev
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/containers/iso/elemental-teal.x86_64.iso
       k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
+      os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-OS-Upgrade-Rancher_Latest
 
-# This worflow is scheduled because it uses Dev artifacts from OBS and
-# not the ones built in the CI (build-ci workflow).
-# The scheduling is also to avoid running the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:
@@ -20,11 +17,11 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_version: latest/devel
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-OS-Upgrade-Rancher_Stable
 
-# This worflow is scheduled because it uses Dev artifacts from OBS and
-# not the ones built in the CI (build-ci workflow).
-# The scheduling is also to avoid running the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:
@@ -20,11 +17,11 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
       k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
+      os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -12,10 +12,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      iso_to_test:
-        description: ISO to test
-        default: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-        type: string
       operator_repo:
         description: Operator version to use for initial deployment
         default: oci://registry.opensuse.org/rancher
@@ -54,11 +50,11 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      iso_to_test: ${{ inputs.iso_to_test }}
       k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest

--- a/.github/workflows/cli-rke2-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-Rancher_Latest
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the worklow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-rke2-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-rancher_stable.yaml
@@ -3,13 +3,8 @@ name: CLI-RKE2-Rancher_Stable
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - build-ci
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   cli:
@@ -23,6 +18,4 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       k8s_version_to_provision: v1.26.8+rke2r1
-      start_condition: ${{ github.event.workflow_run.conclusion }}
-      workflow_download: ${{ github.event.workflow_run.workflow_id }}
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-Scalability-Rancher_Stable
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-Sequential-Rancher_Latest
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
@@ -1,9 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
 name: CLI-RKE2-Sequential-Rancher_Stable
 
-# This worflow is scheduled *after* build-ci to be sure that we have
-# the lastest version built. The scheduling is also to avoid running
-# the workflow on each push on main.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -61,9 +61,6 @@ on:
         description: Version of the elemental ui which will be installed (dev/stable)
         default: dev
         type: string
-      iso_to_test:
-        description: ISO to test (default built one is empty)
-        type: string
       iso_boot:
         description: Choose booting from ISO
         type: boolean
@@ -85,6 +82,10 @@ on:
       operator_upgrade:
         description: Elemental operator version to upgrade to
         type: string
+      os_to_test:
+        description: OS repository to test (dev/staging/stable)
+        type: string
+        default: dev
       proxy:
         description: Deploy a proxy
         type: string
@@ -106,10 +107,6 @@ on:
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)
         default: false
-        type: string
-      start_condition:
-        description: Start condition of the runner
-        default: success
         type: string
       test_description:
         description: Short description of the test
@@ -135,10 +132,6 @@ on:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
         default: v1.26.8+k3s1
         type: string
-      workflow_download:
-        description: build-ci workfluw to use for artifacts
-        default: build-ci.yaml
-        type: string
       zone:
         description: GCP zone to host the runner
         default: us-central1-a
@@ -146,7 +139,6 @@ on:
 
 jobs:
   create-runner:
-    if: inputs.start_condition == 'success'
     runs-on: ubuntu-latest
     outputs:
       uuid: ${{ steps.generator.outputs.uuid }}
@@ -233,45 +225,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: tests/go.mod
-      - name: Cache ISO
-        # NOTE: download the *default* ISO, not the one passed as a parameter
-        if: inputs.iso_to_test == ''
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: build/*
-          key: build-ci-${{ github.event.pull_request.head.sha || github.sha }}
-          # Alternate key, mainly useful for UI test
-          restore-keys: |
-            build-ci-
-      - name: Download specified ISO
-        if: inputs.iso_to_test != ''
-        env:
-          ISO_TO_TEST: ${{ inputs.iso_to_test }}
-          TAG: from-obs
-        run: |
-          ARCH=$(uname -m)
-          mkdir -p build
-          wget -v -L -c ${ISO_TO_TEST} -O build/elemental-teal.${ARCH}-${TAG}.iso
-      - name: Create symbolic link to ISO for SeedImage
-        run: |
-          ISO=$(ls build/*.iso 2> /dev/null)
-          ln -sf ${ISO} base-image.iso
-      - name: Extract iPXE artifacts from ISO
-        run: |
-          # Extract TAG
-          ARCH=$(uname -m)
-          ISO=$(ls build/*.iso 2> /dev/null)
-          TAG=${ISO#*.${ARCH}-}
-          export TAG=${TAG%.iso}
-          # Extract iPXE artifacts
-          make extract_kernel_init_squash
-          make ipxe
-          # Extend regexes (needed for the next 'mv' command)
-          shopt -s extglob
-          # Looks a little bit weird but we have to keep the ISO in build!
-          mv -f build/!(*.iso) .
       - name: Deploy Proxy
         if: inputs.proxy == 'elemental' || inputs.proxy == 'rancher'
         run: docker run -d --name squid_proxy -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
@@ -289,46 +242,12 @@ jobs:
           # Check if DynamicSchemas for MachineInventorySelectorTemplate exists
           if ! kubectl get dynamicschema machineinventoryselectortemplate >/dev/null 2>&1; then
             # If not we have to add it to avoid weird issues!
+            echo "WORKAROUND: DynamicSchemas for MachineInventorySelectorTemplate is missing!"
             kubectl apply -f tests/assets/add_missing_dynamicschemas.yaml
           fi
       - name: Install backup-restore components (K3s only for now)
         if: contains(inputs.upstream_cluster_version, 'k3s')
         run: cd tests && make e2e-install-backup-restore
-      - name: Extracts component versions/informations
-        id: component
-        run: |
-          # Extract rancher-backup-operator version
-          BACKUP_RESTORE_VERSION=$(kubectl get pod \
-                                     --namespace cattle-resources-system \
-                                     -l app.kubernetes.io/name=rancher-backup \
-                                     -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
-          # Extract CertManager version
-          CERT_MANAGER_VERSION=$(kubectl get pod \
-                                   --namespace cert-manager \
-                                   -l app=cert-manager \
-                                   -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
-          # Extract elemental-operator version
-          OPERATOR_VERSION=$(kubectl get pod \
-                             --namespace cattle-elemental-system \
-                             -l app=elemental-operator \
-                             -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
-          # Extract Rancher Manager version
-          RM_VERSION=$(kubectl get pod \
-                         --namespace cattle-system \
-                         -l app=rancher \
-                         -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
-          # Extract OS version from ISO
-          INITRD_FILE=$(isoinfo -i build/*.iso -R -find -type f -name initrd -print 2>/dev/null)
-          isoinfo -i build/*.iso -R -x ${INITRD_FILE} 2>/dev/null \
-            | xz -dc \
-            | cpio -i --to-stdout usr/lib/initrd-release > os-release
-          eval $(grep IMAGE_TAG os-release)
-          # Export values
-          echo "backup_restore_version=${BACKUP_RESTORE_VERSION}" >> ${GITHUB_OUTPUT}
-          echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
-          echo "image_tag=${IMAGE_TAG}" >> ${GITHUB_OUTPUT}
-          echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
-          echo "rm_version=${RM_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Cypress tests - Basics
         # Basics means tests without an extra elemental node needed
         if: inputs.test_type == 'ui'
@@ -338,7 +257,6 @@ jobs:
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           ISO_BOOT: ${{ inputs.iso_boot }}
-          ISO_TO_TEST: ${{ inputs.iso_to_test }}
           K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}
@@ -428,6 +346,58 @@ jobs:
       - name: Configure Rancher & Libvirt
         if: inputs.test_type == 'cli'
         run: cd tests && make e2e-configure-rancher
+      - name: Create ISO image for master pool
+        if: inputs.test_type == 'cli'
+        env:
+          EMULATE_TPM: true
+          OS_TO_TEST: ${{ inputs.os_to_test }}
+          POOL: master
+        run: |
+          # Only use ISO boot if the upstream cluster is RKE2
+          # due to issue with pxe, dhcp traffic
+          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+            export ISO_BOOT=true
+          fi
+          cd tests && make e2e-iso-image
+      - name: Extract iPXE artifacts from ISO
+        if: inputs.test_type == 'cli' && inputs.iso_boot == false
+        run: make extract_kernel_init_squash && make ipxe
+      - name: Extracts component versions/informations
+        id: component
+        run: |
+          # Extract rancher-backup-operator version
+          BACKUP_RESTORE_VERSION=$(kubectl get pod \
+                                     --namespace cattle-resources-system \
+                                     -l app.kubernetes.io/name=rancher-backup \
+                                     -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Extract CertManager version
+          CERT_MANAGER_VERSION=$(kubectl get pod \
+                                   --namespace cert-manager \
+                                   -l app=cert-manager \
+                                   -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Extract elemental-operator version
+          OPERATOR_VERSION=$(kubectl get pod \
+                             --namespace cattle-elemental-system \
+                             -l app=elemental-operator \
+                             -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Extract Rancher Manager version
+          RM_VERSION=$(kubectl get pod \
+                         --namespace cattle-system \
+                         -l app=rancher \
+                         -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Extract OS version from ISO
+          ISO=$(file -Ls *.iso 2>/dev/null | awk -F':' '/boot sector/ { print $1 }')
+          INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name initrd -print 2>/dev/null)
+          isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
+            | xz -dc \
+            | cpio -i --to-stdout usr/lib/initrd-release > os-release
+          eval $(grep IMAGE_TAG os-release)
+          # Export values
+          echo "backup_restore_version=${BACKUP_RESTORE_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "image_tag=${IMAGE_TAG}" >> ${GITHUB_OUTPUT}
+          echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "rm_version=${RM_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Bootstrap node 1, 2 and 3 in pool "master" (use Emulated TPM if possible)
         if: inputs.test_type == 'cli'
         env:
@@ -534,6 +504,17 @@ jobs:
           if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
             make e2e-check-app
           fi
+      - name: Remove old built ISO image
+        # Only one at a time is allowed, the new one will be created after if needed
+        if: inputs.test_type == 'cli'
+        run: rm -f *.iso
+      - name: Create ISO image for worker pool
+        if: inputs.test_type == 'cli'
+        env:
+          ISO_BOOT: true
+          OS_TO_TEST: ${{ inputs.os_to_test }}
+          POOL: worker
+        run: cd tests && make e2e-iso-image
       - name: Bootstrap additional nodes in pool "worker" (total of ${{ inputs.node_number }})
         if: inputs.test_type == 'cli' && inputs.node_number > 3
         env:
@@ -597,10 +578,6 @@ jobs:
           if ${{ inputs.sequential == 'true' }}; then
             BOOTSTRAP_METHOD="Sequential"
           fi
-          ISO_USED=$(ls build/elemental-*.iso 2> /dev/null)
-          if ${{ inputs.iso_to_test != '' }}; then
-            ISO_USED=${{ inputs.iso_to_test }}
-          fi
           # Get nodes configuration (use the first one, they are all identical)
           NODE=$(sudo virsh list --name | head -1)
           if [[ -n "${NODE}" ]]; then
@@ -622,7 +599,7 @@ jobs:
           echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "CertManager Image: ${{ steps.component.outputs.cert_manager_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "### Elemental" >> ${GITHUB_STEP_SUMMARY}
-          echo "Elemental ISO used: ${ISO_USED}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Elemental ISO image: ${{ inputs.os_to_test }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental OS version: ${{ steps.component.outputs.image_tag }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental Operator Image: ${{ steps.component.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Elemental Backup/Restore Operator Image: ${{ steps.component.outputs.backup_restore_version }}" >> ${GITHUB_STEP_SUMMARY}
@@ -645,7 +622,7 @@ jobs:
             echo "Elemental Operator Image: ${{ steps.operator_upgrade.outputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Rancher Manager Image: ${{ steps.rancher_upgrade.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Rancher Manager Version: ${{ inputs.rancher_upgrade }}" >> ${GITHUB_STEP_SUMMARY}
-            echo "Channel used: ${{ inputs.upgrade_os_channel }}" >> ${GITHUB_STEP_SUMMARY}
+            echo "Channel: ${{ inputs.upgrade_os_channel }}" >> ${GITHUB_STEP_SUMMARY}
             echo "Upgrade image: ${{ inputs.upgrade_image }}" >> ${GITHUB_STEP_SUMMARY}
           fi
       - name: Send failed status to slack
@@ -659,7 +636,7 @@ jobs:
                   "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "Workflow build-ci ${{ github.job }}"
+                      "text": "Workflow E2E ${{ github.job }}"
                     },
                     "accessory": {
                       "type": "button",

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -444,16 +444,6 @@ jobs:
             export VM_MEM=8192
             export VM_CPU=4
           fi
-          OPERATOR_VERSION=$(echo ${{ steps.component.outputs.operator_version }} \
-                             | awk -F ':' '{print substr($2,0,3)}')
-          # If elemental-operator is a v1.0.x we should disable EMULATE_TPM
-          [[ "${OPERATOR_VERSION}" == "1.0" ]] && unset EMULATE_TPM
-          # Disable EMULATE_TPM in case of upgrade test
-          # This is because we don't know the version in advance, so easier to not use it
-          if ${{ inputs.upgrade_image != '' }} || \
-             ${{ inputs.upgrade_os_channel != '' }}; then
-            unset EMULATE_TPM
-          fi
           # Execute bootstrapping test
           if ${{ inputs.sequential == 'true' }}; then
             # Force node bootstrapping in sequential instead of parallel

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -83,6 +83,8 @@ e2e-install-app: deps
 	ginkgo --label-filter install-app -r -v ./e2e
 e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
+e2e-iso-image: deps
+	ginkgo --label-filter iso-image -r -v ./e2e
 e2e-ui-rancher: deps
 	ginkgo --label-filter ui -r -v ./e2e
 e2e-uninstall-operator:

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -213,7 +213,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Add node in network configuration
 			err := rancher.AddNode(netDefaultFileName, hostName, index)
@@ -221,7 +221,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 			// Get generated MAC address
 			_, macAdrs := GetNodeInfo(hostName)
-			Expect(macAdrs).To(Not(BeNil()))
+			Expect(macAdrs).To(Not(BeEmpty()))
 
 			wg.Add(1)
 			go func(s, h, m string, i int) {
@@ -250,7 +250,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		if poolType == "master" && isoBoot == "true" {
 			for index := vmIndex; index <= numberOfVMs; index++ {
 				hostName := elemental.SetHostname(vmNameRoot, index)
-				Expect(hostName).To(Not(BeNil()))
+				Expect(hostName).To(Not(BeEmpty()))
 
 				client, _ := GetNodeInfo(hostName)
 				Expect(client).To(Not(BeNil()))
@@ -294,7 +294,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Execute node deployment in parallel
 			wg.Add(1)
@@ -356,7 +356,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Get node information
 			client, _ := GetNodeInfo(hostName)
@@ -415,7 +415,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			for index := vmIndex; index <= numberOfVMs; index++ {
 				// Set node hostname
 				hostName := elemental.SetHostname(vmNameRoot, index)
-				Expect(hostName).To(Not(BeNil()))
+				Expect(hostName).To(Not(BeEmpty()))
 
 				// Get node information
 				client, _ := GetNodeInfo(hostName)
@@ -471,7 +471,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			for index := vmIndex; index <= numberOfVMs; index++ {
 				// Set node hostname
 				hostName := elemental.SetHostname(vmNameRoot, index)
-				Expect(hostName).To(Not(BeNil()))
+				Expect(hostName).To(Not(BeEmpty()))
 
 				// Get node information
 				client, _ := GetNodeInfo(hostName)
@@ -504,7 +504,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Get node information
 			client, _ := GetNodeInfo(hostName)

--- a/tests/e2e/helpers/elemental/elemental.go
+++ b/tests/e2e/helpers/elemental/elemental.go
@@ -52,9 +52,27 @@ func AddSelector(key, value string) ([]byte, error) {
 }
 
 /**
+ * Get container URI from ManagedOSVersion
+ * @param clusterNS Namespace
+ * @param os OS version to get URI from
+ * @returns URI of container image
+ */
+func GetImageURI(clusterNS, os string) (string, error) {
+	uri, err := kubectl.Run("get", "ManagedOSVersion",
+		"--namespace", clusterNS, os,
+		"-o", "jsonpath={.spec.metadata.uri}")
+
+	if err != nil {
+		return "", err
+	}
+
+	return uri, nil
+}
+
+/**
  * Get Machine from MachineInventory
  * @remarks This is useful to link machine name from Elemental to the Rancher Manager one
- * @param clusterNS Name of the repository
+ * @param clusterNS Namespace
  * @param machineInventory Machine name as seen by Elemental
  * @returns Corresponding internal machine name
  */
@@ -104,7 +122,7 @@ func GetOperatorVersion() (string, error) {
 
 /**
  * Get MachineInventory name (aka. server id)
- * @param clusterNS Name of the repository
+ * @param clusterNS Namespace
  * @param index URL of the repository
  * @returns The name/id of the server or an error
  */

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -240,6 +240,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				"-o", "jsonpath={.items[?(@.username==\"admin\")].metadata.name}",
 			)
 			Expect(err).To(Not(HaveOccurred()))
+			Expect(internalUsername).To(Not(BeEmpty()))
 
 			// Add token in Rancher Manager
 			err = tools.Sed("%ADMIN_USER%", internalUsername, ciTokenYaml)

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	"github.com/rancher/elemental/tests/e2e/helpers/elemental"
+)
+
+var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
+	It("Configure and create ISO image", func() {
+		// Globales variables
+		machineRegName := "machine-registration-" + poolType + "-" + clusterName
+		seedImageName := "seed-image-" + poolType + "-" + clusterName
+
+		By("Adding SeedImage", func() {
+			type pattern struct {
+				key   string
+				value string
+			}
+
+			// Wait for list of OS versions to be populated
+			Eventually(func() string {
+				out, _ := kubectl.Run("get", "ManagedOSVersion",
+					"--namespace", clusterNS,
+					"-o", "jsonpath={.items[*].metadata.name}")
+				return out
+			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(Not(BeEmpty()))
+
+			// Get OSVersion name
+			OSVersion, err := exec.Command(getOSScript, os2Test, "true").Output()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(OSVersion).To(Not(BeEmpty()))
+
+			// Extract container image URL
+			baseImageURL, err := elemental.GetImageURI(clusterNS, string(OSVersion))
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(baseImageURL).To(Not(BeEmpty()))
+
+			// Set poweroff to false for master pool to have time to check SeedImage cloud-config
+			if poolType == "master" && isoBoot == "true" {
+				_, err := kubectl.Run("patch", "MachineRegistration",
+					"--namespace", clusterNS, machineRegName,
+					"--type", "merge", "--patch",
+					"{\"spec\":{\"config\":{\"elemental\":{\"install\":{\"poweroff\":false}}}}}")
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Setting emulated TPM to "+strconv.FormatBool(emulateTPM), func() {
+				// Set temporary file
+				emulatedTmp, err := tools.CreateTemp("emulatedTPM")
+				Expect(err).To(Not(HaveOccurred()))
+				defer os.Remove(emulatedTmp)
+
+				// Save original file as it can be modified multiple time
+				err = tools.CopyFile(emulateTPMYaml, emulatedTmp)
+				Expect(err).To(Not(HaveOccurred()))
+
+				// Patch the yaml file
+				err = tools.Sed("%EMULATE_TPM%", strconv.FormatBool(emulateTPM), emulatedTmp)
+				Expect(err).To(Not(HaveOccurred()))
+
+				// And apply it
+				_, err = kubectl.Run("patch", "MachineRegistration",
+					"--namespace", clusterNS, machineRegName,
+					"--type", "merge", "--patch-file", emulatedTmp,
+				)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+
+			// Patterns to replace
+			patterns := []pattern{
+				{
+					key:   "%CLUSTER_NAME%",
+					value: clusterName,
+				},
+				{
+					key:   "%BASE_IMAGE%",
+					value: baseImageURL,
+				},
+				{
+					key:   "%POOL_TYPE%",
+					value: poolType,
+				},
+			}
+
+			// Set temporary file
+			seedImageTmp, err := tools.CreateTemp("seedImage")
+			Expect(err).To(Not(HaveOccurred()))
+			defer os.Remove(seedImageTmp)
+
+			// Save original file as it will have to be modified twice
+			err = tools.CopyFile(seedImageYaml, seedImageTmp)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Create Yaml file
+			for _, p := range patterns {
+				err := tools.Sed(p.key, p.value, seedImageTmp)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			// Apply to k8s
+			err = kubectl.Apply(clusterNS, seedImageTmp)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Check that the seed image is correctly created
+			Eventually(func() string {
+				out, _ := kubectl.Run("get", "SeedImage",
+					"--namespace", clusterNS,
+					seedImageName,
+					"-o", "jsonpath={.status}")
+				return out
+			}, tools.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("downloadURL"))
+		})
+
+		By("Downloading ISO built by SeedImage", func() {
+			seedImageURL, err := kubectl.Run("get", "SeedImage",
+				"--namespace", clusterNS,
+				seedImageName,
+				"-o", "jsonpath={.status.downloadURL}")
+			Expect(err).To(Not(HaveOccurred()))
+
+			// ISO file size should be greater than 500MB
+			Eventually(func() int64 {
+				// No need to check download status, file size at the end is enough
+				filename := "../../elemental-" + poolType + ".iso"
+				_ = tools.GetFileFromURL(seedImageURL, filename, false)
+				file, _ := os.Stat(filename)
+				return file.Size()
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(BeNumerically(">", 500*1024*1024))
+		})
+	})
+})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -48,7 +48,7 @@ const (
 	registrationYaml      = "../assets/machineRegistration.yaml"
 	resetMachineInv       = "../assets/reset_machine_inventory.yaml"
 	restoreYaml           = "../assets/restore.yaml"
-	seedimageYaml         = "../assets/seedImage.yaml"
+	seedImageYaml         = "../assets/seedImage.yaml"
 	selectorYaml          = "../assets/selector.yaml"
 	upgradeSkelYaml       = "../assets/upgrade_skel.yaml"
 	userName              = "root"
@@ -73,6 +73,7 @@ var (
 	numberOfVMs           int
 	operatorUpgrade       string
 	operatorRepo          string
+	os2Test               string
 	poolType              string
 	proxy                 string
 	rancherChannel        string
@@ -212,6 +213,7 @@ var _ = BeforeSuite(func() {
 	number := os.Getenv("VM_NUMBERS")
 	operatorUpgrade = os.Getenv("OPERATOR_UPGRADE")
 	operatorRepo = os.Getenv("OPERATOR_REPO")
+	os2Test = os.Getenv("OS_TO_TEST")
 	poolType = os.Getenv("POOL")
 	proxy = os.Getenv("PROXY")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -176,23 +176,8 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 			defer os.Remove(upgradeTmp)
 
 			if upgradeType == "managedOSVersionName" {
-				// Extract OSVersion informations
-				out, err := kubectl.Run("get", "ManagedOSVersion",
-					"--namespace", clusterNS, "-o", "json")
-				Expect(err).To(Not(HaveOccurred()))
-
-				// Set temporary file
-				outTmp, err := tools.CreateTemp("out")
-				Expect(err).To(Not(HaveOccurred()))
-				defer os.Remove(outTmp)
-
-				// Add "out" to temporary file
-				// NOTE: just add data to the same file
-				tools.AddDataToFile(outTmp, outTmp, []byte(out))
-				Expect(err).To(Not(HaveOccurred()))
-
 				// Get OSVersion name
-				OSVersion, err := exec.Command(getOSScript, outTmp, upgradeOSChannel).Output()
+				OSVersion, err := exec.Command(getOSScript, upgradeOSChannel).Output()
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(OSVersion).To(Not(BeEmpty()))
 
@@ -200,7 +185,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				value = string(OSVersion)
 
 				// Extract the value to check after the upgrade
-				out, err = kubectl.Run("get", "ManagedOSVersion",
+				out, err := kubectl.Run("get", "ManagedOSVersion",
 					"--namespace", clusterNS, string(OSVersion),
 					"-o", "jsonpath={.spec.metadata.upgradeImage}")
 				Expect(err).To(Not(HaveOccurred()))

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -155,7 +155,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Get node information
 			client, _ := GetNodeInfo(hostName)
@@ -203,7 +203,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				// Get OSVersion name
 				OSVersion, err := exec.Command(getOSScript, outTmp, upgradeOSChannel).Output()
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(OSVersion).To(Not(BeNil()))
+				Expect(OSVersion).To(Not(BeEmpty()))
 
 				// Set OS image to use for upgrade
 				value = string(OSVersion)
@@ -226,7 +226,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 			if usedNodes == 1 {
 				// Set node hostname
 				hostName := elemental.SetHostname(vmNameRoot, vmIndex)
-				Expect(hostName).To(Not(BeNil()))
+				Expect(hostName).To(Not(BeEmpty()))
 
 				// Get node information
 				client, _ := GetNodeInfo(hostName)
@@ -266,7 +266,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 		for index := vmIndex; index <= numberOfVMs; index++ {
 			// Set node hostname
 			hostName := elemental.SetHostname(vmNameRoot, index)
-			Expect(hostName).To(Not(BeNil()))
+			Expect(hostName).To(Not(BeEmpty()))
 
 			// Get node information
 			client, _ := GetNodeInfo(hostName)

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -69,15 +69,6 @@ var _ = Describe("E2E - Upgrading Elemental Operator", Label("upgrade-operator")
 		// Wait for all pods to be started
 		err = rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
 		Expect(err).To(Not(HaveOccurred()))
-
-		// Workaround: force re-sync of ManagedOSVersionChannels
-		// NOTE: this should be done directly when upgrading the operator,
-		// see https://github.com/rancher/elemental-operator/issues/519
-		_, err = kubectl.Run("patch", "ManagedOSVersionChannel",
-			"--namespace", clusterNS, "elemental-teal-channel",
-			"--type", "merge", "--patch", "{\"spec\":{\"syncInterval\":\"1m\"}}",
-		)
-		Expect(err).To(Not(HaveOccurred()))
 	})
 })
 

--- a/tests/scripts/get-name-from-managedosversion
+++ b/tests/scripts/get-name-from-managedosversion
@@ -5,9 +5,10 @@
 set -e -x
 
 # Variables
-FILE_TO_CHECK=$1
-KIND_OF_OS=$2
+KIND_OF_OS=$1
+CHECK_FOR_ISO=$2
 INVERTED="| not"
+GREP_OPTS="-v"
 
 # Define if we check for stable or unstable OS
 case ${KIND_OF_OS} in
@@ -16,10 +17,13 @@ case ${KIND_OF_OS} in
     ;;
 esac
 
+# Define if we have to check for ISO image or not
+[[ -n "${CHECK_FOR_ISO}" ]] && unset GREP_OPTS
+
 # Get the value
-# NOTE: don't check for ISO, only container images are used for upgrade
-VALUE=$(jq -r ".items[] | select(.spec.metadata.displayName | contains(\"unstable\")${INVERTED}).metadata.name" 2>/dev/null ${FILE_TO_CHECK} \
-        | grep -v '\-iso$' \
+VALUE=$(kubectl get ManagedOSVersion --namespace ${CLUSTER_NS} -o json 2>/dev/null \
+        | jq -r ".items[] | select(.spec.metadata.displayName | contains(\"unstable\")${INVERTED}).metadata.name" 2>/dev/null \
+        | grep ${GREP_OPTS} '\-iso' \
         | sort \
         | tail -1)
 

--- a/tests/scripts/get-name-from-managedosversion
+++ b/tests/scripts/get-name-from-managedosversion
@@ -17,9 +17,8 @@ case ${KIND_OF_OS} in
 esac
 
 # Get the value
-# NOTE: check for ISO only, as we can only build an image with ISO and SeedImage
-VALUE=$(cat ${FILE_TO_CHECK} \
-        | jq -r ".items[] | select(.spec.metadata.displayName | contains(\"unstable\")${INVERTED}).metadata.name" 2>/dev/null \
+# NOTE: don't check for ISO, only container images are used for upgrade
+VALUE=$(jq -r ".items[] | select(.spec.metadata.displayName | contains(\"unstable\")${INVERTED}).metadata.name" 2>/dev/null ${FILE_TO_CHECK} \
         | grep -v '\-iso$' \
         | sort \
         | tail -1)


### PR DESCRIPTION
Should fix #1002.

Verification runs:
- [CLI-K3s-OBS_Dev without reset test](https://github.com/rancher/elemental/actions/runs/6405511921)
- [CLI-RKE2-OBS_Dev without reset test](https://github.com/rancher/elemental/actions/runs/6405918980)
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6407885930)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6407893718)
- [CLI-K3s-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6408778570)
- [CLI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6408786303)
- [CLI-RKE2-Hardened-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6408152027)

Regression tests:
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6417699038)
- [UI-RKE2-OS-Upgrade-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6417696240)

NOTE: upgrade tests are failing for another reason and will be investigated/fixed in another PR.