### PR TITLE
ci/ui: fix ui tests to run rancher 2.8

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
@@ -29,7 +29,7 @@ filterTests(['main'], () => {
       cy.visit('/');
   
       // Open the navigation menu
-      cypressLib.burgerMenuOpenIfClosed();
+      cypressLib.burgerMenuToggle();
   
       // Click on the Elemental's icon
       cypressLib.accesMenu('OS Management');

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -16,6 +16,7 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import * as utils from '~/support/utils';
 
 filterTests(['main'], () => {
   Cypress.config();
@@ -24,6 +25,8 @@ filterTests(['main'], () => {
     beforeEach(() => {
       cy.login();
       cy.visit('/');
+      cypressLib.burgerMenuToggle();
+      cy.viewport(1920, 1080);
     });
     
     qase(31,
@@ -31,12 +34,12 @@ filterTests(['main'], () => {
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(20000);
-        cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
+        utils.isRancherManagerVersion('2.7') ? cypressLib.burgerMenuToggle(): null;
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         // TODO: function to deploy app?
         cy.contains(clusterName)
           .click();
-        cy.contains('Apps')
+        cy.get('.nav').contains('Apps')
           .click();
         cy.contains('Charts')
           .click();
@@ -56,17 +59,19 @@ filterTests(['main'], () => {
     qase(32,
       it('Remove Alerting Drivers application', () => {
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
-        cypressLib.burgerMenuOpenIfClosed();
         cy.contains(clusterName)
           .click();
-        cy.contains('Apps')
+        cy.get('.nav').contains('Apps')
           .click();
         cy.contains('Installed Apps')
           .click();
         cy.contains('.title', 'Installed Apps', {timeout:20000});
+        cy.contains('rancher-alerting-drivers');
         cy.get('[width="30"] > .checkbox-outer-container')
           .click();
-        cy.clickButton('Delete');
+        cy.get('.outlet')
+          .getBySel('sortable-table-promptRemove')
+          .click();
         cy.confirmDelete();
         cy.contains('SUCCESS: helm uninstall', {timeout:60000});
         cy.contains('.apps', 'rancher-alerting-drivers')

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -25,6 +25,7 @@ filterTests(['main', 'upgrade'], () => {
     beforeEach(() => {
       cy.login();
       cy.visit('/');
+      cypressLib.burgerMenuToggle();
     });
   
     qase(11,
@@ -35,14 +36,12 @@ filterTests(['main', 'upgrade'], () => {
     
     qase(12,
       it('Enable extension support', () => {
-        cypressLib.burgerMenuOpenIfClosed();
         isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false, isRancherManagerVersion("head"));
       })
     );
   
     qase(13,
       it('Install Elemental plugin', () => {
-        cypressLib.burgerMenuOpenIfClosed();
         // TODO: create a function to install any plugin and not elemental only
         cy.contains('Extensions')
           .click();

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -35,7 +35,7 @@ describe('Machine inventory testing', () => {
     cy.visit('/');
 
     // Open the navigation menu
-    cypressLib.burgerMenuOpenIfClosed();
+    cypressLib.burgerMenuToggle();
 
     // Click on the Elemental's icon
     cypressLib.accesMenu('OS Management');
@@ -88,8 +88,9 @@ describe('Machine inventory testing', () => {
   
   filterTests(['main', 'upgrade'], () => {
     it('Check Elemental cluster status', () => {
+      cypressLib.burgerMenuToggle();
       cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
-      cypressLib.burgerMenuOpenIfClosed();
+      cypressLib.burgerMenuToggle();
       cy.contains(clusterName)
         .click();
     })

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -29,7 +29,7 @@ describe('Machine registration testing', () => {
     cy.visit('/');
 
     // Open the navigation menu
-    cypressLib.burgerMenuOpenIfClosed();
+    cypressLib.burgerMenuToggle();
 
     // Click on the Elemental's icon
     cypressLib.accesMenu('OS Management');
@@ -47,11 +47,12 @@ describe('Machine registration testing', () => {
   });
 
   beforeEach(() => {
+    cy.viewport(1920, 1080);
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
     cy.visit('/');
 
     // Open the navigation menu
-    cypressLib.burgerMenuOpenIfClosed();
+    cypressLib.burgerMenuToggle();
 
     // Click on the Elemental's icon
     cypressLib.accesMenu('OS Management');

--- a/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
@@ -31,7 +31,7 @@ filterTests(['main'], () => {
       cy.visit('/');
   
       // Open the navigation menu
-      cypressLib.burgerMenuOpenIfClosed();
+      cypressLib.burgerMenuToggle();
   
       // Click on the Elemental's icon
       cypressLib.accesMenu('OS Management');

--- a/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
@@ -29,12 +29,12 @@ filterTests(['main'], () => {
     beforeEach(() => {
       (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
       cy.visit('/');
+      cypressLib.burgerMenuToggle();
     });
   
     qase(2,
       it('Check Elemental logo', () => {
         // Elemental's icon should appear in the side menu
-        cypressLib.burgerMenuOpenIfClosed();
         cypressLib.checkNavIcon('elemental')
           .should('exist');
       })
@@ -42,8 +42,6 @@ filterTests(['main'], () => {
     
     qase(3,
       it('Check Elemental menu', () => {
-        cypressLib.burgerMenuOpenIfClosed();
-  
         // Elemental's icon should appear in the side menu
         cypressLib.checkNavIcon('elemental')
           .should('exist');

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -31,7 +31,7 @@ filterTests(['main'], () => {
     beforeEach(() => {
       (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
       cy.visit('/');
-      cypressLib.burgerMenuOpenIfClosed();
+      cypressLib.burgerMenuToggle();
       cypressLib.accesMenu('OS Management');
     });
     
@@ -59,7 +59,7 @@ filterTests(['main'], () => {
         cy.getBySel('prompt-remove-input')
           .type('mycluster');
         cy.getBySel('prompt-remove-confirm-button').click();
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cypressLib.accesMenu('OS Management');
         cy.clickNavMenu(["Inventory of Machines"]);
         cy.contains('There are no rows to show.');

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -33,7 +33,7 @@ describe('Upgrade tests', () => {
     cy.visit('/');
 
     // Open the navigation menu
-    cypressLib.burgerMenuOpenIfClosed();    
+    cypressLib.burgerMenuToggle();
 
     // Click on the Elemental's icon
     cypressLib.accesMenu('OS Management');
@@ -51,8 +51,8 @@ describe('Upgrade tests', () => {
 
     qase(34,
       it('Upgrade one node (different methods if rke2 or k3s)', () => {
+        cypressLib.burgerMenuToggle();
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
-        cypressLib.burgerMenuOpenIfClosed();
         cypressLib.accesMenu('OS Management');
         /////////////////////////////////////////
         // K3s cluster upgraded with OS Image
@@ -103,7 +103,7 @@ describe('Upgrade tests', () => {
         // Workaround to avoid sporadic issue with Upgrade
         // https://github.com/rancher/elemental/issues/410
         // Restart fleet agent inside downstream cluster
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cy.getBySel('side-menu')
           .contains(clusterName)
           .click();
@@ -122,7 +122,7 @@ describe('Upgrade tests', () => {
           .type('kubectl rollout status deployment/fleet-agent -n cattle-fleet-system{enter}');
 
         // Check if the node reboots to apply the upgrade
-        cypressLib.burgerMenuOpenIfClosed();    
+        cypressLib.burgerMenuToggle();
         cypressLib.accesMenu('OS Management');
         cy.clickNavMenu(["Dashboard"]);
         cy.getBySel('card-clusters')

--- a/tests/cypress/latest/e2e/unit_tests/user.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/user.spec.ts
@@ -34,7 +34,7 @@ describe('User role testing', () => {
       it('Create standard user', () => {
         // User without the elemental-administrator role
         cy.login();
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cypressLib.createUser(stdUser, uiPassword);
       })
     );
@@ -43,7 +43,7 @@ describe('User role testing', () => {
       it('Create elemental user', () => {
         // User with the elemental-administrator role
         cy.login();
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cypressLib.createUser(elementalUser, uiPassword, 'Elemental Administrator');
       })
     );
@@ -55,7 +55,7 @@ describe('User role testing', () => {
         cy.login(elementalUser, uiPassword);
         cy.getBySel('banner-title')
           .contains('Welcome to Rancher');
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cypressLib.checkNavIcon('elemental').should('exist');
         cypressLib.accesMenu('OS Management');
         elemental.checkElementalNav();
@@ -67,7 +67,7 @@ describe('User role testing', () => {
         cy.login(stdUser, uiPassword);
         cy.getBySel('banner-title')
           .contains('Welcome to Rancher');
-        cypressLib.burgerMenuOpenIfClosed();
+        cypressLib.burgerMenuToggle();
         cypressLib.checkNavIcon('elemental').should('exist');
         cypressLib.accesMenu('OS Management');
         // User without appropriate role will get a specific page

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/rancher/elemental#readme",
   "dependencies": {
-    "@rancher-ecp-qa/cypress-library": "1.0.7",
+    "@rancher-ecp-qa/cypress-library": "1.0.8",
     "cy-verify-downloads": "^0.1.8",
     "cypress": "^10.0.0",
     "cypress-dark": "^1.8.3",

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -84,7 +84,9 @@ export const createCluster = (clusterName: string, k8sVersion: string, proxy: st
   // This wait can be replaced by something cleaner
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(3000);
+  cypressLib.burgerMenuToggle();
   cypressLib.checkClusterStatus(clusterName, 'Updating', 300000);
+  cypressLib.burgerMenuToggle();
   cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
   // Ugly but needed unfortunately to make sure the cluster stops switching status
   // eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
Fix #1049 

* Major change is the side nav menu

## Verification runs
[UI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6656157363) ✅ 
[UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6656159069) ✅ 
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/6657849127) ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6655739175) ❌
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6655744765) ❌