### PR TITLE
ci: fix operator uninstallation with RM Stable

### DIFF
--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -126,8 +126,12 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 				// Delete blocking Finalizers
 				GinkgoWriter.Printf("WORKAROUND EXECUTED: deleting Finalizers for MachineInventory '%s'...\n", machine)
 				deleteFinalizers(clusterNS, "MachineInventory", machine)
-				GinkgoWriter.Printf("WORKAROUND EXECUTED: deleting Finalizers for Machine '%s'...\n", internalMachine)
-				deleteFinalizers(clusterNS, "Machine", internalMachine)
+
+				// Only if Machine is still present
+				if internalMachine != "" {
+					GinkgoWriter.Printf("WORKAROUND EXECUTED: deleting Finalizers for Machine '%s'...\n", internalMachine)
+					deleteFinalizers(clusterNS, "Machine", internalMachine)
+				}
 			}
 		})
 


### PR DESCRIPTION
Try to patch Machine object only if it exists.

Verification runs:
- [CLI-RKE2-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6377239471)
- [CLI-RKE2-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6377037643)
- [CLI-K3s-Rancher_Stable](https://github.com/rancher/elemental/actions/runs/6377267340) - Failed for another issue...
- [CLI-K3s-Rancher_Latest](https://github.com/rancher/elemental/actions/runs/6377264244)