### PR TITLE
ci/ui: install dev os channel if stable operator

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -41,12 +41,18 @@ describe('Upgrade tests', () => {
   });
 
   filterTests(['upgrade'], () => {
+    // Add dev OS Version Channel if stable operator is installed
+    // because we do not update the operator in UI test so far
+    if (utils.isOperatorVersion('registry.suse.com')) {
+      it('Add dev channel for RKE2 upgrade', () => {
+        cy.addOsVersionChannel('dev');
+      })
+    }
+
     qase(33,
       it('Check OS Versions', () => {
         cy.clickNavMenu(["Advanced", "OS Versions"]);
-        if (utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
-          cy.contains(new RegExp('Active.*-iso-unstable'), {timeout: 120000})
-        }
+        cy.contains(new RegExp('Active.*-iso-unstable'), {timeout: 120000})
       })
     );
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -399,9 +399,9 @@ Cypress.Commands.add('checkLabelSize', (sizeToCheck) => {
 
 // Add an OS version channel
 Cypress.Commands.add('addOsVersionChannel', (channelVersion) => {
-  let channelRepo = `registry.opensuse.org/isv/rancher/elemental/${channelVersion}/containers/rancher/elemental-teal-channel:latest`;
+  let channelRepo = `registry.opensuse.org/isv/rancher/elemental/${channelVersion}/containers/rancher/elemental-channel:latest`;
   if (channelVersion == "stable") {
-    channelRepo = 'registry.suse.com/rancher/elemental-teal-channel:latest';
+    channelRepo = 'registry.suse.com/rancher/elemental-channel:latest';
   }
   cy.clickNavMenu(["Advanced", "OS Version Channels"]);
   cy.getBySel('masthead-create')


### PR DESCRIPTION
* Remove teal from the channel URL path
* Install dev channel to allow upgrade from stable to devel

## Verification runs
[UI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/6733585703/job/18303853940) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6735487355) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6733584181/job/18302654733)  ✅ 
