### PR TITLE
Drop the 'for Rancher' suffix

### DIFF
--- a/.obs/dockerfile/slem-base-iso/Dockerfile
+++ b/.obs/dockerfile/slem-base-iso/Dockerfile
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#!BuildTag: suse/sle-micro-iso/base-%%SLEMICRO_VERSION%%:latest
+#!BuildConstraint: hardware:disk:size unit=G 10
+#!BuildConstraint: hardware:memory:size unit=G 16
+
+ARG SLEMICRO_VERSION
+ARG SLE_VERSION
+
+FROM suse/sle-micro/base-${SLEMICRO_VERSION}:latest AS os
+FROM suse/sle-micro/${SLEMICRO_VERSION}:latest AS builder
+
+WORKDIR /iso
+
+COPY manifest.yaml manifest.yaml
+COPY --from=os / rootfs
+
+# Version value is taken form the elemental repository tags
+# Release value of this image and os image are unrelated
+RUN elemental --debug --config-dir . build-iso -o /output -n "sle-micro.$(uname -m)-base-%VERSION%-Build%RELEASE%" dir:rootfs
+
+# Only keep the ISO as a result
+FROM bci/bci-busybox:$SLE_VERSION
+COPY --from=builder /output /elemental-iso
+
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro-iso/base-$SLEMICRO_VERSION
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.rancher.slem
+LABEL org.opencontainers.image.title="SLE Micro base-ISO"
+LABEL org.opencontainers.image.description="Includes the SLE Micro ISO"
+LABEL org.opencontainers.image.version="%VERSION%"
+LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opensuse.reference=$IMAGE_REPO
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="l3"
+# endlabelprefix
+
+# By default run a shell
+ENTRYPOINT ["busybox"]
+CMD ["sh"]

