### PR TITLE
Remove longhorn overlay mount

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -45,7 +45,6 @@ stages:
           /var/lib/rancher
           /var/lib/kubelet
           /var/lib/NetworkManager
-          /var/lib/longhorn
           /var/lib/cni
           /var/lib/calico
         PERSISTENT_STATE_BIND: "true"


### PR DESCRIPTION
As I understand it this path should be mounted by longhorn and we don't need to add a persistent overlay for it.