### PR TITLE
ci/ui: improve ui upgrade tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -35,15 +35,16 @@ describe('Machine registration testing', () => {
     cypressLib.accesMenu('OS Management');
 
     // In upgrade scenario, we need to add extra channels
-    if (utils.isCypressTag('upgrade')) {
-      if (utils.isOperatorVersion('registry.suse.com')) {
-        utils.isUpgradeOsChannel('dev') ? cy.addOsVersionChannel('dev') : cy.addOsVersionChannel('staging');
-      } else if (utils.isOperatorVersion('staging')) {
-        cy.addOsVersionChannel('dev');
-      } else {
-        cy.addOsVersionChannel('stable');
-      }
-    }
+    // KEEP THIS COMMENTED FOR NOW
+    //if (utils.isCypressTag('upgrade')) {
+    //  if (utils.isOperatorVersion('registry.suse.com')) {
+    //    utils.isUpgradeOsChannel('dev') ? cy.addOsVersionChannel('dev') : cy.addOsVersionChannel('staging');
+    //  } else if (utils.isOperatorVersion('staging')) {
+    //    cy.addOsVersionChannel('dev');
+    //  } else {
+    //    cy.addOsVersionChannel('stable');
+    //  }
+    //}
   });
 
   beforeEach(() => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -31,6 +31,7 @@ describe('Upgrade tests', () => {
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
     cy.visit('/');
+    cy.viewport(1920, 1080);
 
     // Open the navigation menu
     cypressLib.burgerMenuToggle();
@@ -53,6 +54,7 @@ describe('Upgrade tests', () => {
       it('Upgrade one node (different methods if rke2 or k3s)', () => {
         cypressLib.burgerMenuToggle();
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
+        cypressLib.burgerMenuToggle();
         cypressLib.accesMenu('OS Management');
         /////////////////////////////////////////
         // K3s cluster upgraded with OS Image
@@ -68,7 +70,8 @@ describe('Upgrade tests', () => {
         cy.contains('Target Cluster')
         cy.getBySel('cluster-target')
           .click();
-        cy.contains(clusterName)
+        cy.get('#vs5__listbox')
+          .contains(clusterName)
           .click();
         if (utils.isK8sVersion("k3s")) {
           cy.getBySel('upgrade-choice-selector')
@@ -99,28 +102,6 @@ describe('Upgrade tests', () => {
         cy.wait(10000);
         cy.getBySel('sortable-cell-0-0')
           .contains('Active');
-
-        // Workaround to avoid sporadic issue with Upgrade
-        // https://github.com/rancher/elemental/issues/410
-        // Restart fleet agent inside downstream cluster
-        cypressLib.burgerMenuToggle();
-        cy.getBySel('side-menu')
-          .contains(clusterName)
-          .click();
-        cy.contains('Workload')
-          .click();
-        cy.contains('Pods')
-          .click();
-        cy.get('.header-buttons > :nth-child(2)')
-          .click();
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(20000);
-        // NOTE: in the downstream cluster the Namespace is cattle-fleet-system!
-        cy.get('.shell-body')
-          .type('kubectl rollout restart deployment/fleet-agent -n cattle-fleet-system{enter}');
-        cy.get('.shell-body')
-          .type('kubectl rollout status deployment/fleet-agent -n cattle-fleet-system{enter}');
-
         // Check if the node reboots to apply the upgrade
         cypressLib.burgerMenuToggle();
         cypressLib.accesMenu('OS Management');
@@ -130,14 +111,15 @@ describe('Upgrade tests', () => {
           .click()
         cy.get('.title')
           .contains('Clusters');
-        cy.contains(clusterName)
+        cy.get('.outlet')
+          .contains(clusterName)
           .click();
         cy.get('.primaryheader')
           .contains('Active');
         cy.get('.primaryheader')
           .contains('Active', {timeout: 420000}).should('not.exist');
         cy.get('.primaryheader')
-          .contains('Active', {timeout: 420000});
+          .contains('Active', {timeout: 540000});
       })
     );
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -114,11 +114,11 @@ Cypress.Commands.add('createMachReg', (
         // In rare case, we might want to test upgrading from staging to dev
         utils.isUpgradeOsChannel('dev') ? cy.contains('ISO x86_64 (unstable)').click(): null;
       } else {
-          cy.contains('ISO x86_64 v1.2.2')
+          cy.contains('ISO x86_64 v1.2.3')
           .click();
       }
     } else if (utils.isOperatorVersion('registry.suse.com')) {
-      cy.contains('ISO x86_64 v1.2.2')
+      cy.contains('ISO x86_64 v1.2.3')
         .click();
     } else {
       cy.contains('ISO x86_64 (unstable)')


### PR DESCRIPTION
* no need to add extra channel anymore
* remove the older/ugly workaround in upgrade test
* bump elemental stable version

## Verification runs
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6691754522/job/18179606611) ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6668442275/job/18124048369) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6691756184/job/18179611861) ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6691752908/job/18179604365) ✅  
[UI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6691909678/job/18180079184) ✅ 