### PR TITLE
ci: bump K3s/RKE2 versions

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_latest.yaml
@@ -18,6 +18,6 @@ jobs:
       cert-manager_version: v1.11.1
       cluster_name: cluster-k3s
       cluster_type: hardened
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       node_number: 3
       rancher_version: latest/devel

--- a/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rancher_stable.yaml
@@ -18,5 +18,5 @@ jobs:
       cert-manager_version: v1.11.1
       cluster_name: cluster-k3s
       cluster_type: hardened
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       node_number: 3

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -39,6 +39,6 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -39,6 +39,6 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -39,6 +39,6 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/containers/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_latest.yaml
@@ -20,7 +20,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rancher_stable.yaml
@@ -20,7 +20,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -54,7 +54,7 @@ jobs:
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/cli-k3s-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-rancher_latest.yaml
@@ -19,5 +19,5 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       rancher_version: latest/devel

--- a/.github/workflows/cli-k3s-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-rancher_stable.yaml
@@ -21,6 +21,6 @@ jobs:
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       start_condition: ${{ github.event.workflow_run.conclusion }}
       workflow_download: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_latest.yaml
@@ -19,6 +19,6 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       rancher_version: latest/devel
       sequential: true

--- a/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rancher_stable.yaml
@@ -19,6 +19,6 @@ jobs:
     with:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       rancher_version: stable/latest
       sequential: true

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -21,7 +21,7 @@ on:
         type: string
       k8s_version:
         description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
-        default: v1.26.7+k3s1
+        default: v1.26.8+k3s1
         type: string
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster

--- a/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_latest.yaml
@@ -18,7 +18,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cluster_type: hardened
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 3
       rancher_version: latest/devel
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rancher_stable.yaml
@@ -18,6 +18,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       cluster_type: hardened
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 3
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -40,7 +40,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -40,7 +40,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Dev/containers/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -40,7 +40,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/containers/iso/elemental-teal.x86_64.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_latest.yaml
@@ -21,11 +21,11 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: latest/devel
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rancher_stable.yaml
@@ -21,7 +21,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       iso_to_test: https://updates.suse.com/SUSE/Products/ElementalTeal/5.4/x86_64/iso/elemental-teal.x86_64-1.2.2-GM.iso
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -29,4 +29,4 @@ jobs:
       rancher_version: stable/latest
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -55,11 +55,11 @@ jobs:
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_to_test: ${{ inputs.iso_to_test }}
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-rancher_latest.yaml
@@ -20,6 +20,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: latest/devel
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-rancher_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       start_condition: ${{ github.event.workflow_run.conclusion }}
       workflow_download: ${{ github.event.workflow_run.workflow_id }}
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rancher_stable.yaml
@@ -21,8 +21,8 @@ jobs:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       node_number: 60
       rancher_version: stable/latest
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_latest.yaml
@@ -20,7 +20,7 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: latest/devel
       sequential: true
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rancher_stable.yaml
@@ -20,7 +20,7 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: stable/latest
       sequential: true
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -133,7 +133,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.26.7+k3s1
+        default: v1.26.8+k3s1
         type: string
       workflow_download:
         description: build-ci workfluw to use for artifacts

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -41,7 +41,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_latest.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rancher_stable.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -44,7 +44,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-rancher_latest.yaml
+++ b/.github/workflows/ui-k3s-rancher_latest.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rancher_stable.yaml
+++ b/.github/workflows/ui-k3s-rancher_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+k3s1
+      k8s_version_to_provision: v1.26.8+k3s1
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: string
       k8s_version_to_provision:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
-        default: v1.26.7+k3s1
+        default: v1.26.8+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -39,8 +39,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -35,8 +35,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -35,8 +35,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_latest.yaml
@@ -37,9 +37,9 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rancher_stable.yaml
@@ -41,10 +41,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -45,10 +45,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-rancher_latest.yaml
+++ b/.github/workflows/ui-rke2-rancher_latest.yaml
@@ -31,7 +31,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel' }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-rancher_stable.yaml
+++ b/.github/workflows/ui-rke2-rancher_stable.yaml
@@ -34,7 +34,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner || true }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.7+rke2r1
+      k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'stable/latest' }}
       test_type: ui
-      upstream_cluster_version: v1.26.7+rke2r1
+      upstream_cluster_version: v1.26.8+rke2r1

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -295,15 +295,6 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 		By("Installing Elemental Operator", func() {
 			for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
-				// Check if CRDs chart is available (not always the case in older versions)
-				// Anyway, if it is needed and missing the next chart installation will fail too
-				if strings.Contains(chart, "-crds") {
-					noChart := kubectl.RunHelmBinaryWithCustomErr("show", "readme", operatorRepo+"/"+chart+"-chart")
-					if noChart != nil {
-						continue
-					}
-				}
-
 				RunHelmCmdWithRetry("upgrade", "--install", chart,
 					operatorRepo+"/"+chart+"-chart",
 					"--namespace", "cattle-elemental-system",

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package e2e_test
 
 import (
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -61,19 +60,6 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 		By("Uninstalling Operator via Helm", func() {
 			for _, chart := range []string{"elemental-operator", "elemental-operator-crds"} {
-				if strings.Contains(chart, "-crds") {
-					// Check if CRDs chart is available (not always the case in older versions)
-					chartList, err := exec.Command("helm",
-						"list",
-						"--no-headers",
-						"--namespace", "cattle-elemental-system",
-					).CombinedOutput()
-					Expect(err).To(Not(HaveOccurred()))
-
-					if !strings.Contains(string(chartList), chart) {
-						continue
-					}
-				}
 				RunHelmCmdWithRetry(
 					"uninstall", chart,
 					"--namespace", "cattle-elemental-system",
@@ -150,14 +136,6 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 	It("Re-install Elemental Operator", func() {
 		By("Installing Operator via Helm", func() {
 			for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
-				// Check if CRDs chart is available (not always the case in older versions)
-				// Anyway, if it is needed and missing the next chart installation will fail too
-				if strings.Contains(chart, "-crds") {
-					noChart := kubectl.RunHelmBinaryWithCustomErr("show", "readme", operatorRepo+"/"+chart+"-chart")
-					if noChart != nil {
-						continue
-					}
-				}
 				RunHelmCmdWithRetry("upgrade", "--install", chart,
 					operatorRepo+"/"+chart+"-chart",
 					"--namespace", "cattle-elemental-system",


### PR DESCRIPTION
Bump K3s/RKE2 versions to the latest supported ones.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6382149454)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6382152309)
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6380722391)
- [UI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6380724097)