### PR TITLE
ci: fix cluster check in sequential test

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -137,11 +137,12 @@ func CheckClusterState(ns, cluster string) {
 	}
 
 	// Check that the cluster is in Ready state (this means that it has been created)
-	clusterStatus, err := kubectl.Run("get", "cluster",
-		"--namespace", ns, cluster,
-		"-o", "jsonpath={.status.ready}")
-	Expect(err).To(Not(HaveOccurred()))
-	Expect(clusterStatus).To(Equal("true"))
+	Eventually(func() string {
+		status, _ := kubectl.Run("get", "cluster",
+			"--namespace", ns, cluster,
+			"-o", "jsonpath={.status.ready}")
+		return status
+	}, tools.SetTimeout(2*time.Duration(usedNodes)*time.Minute), 10*time.Second).Should(Equal("true"))
 
 	// Check that all needed conditions are in the good state
 	for _, s := range states {


### PR DESCRIPTION
In sequential test the cluster takes more time to appear.

This should fix the issue seen here: https://github.com/rancher/elemental/actions/runs/6287282110/job/17071611849.

Verification runs:
- [CLI-K3s-Sequential-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6296744747)