### PR TITLE
ci/ui: fix check os version tag

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -44,7 +44,7 @@ describe('Upgrade tests', () => {
       it('Check OS Versions', () => {
         cy.clickNavMenu(["Advanced", "OS Versions"]);
         if (utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
-          cy.contains('Active latest', {timeout: 120000});
+          cy.contains(new RegExp('Active.*-iso-unstable'), {timeout: 120000})
         }
       })
     );


### PR DESCRIPTION
Fix 
![Upgrade tests -- Check OS Versions (Qase ID 33) (failed)](https://github.com/rancher/elemental/assets/6025636/a633a8f6-fc0d-4594-8dfe-d54aed1e7285)

## Verification runs
[UI-K3s-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6310728078) ✅ 
[UI-RKE2-OS-Upgrade-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6310752826) ✅ 