### PR TITLE
ci/ui: bump cypress library to 1.0.9

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
-import { isUIVersion, isRancherManagerVersion } from '../../support/utils';
+import { isUIVersion } from '../../support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
@@ -36,7 +36,7 @@ filterTests(['main', 'upgrade'], () => {
     
     qase(12,
       it('Enable extension support', () => {
-        isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false, isRancherManagerVersion("head"));
+        isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false);
       })
     );
   

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/rancher/elemental#readme",
   "dependencies": {
-    "@rancher-ecp-qa/cypress-library": "1.0.8",
+    "@rancher-ecp-qa/cypress-library": "1.0.9",
     "cy-verify-downloads": "^0.1.8",
     "cypress": "^10.0.0",
     "cypress-dark": "^1.8.3",

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -62,24 +62,15 @@ export const createCluster = (clusterName: string, k8sVersion: string, proxy: st
       .click();
     cy.get(':nth-child(7) > input')
       .type('HTTPS_PROXY');
-    if (isRancherManagerVersion('-head')) {
-      cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
-    } else {
-      cy.get(':nth-child(8) > .no-resize').type(proxy);
-    }
+    cy.get(':nth-child(8) > > [data-testid="text-area-auto-grow"]').type(proxy);
     cy.get('#agentEnv > .key-value')
       .contains('Add')
       .click();
     cy.get(':nth-child(10) > input')
       .type('NO_PROXY');
-    if (isRancherManagerVersion('-head')) {
-      cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
-        .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
-    } else {
-      cy.get(':nth-child(11) > .no-resize')
+    cy.get(':nth-child(11) > > [data-testid="text-area-auto-grow"]')
       .type('localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local');
     }
-  }
   cy.clickButton('Create');
   // This wait can be replaced by something cleaner
   // eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
* fix enableExtensionSupport function
Failed test: https://github.com/rancher/elemental/actions/workflows/ui-k3s-rm_stable.yaml

Library fix: https://github.com/rancher-sandbox/rancher-ecp-qa/pull/9

## Verification runs
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/6745426965) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/6745428706) ✅ 
[UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6745431000) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/6743607839/job/18331862591) ✅ 