### PR TITLE
Few renfinements to the slem4r-os image

### DIFF
--- a/.obs/dockerfile/slem4r-os/Dockerfile
+++ b/.obs/dockerfile/slem4r-os/Dockerfile
@@ -1,31 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
 #!BuildTag: suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:latest
-#!BuildTag: suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:%RELEASE%
+#!BuildTag: suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 #
 
-FROM suse/sle15:15.5 as host
+ARG SLE_VERSION
+FROM suse/sle15:$SLE_VERSION as host
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
-
-# Define labels according to https://en.opensuse.org/Building_derived_containers
-# labelprefix=com.suse.sle.micro.rancher
-LABEL org.opencontainers.image.title="SLE Micro for Rancher"
-LABEL org.opencontainers.image.description="Image containing SLE Micro for Rancher - a containerized OS layer for Kubernetes."
-LABEL org.opencontainers.image.version="%%SLEMICRO_VERSION%%.%RELEASE%"
-LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"
-LABEL org.opencontainers.image.created="%BUILDTIME%"
-LABEL org.opencontainers.image.vendor="SUSE LLC"
-LABEL org.opencontainers.image.source="%SOURCEURL%"
-LABEL org.opensuse.reference="registry.suse.com/suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:%RELEASE%"
-LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL com.suse.supportlevel="alpha"
-LABEL com.suse.eula="sle-eula"
-LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle#suse-linux-enterprise-micro"
-LABEL com.suse.image-type="sle-micro"
-LABEL com.suse.release-stage="unreleased"
-# endlabelprefix
 
 RUN mkdir /osimage
 
@@ -78,6 +62,27 @@ RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
     echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \
     echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"   >> /etc/os-release && \
     echo GRUB_ENTRY_NAME=\"Elemental\"        >> /etc/os-release
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.sle.micro.rancher
+LABEL org.opencontainers.image.title="SLE Micro for Rancher"
+LABEL org.opencontainers.image.description="Image containing SLE Micro for Rancher - a containerized OS layer for Kubernetes."
+LABEL org.opencontainers.image.version="%%SLEMICRO_VERSION%%.%RELEASE%"
+LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opensuse.reference="registry.suse.com/suse/sle-micro-rancher/%%SLEMICRO_VERSION%%:%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="alpha"
+LABEL com.suse.eula="sle-eula"
+LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle#suse-linux-enterprise-micro"
+LABEL com.suse.image-type="sle-micro"
+LABEL com.suse.release-stage="unreleased"
+# endlabelprefix
+
+# Make sure trusted certificates are properly generated
+RUN /usr/sbin/update-ca-certificates
 
 # Ensure /tmp is mounted as tmpfs by default
 RUN if [ -e /usr/share/systemd/tmp.mount ]; then \


### PR DESCRIPTION
This commit includes 3 changes:
* Move LABELS for the final image instead of intermediate stage
* Sets tags with the usuall 3 tags approach: latest, version and version-release
* Works around ca-certificates installation failures when installing on a custom root

Part of #1008