--- a/.obs/dockerfile/slem-base-os/Dockerfile
+++ b/.obs/dockerfile/slem-base-os/Dockerfile
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Define the names/tags of the container
+#!BuildTag: suse/sle-micro/base-%%SLEMICRO_VERSION%%:latest
+#!BuildTag: suse/sle-micro/base-%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: suse/sle-micro/base-%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildConstraint: hardware:disk:size unit=G 8
+#
+
+ARG SLE_VERSION
+FROM suse/sle15:$SLE_VERSION as host
+
+MAINTAINER SUSE LLC (https://www.suse.com/)
+
+RUN mkdir /osimage
+
+RUN rpm --initdb --root /osimage
+
+RUN zypper --installroot /osimage in --no-recommends -y filesystem
+
+# make system bootable
+RUN zypper --installroot /osimage in --no-recommends -y grub2 shim dracut kernel systemd bash
+
+#!ArchExclusiveLine: x86_64
+RUN if [ `uname -m` = "x86-64" ]; then zypper --installroot /osimage in --no-recommends -y syslinux; fi
+
+# make dracut happy
+RUN zypper --installroot /osimage in --no-recommends -y squashfs NetworkManager device-mapper iproute2 tar curl ca-certificates ca-certificates-mozilla
+
+# make ARM happy
+#!ArchExclusiveLine: aarch64
+RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y raspberrypi-firmware-uefi grub2-arm64-efi; fi
+                
+# make SUSE happy
+RUN zypper --installroot /osimage in --no-recommends -y SLE-Micro-Rancher-release systemd-presets-branding-SLE-Micro-for-Rancher
+
+# make elemental-register happy
+RUN zypper --installroot /osimage in --no-recommends -y dmidecode lvm2
+
+# make Rancher (containerd) happy
+RUN zypper --installroot /osimage in --no-recommends -y apparmor-parser
+
+# add elemental
+RUN zypper --installroot /osimage in --no-recommends -y elemental
+
+# end of mandatory package installs for SLE Micro
+
+# make derived containers possible
+RUN zypper --installroot /osimage in --no-recommends -y zypper
+
+FROM scratch as osimage
+
+COPY --from=host /osimage /
+
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/base-$SLEMICRO_VERSION
+ARG IMAGE_TAG=%VERSION%-%RELEASE%
+
+# IMPORTANT: Setup elemental-release used for versioning/upgrade. The
+# values here should reflect the tag of the image being built
+# Also used by elemental-populate-labels
+RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
+    echo IMAGE_TAG=\"${IMAGE_TAG}\"                >> /etc/os-release && \
+    echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\"      >> /etc/os-release && \
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"        >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"SLE Micro\" >> /etc/os-release
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.sle.micro
+LABEL org.opencontainers.image.title="SLE Micro"
+LABEL org.opencontainers.image.description="Image containing SLE Micro - a containerized OS layer for Kubernetes."
+LABEL org.opencontainers.image.version="base-%%SLEMICRO_VERSION%%.%RELEASE%"
+LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opensuse.reference="registry.suse.com/suse/sle-micro/%%SLEMICRO_VERSION%%:%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="alpha"
+LABEL com.suse.eula="sle-eula"
+LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle#suse-linux-enterprise-micro"
+LABEL com.suse.image-type="sle-micro"
+LABEL com.suse.release-stage="unreleased"
+# endlabelprefix
+
+# Make sure trusted certificates are properly generated
+RUN /usr/sbin/update-ca-certificates
+
+# Ensure /tmp is mounted as tmpfs by default
+RUN if [ -e /usr/share/systemd/tmp.mount ]; then \
+      cp /usr/share/systemd/tmp.mount /etc/systemd/system; \
+    fi
+
+# Save some space
+RUN zypper clean --all && \
+    rm -rf /var/log/update* && \
+    >/var/log/lastlog && \
+    rm -rf /boot/vmlinux*
+
+# Rebuild initrd to setup dracut with the boot configurations
+RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
+    # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
+    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi

--- a/.obs/dockerfile/slem-flavored-os/Dockerfile
+++ b/.obs/dockerfile/slem-flavored-os/Dockerfile
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Define the names/tags of the container
+#!BuildTag: suse/sle-micro/%%BUILD_FLAVOR%%%%SLEMICRO_VERSION%%:latest
+#!BuildTag: suse/sle-micro/%%BUILD_FLAVOR%%%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: suse/sle-micro/%%BUILD_FLAVOR%%%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildConstraint: hardware:disk:size unit=G 8
+#
+
+ARG SLEMICRO_VERSION
+
+FROM suse/sle-micro/base-${SLEMICRO_VERSION}:latest
+
+# dummy zypper call to get elemental into the build context and extract %VERSION% from it via _service
+RUN zypper in --no-recommends -y systemd-presets-branding-SLE-Micro-for-Rancher elemental
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.sle.micro
+LABEL org.opencontainers.image.version="%%BUILD_FLAVOR%%%%SLEMICRO_VERSION%%.%VERSION%.%RELEASE%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.source="%SOURCEURL%"
+# endlabelprefix
+
+
+RUN if [[ "%%BUILD_FLAVOR%%" == "kvm-" ]]; then \
+  # replace default kernel with smaller one, sufficient to run kvm guests \
+  zypper in --no-recommends -y kernel-default-base -kernel-default; \
+else \
+  # extend -base with baremetal and usability packages \
+  zypper in --no-recommends -y procps openssl openssh vim-small less iputils kernel-firmware-all NetworkManager-wwan cryptsetup; \
+fi
+
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/$SLEMICRO_VERSION
+ARG IMAGE_TAG=%VERSION%-%RELEASE%
+
+# IMPORTANT: Setup elemental-release used for versioning/upgrade. The
+# values here should reflect the tag of the image being built
+# Also used by elemental-populate-labels
+RUN grep -v IMAGE_REPO /etc/os-release | grep -v "IMAGE_TAG|IMAGE=|TIMESTAMP|GRUB_ENTRY_NAME" > /tmp/os-release
+RUN mv /tmp/os-release /etc/os-release
+RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
+    echo IMAGE_TAG=\"${IMAGE_TAG}\"                >> /etc/os-release && \
+    echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\"      >> /etc/os-release && \
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"        >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"SLE Micro\" >> /etc/os-release
+
+# Ensure /tmp is mounted as tmpfs by default
+RUN if [ -e /usr/share/systemd/tmp.mount ]; then \
+      cp /usr/share/systemd/tmp.mount /etc/systemd/system; \
+    fi
+
+# Save some space
+RUN if [ -f /usr/bin/zypper ]; then zypper clean --all; fi
+# Save more space
+RUN rm -rf /var/log/update* && \
+    >/var/log/lastlog && \
+    rm -rf /boot/vmlinux*
+
+# Rebuild initrd to setup dracut with the boot configurations
+RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
+    # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
+    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi

--- a/.obs/dockerfile/slem-iso/Dockerfile
+++ b/.obs/dockerfile/slem-iso/Dockerfile
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#!BuildTag: suse/sle-micro-iso/%%SLEMICRO_VERSION%%:latest
+#!BuildTag: suse/sle-micro-iso/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: suse/sle-micro-iso/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildConstraint: hardware:disk:size unit=G 10
+#!BuildConstraint: hardware:memory:size unit=G 16
+
+ARG SLE_VERSION
+ARG SLEMICRO_VERSION
+
+FROM suse/sle-micro/$SLEMICRO_VERSION:latest AS os
+FROM suse/sle-micro/$SLEMICRO_VERSION:latest AS builder
+
+WORKDIR /iso
+
+COPY manifest.yaml manifest.yaml
+COPY --from=os / rootfs
+
+# Version value is taken form the elemental repository tags
+# Release value of this image and os image are unrelated
+RUN elemental --debug --config-dir . build-iso -o /output -n "sle-micro.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
+
+# Only keep the ISO as a result
+FROM bci/bci-busybox:$SLE_VERSION
+COPY --from=builder /output /elemental-iso
+
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro-iso/$SLEMICRO_VERSION
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.rancher.slem
+LABEL org.opencontainers.image.title="SLE Micro ISO"
+LABEL org.opencontainers.image.description="Includes the SLE Micro ISO"
+LABEL org.opencontainers.image.version="%VERSION%"
+LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opensuse.reference=$IMAGE_REPO
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="l3"
+# endlabelprefix
+
+# By default run a shell
+ENTRYPOINT ["busybox"]
+CMD ["sh"]

--- a/.obs/dockerfile/slem-iso/manifest.yaml
+++ b/.obs/dockerfile/slem-iso/manifest.yaml
@@ -1,0 +1,6 @@
+iso:
+  bootloader-in-rootfs: true
+  grub-entry-name: "SLE Micro for Rancher Install"
+
+squash-no-compression: true
+

--- a/.obs/dockerfile/slem-os/Dockerfile
+++ b/.obs/dockerfile/slem-os/Dockerfile
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Define the names/tags of the container
+#!BuildTag: suse/sle-micro/%%SLEMICRO_VERSION%%:latest
+#!BuildTag: suse/sle-micro/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: suse/sle-micro/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildConstraint: hardware:disk:size unit=G 8
+#
+
+ARG SLE_VERSION
+FROM suse/sle15:$SLE_VERSION as host
+
+MAINTAINER SUSE LLC (https://www.suse.com/)
+
+RUN mkdir /osimage
+
+RUN rpm --initdb --root /osimage
+
+RUN zypper --installroot /osimage in --no-recommends -y filesystem
+
+# make system bootable
+RUN zypper --installroot /osimage in --no-recommends -y grub2 shim dracut kernel kernel-firmware-all systemd bash
+
+#!ArchExclusiveLine: x86_64
+RUN if [ `uname -m` = "x86-64" ]; then zypper --installroot /osimage in --no-recommends -y syslinux; fi
+
+# make dracut happy
+RUN zypper --installroot /osimage in --no-recommends -y squashfs NetworkManager device-mapper iproute2 tar curl ca-certificates ca-certificates-mozilla
+
+# make ARM happy
+#!ArchExclusiveLine: aarch64
+RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y grub2-arm64-efi raspberrypi-firmware raspberrypi-firmware-config raspberrypi-firmware-dt u-boot-rpiarm64; fi
+
+# make SUSE happy
+RUN zypper --installroot /osimage in --no-recommends -y SLE-Micro-Rancher-release systemd-presets-branding-SLE-Micro-for-Rancher
+
+# make elemental-register happy
+RUN zypper --installroot /osimage in --no-recommends -y dmidecode lvm2
+
+# make Rancher (containerd) happy
+RUN zypper --installroot /osimage in --no-recommends -y apparmor-parser
+
+# add elemental
+RUN zypper --installroot /osimage in --no-recommends -y elemental
+
+# make users happy
+RUN zypper --installroot /osimage in --no-recommends -y procps openssl openssh vim-small less iputils NetworkManager-wwan cryptsetup podman zypper
+
+FROM scratch as osimage
+
+COPY --from=host /osimage /
+
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/$SLEMICRO_VERSION
+ARG IMAGE_TAG=%VERSION%-%RELEASE%
+
+# IMPORTANT: Setup elemental-release used for versioning/upgrade. The
+# values here should reflect the tag of the image being built
+# Also used by elemental-populate-labels
+RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
+    echo IMAGE_TAG=\"${IMAGE_TAG}\"                >> /etc/os-release && \
+    echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\"      >> /etc/os-release && \
+    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"        >> /etc/os-release && \
+    echo GRUB_ENTRY_NAME=\"SLE Micro\" >> /etc/os-release
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.sle.micro
+LABEL org.opencontainers.image.title="SLE Micro"
+LABEL org.opencontainers.image.description="Image containing SLE Micro - a containerized OS layer for Kubernetes."
+LABEL org.opencontainers.image.version="%%SLEMICRO_VERSION%%.%RELEASE%"
+LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opensuse.reference="registry.suse.com/suse/sle-micro/%%SLEMICRO_VERSION%%:%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="alpha"
+LABEL com.suse.eula="sle-eula"
+LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle#suse-linux-enterprise-micro"
+LABEL com.suse.image-type="sle-micro"
+LABEL com.suse.release-stage="unreleased"
+# endlabelprefix
+
+# Make sure trusted certificates are properly generated
+RUN /usr/sbin/update-ca-certificates
+
+# Ensure /tmp is mounted as tmpfs by default
+RUN if [ -e /usr/share/systemd/tmp.mount ]; then \
+      cp /usr/share/systemd/tmp.mount /etc/systemd/system; \
+    fi
+
+# Save some space
+RUN zypper clean --all && \
+    rm -rf /var/log/update* && \
+    >/var/log/lastlog && \
+    rm -rf /boot/vmlinux*
+
+# Rebuild initrd to setup dracut with the boot configurations
+RUN elemental init --force immutable-rootfs,grub-config,dracut-config,cloud-config-essentials,elemental-setup && \
+    # aarch64 has an uncompressed kernel so we need to link it to vmlinuz
+    kernel=$(ls /boot/Image-* 2>/dev/null | head -n1) && \
+    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi


### PR DESCRIPTION
only for image names and tags.

keep it for the release and the systemd-preset package.