### PR TITLE
ci/ui: fix minor issues in UI tests

### DIFF
--- a/.github/workflows/ui-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.7.yaml
@@ -32,6 +32,6 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.8+rke2r1
-      rancher_version: ${{ inputs.rancher_version || 'latest/deve/2.7' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.8.yaml
@@ -32,6 +32,6 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.8+rke2r1
-      rancher_version: ${{ inputs.rancher_version || 'latest/deve/2.8' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
       upstream_cluster_version: v1.26.8+rke2r1

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -399,10 +399,10 @@ Cypress.Commands.add('checkLabelSize', (sizeToCheck) => {
 
 // Add an OS version channel
 Cypress.Commands.add('addOsVersionChannel', (channelVersion) => {
-    let channelRepo = `registry.opensuse.org/isv/rancher/elemental/${channelVersion}/containers/rancher/elemental-teal-channel:latest`;
-    if (channelVersion == "stable") {
-        channelRepo = `registry.opensuse.org/isv/rancher/elemental/${channelVersion}/teal53/15.4/rancher/elemental-teal-channel/5.3:latest`;
-    }
+  let channelRepo = `registry.opensuse.org/isv/rancher/elemental/${channelVersion}/containers/rancher/elemental-teal-channel:latest`;
+  if (channelVersion == "stable") {
+    channelRepo = 'registry.suse.com/rancher/elemental-teal-channel:latest';
+  }
     cy.clickNavMenu(["Advanced", "OS Version Channels"]);
     cy.getBySel('masthead-create')
       .contains('Create')
@@ -420,4 +420,4 @@ Cypress.Commands.add('addOsVersionChannel', (channelVersion) => {
     cy.wait(10000);
     // Make sure the new channel is in Active state
     cy.contains("Active "+channelVersion+"-channel", {timeout: 50000});
-  });
+});

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -42,15 +42,15 @@ Cypress.Commands.overwrite('type', (originalFn, subject, text, options = {}) => 
 const COMMAND_DELAY = 1000;
 
 for (const command of ['visit', 'click', 'trigger', 'type', 'clear', 'reload', 'contains']) {
-    Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-        const origVal = originalFn(...args);
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args);
 
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(origVal);
-            }, COMMAND_DELAY);
-        });
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(origVal);
+      }, COMMAND_DELAY);
     });
+  });
 }; 
 
 // Machine registration commands
