### PR TITLE
ci/cli: increase timeout for scalabilty test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ ISO:=$(shell file -Ls $(ROOT_DIR)/*.iso 2>/dev/null | awk -F':' '/boot sector/ {
 # Define Ginkgo timeout for the tests
 GINKGO_TIMEOUT?=3600
 ifdef VM_NUMBERS
-	ifeq ($(shell expr $(VM_NUMBERS) \> 80), 1)
+	ifeq ($(shell expr $(VM_NUMBERS) \> 50), 1)
 		GINKGO_TIMEOUT=7200
 	endif
 endif


### PR DESCRIPTION
Needed because cluster state check takes more time now.

Verification run:
- [CLI-RKE2-Scalability-RM_Stable](https://github.com/rancher/elemental/actions/runs/6888337771)

NOTE: VR is failing but for something else that we will investigated later.