### PR TITLE
ci: fix upgrade test with SLE Micro OS

### DIFF
--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -31,5 +31,5 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.7
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -31,5 +31,5 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.8
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -32,5 +32,5 @@ jobs:
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
@@ -28,5 +28,5 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.7
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
@@ -28,5 +28,5 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.8
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -29,5 +29,5 @@ jobs:
       os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -23,9 +23,9 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
         type: string
-      teal_version:
-        description: Elemental Teal base OS version
-        default: 5.4
+      slem_version:
+        description: SLE Micro version
+        default: 5.5
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -56,4 +56,4 @@ jobs:
       os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro-rancher/${{ inputs.slem_version }}:latest

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -31,6 +31,6 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.7
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -31,6 +31,6 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.8
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -32,6 +32,6 @@ jobs:
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
@@ -30,6 +30,6 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.7
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
@@ -30,6 +30,6 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.8
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -30,6 +30,6 @@ jobs:
       os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -23,9 +23,9 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
         type: string
-      teal_version:
-        description: Elemental Teal base OS version
-        default: 5.4
+      slem_version:
+        description: SLE Micro version
+        default: 5.5
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
@@ -57,5 +57,5 @@ jobs:
       os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/rancher/elemental-teal/${{ inputs.teal_version }}:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro-rancher/${{ inputs.slem_version }}:latest
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -43,4 +43,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -43,4 +43,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -37,4 +37,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -24,9 +24,10 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
         type: string
+      # Test OS upgrade with OS image in this test ("Use image from registry")
       upgrade_image:
         description: Upgrade image to use
-        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
         type: string
 
 jobs:

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -40,6 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -40,6 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.8+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -45,6 +45,6 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-teal/5.4:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.8+rke2r1

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -24,6 +24,7 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
         type: string
+      # Test OS upgrade with OS channel in this test ("Use Managed OS Version")
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade
         default: dev


### PR DESCRIPTION
Needed to support https://github.com/rancher/elemental-operator/pull/544.

Verification runs:
- [CLI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6669882565)
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6669884254)
- [UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6668807988)

NOTE: issues in UI upgrade test should be fixed in PR #1068. And failure in Rancher Manager upgrade in `RM_Stable` test is not related to this PR at all.