### PR TITLE
ci/cli: fix sporadic error in WaitCluster

### DIFF
--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -189,7 +189,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 					const channel = "elemental-channel"
 
 					// Log the workaround, could be useful
-					GinkgoWriter.Printf("!! ManagedOSVersionChannel not synced !! Triggering a re-sync!`\n")
+					GinkgoWriter.Printf("!! ManagedOSVersionChannel not synced !! Triggering a re-sync!\n")
 
 					// Get current syncInterval
 					syncValue, err := kubectl.Run("get", "managedOSVersionChannel",


### PR DESCRIPTION
Not a good idea to check error value inside an `Eventually`, better to loop until the condition is met or wait for timeout.

Verification run:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/6730566015)

NOTE: VR is failing for another issue not related to this PR. The code changed here has been validated in the master node deployment.