@@ -67,109 +67,109 @@ Cypress.Commands.add('createMachReg', (
   checkIsoBuilding=false,
   customCloudConfig='',
   checkDefaultCloudConfig=true ) => {
-    cy.clickNavMenu(["Dashboard"]);
-    cy.getBySel('button-create-registration-endpoint')
-      .click();
-    cy.getBySel('name-ns-description-name')
-      .type(machRegName);
+  cy.clickNavMenu(["Dashboard"]);
+  cy.getBySel('button-create-registration-endpoint')
+    .click();
+  cy.getBySel('name-ns-description-name')
+    .type(machRegName);
 
-    if (customCloudConfig != '') {
-      cy.get('input[type="file"]')
-        .attachFile({filePath: customCloudConfig});
-    }
+  if (customCloudConfig != '') {
+    cy.get('input[type="file"]')
+      .attachFile({filePath: customCloudConfig});
+  }
 
-    checkLabels ? cy.addMachRegLabel('myLabel1', 'myLabelValue1') : null;
-    checkAnnotations? cy.addMachRegAnnotation('myAnnotation1', 'myAnnotationValue1') : null;
-    checkInventoryLabels ? cy.addMachInvLabel('myInvLabel1', 'myInvLabelValue1') : null;
-    checkInventoryAnnotations ? cy.addMachInvAnnotation('myInvAnnotation1', 'myInvAnnotationValue1') : null;
+  checkLabels ? cy.addMachRegLabel('myLabel1', 'myLabelValue1') : null;
+  checkAnnotations? cy.addMachRegAnnotation('myAnnotation1', 'myAnnotationValue1') : null;
+  checkInventoryLabels ? cy.addMachInvLabel('myInvLabel1', 'myInvLabelValue1') : null;
+  checkInventoryAnnotations ? cy.addMachInvAnnotation('myInvAnnotation1', 'myInvAnnotationValue1') : null;
 
-    cy.getBySel('form-save')
-      .contains('Create')
-      .click();
+  cy.getBySel('form-save')
+    .contains('Create')
+    .click();
 
-    // Make sure the machine registration is created and active
-    cy.contains('.masthead', 'Registration Endpoint: '+ machRegName + 'Active')
-      .should('exist');
+  // Make sure the machine registration is created and active
+  cy.contains('.masthead', 'Registration Endpoint: '+ machRegName + 'Active')
+    .should('exist');
 
-    // Check the namespace
-    cy.contains('.masthead', 'Namespace: '+ namespace)
-      .should('exist');
+  // Check the namespace
+  cy.contains('.masthead', 'Namespace: '+ namespace)
+    .should('exist');
 
-    // Make sure there is an URL registration in the Registration URL block
-    cy.getBySel('registration-url')
-      .contains(/https:\/\/.*elemental\/registration/);
+  // Make sure there is an URL registration in the Registration URL block
+  cy.getBySel('registration-url')
+    .contains(/https:\/\/.*elemental\/registration/);
 
-    // Test ISO building feature
-    if (checkIsoBuilding) {
-      // Build the ISO according to the elemental operator version
-      // Most of the time, it uses the latest dev version but sometimes
-      // before releasing, we want to test staging/stable artifacts 
-      cy.getBySel('select-os-version-build-iso')
-      .click();
-      // Never build from dev ISO in upgrade scenario
-      if (utils.isCypressTag('upgrade')) {
-        // Stable operator version is hardcoded for now
-        // Will try to improve it in next version
-        if (utils.isOperatorVersion('staging')) {
-          // In rare case, we might want to test upgrading from staging to dev
-          utils.isUpgradeOsChannel('dev') ? cy.contains('ISO x86_64 (unstable)').click(): null;
-        } else {
-            cy.contains('ISO x86_64 v1.2.2')
-            .click();
-        }
-      } else if (utils.isOperatorVersion('registry.suse.com')) {
-        cy.contains('ISO x86_64 v1.2.2')
-          .click();
+  // Test ISO building feature
+  if (checkIsoBuilding) {
+    // Build the ISO according to the elemental operator version
+    // Most of the time, it uses the latest dev version but sometimes
+    // before releasing, we want to test staging/stable artifacts 
+    cy.getBySel('select-os-version-build-iso')
+    .click();
+    // Never build from dev ISO in upgrade scenario
+    if (utils.isCypressTag('upgrade')) {
+      // Stable operator version is hardcoded for now
+      // Will try to improve it in next version
+      if (utils.isOperatorVersion('staging')) {
+        // In rare case, we might want to test upgrading from staging to dev
+        utils.isUpgradeOsChannel('dev') ? cy.contains('ISO x86_64 (unstable)').click(): null;
       } else {
-        cy.contains('ISO x86_64 (unstable)')
+          cy.contains('ISO x86_64 v1.2.2')
           .click();
       }
-      cy.getBySel('build-iso-btn')
+    } else if (utils.isOperatorVersion('registry.suse.com')) {
+      cy.contains('ISO x86_64 v1.2.2')
         .click();
-      cy.getBySel('build-iso-btn')
-        .get('.icon-spin');
-      // Download button is disabled while ISO is building
-      cy.getBySel('download-iso-btn').should(($input) => {
-        expect($input).to.have.attr('disabled')
-      })
-      // Download button is enabled once ISO building done
-      cy.getBySel('download-iso-btn', { timeout: 600000 }).should(($input) => {
-        expect($input).to.not.have.attr('disabled')
-      })
-      cy.getBySel('download-iso-btn')
-        .click()
-      cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
+    } else {
+      cy.contains('ISO x86_64 (unstable)')
+        .click();
     }
+    cy.getBySel('build-iso-btn')
+      .click();
+    cy.getBySel('build-iso-btn')
+      .get('.icon-spin');
+    // Download button is disabled while ISO is building
+    cy.getBySel('download-iso-btn').should(($input) => {
+      expect($input).to.have.attr('disabled')
+    })
+    // Download button is enabled once ISO building done
+    cy.getBySel('download-iso-btn', { timeout: 600000 }).should(($input) => {
+      expect($input).to.not.have.attr('disabled')
+    })
+    cy.getBySel('download-iso-btn')
+      .click()
+    cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
+  }
   
-    // Try to download the registration file and check it
-    cy.getBySel('download-btn')
-      .click();
-    cy.verifyDownload(machRegName + '_registrationURL.yaml');
-    cy.contains('Saving')
-      .should('not.exist');
+  // Try to download the registration file and check it
+  cy.getBySel('download-btn')
+    .click();
+  cy.verifyDownload(machRegName + '_registrationURL.yaml');
+  cy.contains('Saving')
+    .should('not.exist');
 
-    // Check Cloud configuration
-    // TODO: Maybe the check may be improved in one line
-    if (checkDefaultCloudConfig) {
-      cy.getBySel('yaml-editor-code-mirror')
-        .should('include.text','config:')
-        .should('include.text','cloud-config:')
-        .should('include.text','users:')
-        .should('include.text','- name: root')
-        .should('include.text','passwd: root')
-        .should('include.text','elemental:')
-        .should('include.text','install:')
-        .should('include.text','device: /dev/nvme0n1')
-        .should('include.text','poweroff: true');
-    }
+  // Check Cloud configuration
+  // TODO: Maybe the check may be improved in one line
+  if (checkDefaultCloudConfig) {
+    cy.getBySel('yaml-editor-code-mirror')
+      .should('include.text','config:')
+      .should('include.text','cloud-config:')
+      .should('include.text','users:')
+      .should('include.text','- name: root')
+      .should('include.text','passwd: root')
+      .should('include.text','elemental:')
+      .should('include.text','install:')
+      .should('include.text','device: /dev/nvme0n1')
+      .should('include.text','poweroff: true');
+  }
 
-    // Check label and annotation in YAML
-    // For now, we can only check in YAML because the fields are disabled and we cannot check their content
-    // It looks like we can use shadow DOM to catch it but too complicated for now
-    cy.contains('Registration Endpoint')
-      .click();
-    checkLabels ? cy.checkMachRegLabel(machRegName, 'myLabel1', 'myLabelValue1') : null;
-    checkAnnotations ? cy.checkMachRegAnnotation(machRegName, 'myAnnotation1', 'myAnnotationValue1') : null;
+  // Check label and annotation in YAML
+  // For now, we can only check in YAML because the fields are disabled and we cannot check their content
+  // It looks like we can use shadow DOM to catch it but too complicated for now
+  cy.contains('Registration Endpoint')
+    .click();
+  checkLabels ? cy.checkMachRegLabel(machRegName, 'myLabel1', 'myLabelValue1') : null;
+  checkAnnotations ? cy.checkMachRegAnnotation(machRegName, 'myAnnotation1', 'myAnnotationValue1') : null;
 });
 
 // Add Label to machine registration
@@ -259,12 +259,12 @@ Cypress.Commands.add('checkMachInvLabel', (machRegName, labelName, labelValue, a
     };
     cy.clickButton('Cancel');
   } else {
-      cy.getBySel('yaml-editor-code-mirror')
-        .contains(labelName + ': ' + labelValue);
-      if (userHardwareLabels) {
-        for (const key in hwLabels) {
-          cy.getBySel('yaml-editor-code-mirror')
-            .contains(key +': ');
+    cy.getBySel('yaml-editor-code-mirror')
+      .contains(labelName + ': ' + labelValue);
+    if (userHardwareLabels) {
+      for (const key in hwLabels) {
+        cy.getBySel('yaml-editor-code-mirror')
+          .contains(key +': ');
       };
     };
   }
@@ -272,56 +272,56 @@ Cypress.Commands.add('checkMachInvLabel', (machRegName, labelName, labelValue, a
 
 // Check machine registration label in YAML
 Cypress.Commands.add('checkMachRegLabel', (machRegName, labelName, labelValue) => {
-    cy.contains(machRegName)
-      .click();
-    cy.get('div.actions > .role-multi-action')
-      .click()
-    cy.contains('li', 'Edit YAML')
-      .click();
-    cy.contains('Registration Endpoint: '+ machRegName)
-      .should('exist');
-    cy.getBySel('yaml-editor-code-mirror')
-      .contains(labelName + ': ' + labelValue);
-    cy.clickButton('Cancel');
+  cy.contains(machRegName)
+    .click();
+  cy.get('div.actions > .role-multi-action')
+    .click()
+  cy.contains('li', 'Edit YAML')
+    .click();
+  cy.contains('Registration Endpoint: '+ machRegName)
+    .should('exist');
+  cy.getBySel('yaml-editor-code-mirror')
+    .contains(labelName + ': ' + labelValue);
+  cy.clickButton('Cancel');
 });
 
 // Check machine registration annotation in YAML
 Cypress.Commands.add('checkMachRegAnnotation', ( machRegName, annotationName, annotationValue) => {
-    cy.contains(machRegName)
-      .click();
-    cy.get('div.actions > .role-multi-action')
-      .click()
-    cy.contains('li', 'Edit YAML')
-      .click();
-    cy.contains('Registration Endpoint: '+ machRegName)
-      .should('exist');
-    cy.getBySel('yaml-editor-code-mirror')
-      .contains(annotationName + ': ' + annotationValue);
-    cy.clickButton('Cancel');
+  cy.contains(machRegName)
+    .click();
+  cy.get('div.actions > .role-multi-action')
+    .click()
+  cy.contains('li', 'Edit YAML')
+    .click();
+  cy.contains('Registration Endpoint: '+ machRegName)
+    .should('exist');
+  cy.getBySel('yaml-editor-code-mirror')
+    .contains(annotationName + ': ' + annotationValue);
+  cy.clickButton('Cancel');
 });
 
 // Edit a machine registration
 Cypress.Commands.add('editMachReg', ( machRegName, addLabel=false, addAnnotation=false, withYAML=false) => {
-    cy.contains(machRegName)
+  cy.contains(machRegName)
+    .click();
+  // Select the 3dots button and edit configuration
+  cy.get('div.actions > .role-multi-action')
+    .click()
+  if (withYAML) {
+    cy.contains('li', 'Edit YAML')
       .click();
-    // Select the 3dots button and edit configuration
-    cy.get('div.actions > .role-multi-action')
-      .click()
-    if (withYAML) {
-      cy.contains('li', 'Edit YAML')
-        .click();
-      cy.contains('metadata').as('meta')
-      cy.get('@meta').click(0,0)
-      cy.get('@meta').type('{end}{enter}  labels:{enter}  myLabel1: myLabelValue1');
-      cy.contains('metadata').as('meta')
-      cy.get('@meta').click(0,0)
-      cy.get('@meta').type('{end}{enter}  annotations:{enter}  myAnnotation1: myAnnotationValue1');
-    } else {
-      cy.contains('li', 'Edit Config')
-        .click();
-      addLabel ? cy.addMachRegLabel('myLabel1', 'myLabelValue1' ) : null;
-      addAnnotation ? cy.addMachRegAnnotation('myAnnotation1', 'myAnnotationValue1') : null;
-    }
+    cy.contains('metadata').as('meta')
+    cy.get('@meta').click(0,0)
+    cy.get('@meta').type('{end}{enter}  labels:{enter}  myLabel1: myLabelValue1');
+    cy.contains('metadata').as('meta')
+    cy.get('@meta').click(0,0)
+    cy.get('@meta').type('{end}{enter}  annotations:{enter}  myAnnotation1: myAnnotationValue1');
+  } else {
+    cy.contains('li', 'Edit Config')
+      .click();
+    addLabel ? cy.addMachRegLabel('myLabel1', 'myLabelValue1' ) : null;
+    addAnnotation ? cy.addMachRegAnnotation('myAnnotation1', 'myAnnotationValue1') : null;
+  }
 });
 
 // Delete a machine registration
@@ -354,44 +354,44 @@ Cypress.Commands.add('deleteMachReg', (machRegName) => {
 
 // Import machine inventory
 Cypress.Commands.add('importMachineInventory', (machineInventoryFile, machineInventoryName) => {
-    cy.clickNavMenu(["Inventory of Machines"]);
-    cy.getBySel('masthead-create-yaml')
-      .click();
-    cy.clickButton('Read from File');
-    cy.get('input[type="file"]')
-      .attachFile({filePath: machineInventoryFile});
-    cy.getBySel('action-button-async-button')
-      .contains('Create')
-      .click();
-    cy.contains('Creating')
-      .should('not.exist');
-    cy.contains(machineInventoryName)
-      .should('exist');
+  cy.clickNavMenu(["Inventory of Machines"]);
+  cy.getBySel('masthead-create-yaml')
+    .click();
+  cy.clickButton('Read from File');
+  cy.get('input[type="file"]')
+    .attachFile({filePath: machineInventoryFile});
+  cy.getBySel('action-button-async-button')
+    .contains('Create')
+    .click();
+  cy.contains('Creating')
+    .should('not.exist');
+  cy.contains(machineInventoryName)
+    .should('exist');
 });
 
 Cypress.Commands.add('checkFilter', (filterName, testFilterOne, testFilterTwo, shouldNotMatch) => {
-    cy.clickNavMenu(["Inventory of Machines"]);
-    cy.clickButton("Add Filter");
-    cy.get('.advanced-search-box').type(filterName);
-    cy.get('.bottom-block > .role-primary').click();
-    (testFilterOne) ? cy.contains('test-filter-one').should('exist') : cy.contains('test-filter-one').should('not.exist');
-    (testFilterTwo) ? cy.contains('test-filter-two').should('exist') : cy.contains('test-filter-two').should('not.exist');
-    (shouldNotMatch) ? cy.contains('shouldnotmatch').should('exist') : cy.contains('shouldnotmatch').should('not.exist');
+  cy.clickNavMenu(["Inventory of Machines"]);
+  cy.clickButton("Add Filter");
+  cy.get('.advanced-search-box').type(filterName);
+  cy.get('.bottom-block > .role-primary').click();
+  (testFilterOne) ? cy.contains('test-filter-one').should('exist') : cy.contains('test-filter-one').should('not.exist');
+  (testFilterTwo) ? cy.contains('test-filter-two').should('exist') : cy.contains('test-filter-two').should('not.exist');
+  (shouldNotMatch) ? cy.contains('shouldnotmatch').should('exist') : cy.contains('shouldnotmatch').should('not.exist');
 });
 
 Cypress.Commands.add('checkLabelSize', (sizeToCheck) => {
-    cy.clickNavMenu(["Dashboard"]);
-    cy.getBySel('button-create-registration-endpoint')
-      .click();
-    sizeToCheck == "name" ? cy.addMachInvLabel('labeltoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', 'mylabelvalue', false) : null;
-    sizeToCheck == "value" ? cy.addMachInvLabel('mylabelname', 'valuetoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', false) : null;
-    // A banner should appear alerting you about the size exceeded
-    // Following condition could be removed when we will release next Elemental UI (> 1.2.0)
-    utils.isUIVersion('dev') ? cy.get('[data-testid="banner-content"]') : cy.get('.banner > span');
-    // Create button should be disabled
-    cy.getBySel('form-save').should(($input) => {
-      expect($input).to.have.attr('disabled')
-    })
+  cy.clickNavMenu(["Dashboard"]);
+  cy.getBySel('button-create-registration-endpoint')
+    .click();
+  sizeToCheck == "name" ? cy.addMachInvLabel('labeltoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', 'mylabelvalue', false) : null;
+  sizeToCheck == "value" ? cy.addMachInvLabel('mylabelname', 'valuetoolonggggggggggggggggggggggggggggggggggggggggggggggggggggg', false) : null;
+  // A banner should appear alerting you about the size exceeded
+  // Following condition could be removed when we will release next Elemental UI (> 1.2.0)
+  utils.isUIVersion('dev') ? cy.get('[data-testid="banner-content"]') : cy.get('.banner > span');
+  // Create button should be disabled
+  cy.getBySel('form-save').should(($input) => {
+    expect($input).to.have.attr('disabled')
+  })
 });
 
 // OS Versions commands
@@ -403,21 +403,21 @@ Cypress.Commands.add('addOsVersionChannel', (channelVersion) => {
   if (channelVersion == "stable") {
     channelRepo = 'registry.suse.com/rancher/elemental-teal-channel:latest';
   }
-    cy.clickNavMenu(["Advanced", "OS Version Channels"]);
-    cy.getBySel('masthead-create')
-      .contains('Create')
-      .click();
-    cy.getBySel('name-ns-description-name')
-      .type(channelVersion + "-channel");
-    cy.getBySel('os-version-channel-path')
-      .type(channelRepo);
-    cy.getBySel('form-save')
-      .contains('Create')
-      .click();
-    // Status changes a lot right after the creation so let's wait 10 secondes
-    // before checking
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(10000);
-    // Make sure the new channel is in Active state
-    cy.contains("Active "+channelVersion+"-channel", {timeout: 50000});
+  cy.clickNavMenu(["Advanced", "OS Version Channels"]);
+  cy.getBySel('masthead-create')
+    .contains('Create')
+    .click();
+  cy.getBySel('name-ns-description-name')
+    .type(channelVersion + "-channel");
+  cy.getBySel('os-version-channel-path')
+    .type(channelRepo);
+  cy.getBySel('form-save')
+    .contains('Create')
+    .click();
+  // Status changes a lot right after the creation so let's wait 10 secondes
+  // before checking
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(10000);
+  // Make sure the new channel is in Active state
+  cy.contains("Active "+channelVersion+"-channel", {timeout: 50000});
 });


### PR DESCRIPTION
Fix some issues:
- new path for stable OS channel
Issue reported by this test: https://github.com/rancher/elemental/actions/runs/6661825940
![image](https://github.com/rancher/elemental/assets/6025636/d24fed96-53cc-4e49-97cf-7d59a57d6136)
OS channel failed to synchronize.
Os channel stable path is now: `registry.suse.com/rancher/elemental-teal-channel:latest`

- code indentation in `commands.ts`
- missing `l` in `rancher_version` for rke2 tests

## Verification runs
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6664312579) 🕐 
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6664313267) 🕐
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6664313955) 🕐

[UI-RKE2-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6664381840) 🕐
[UI-RKE2-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6664400580) 🕐