### PR TITLE
ci: disable metrics-server, bump k8s versions, increase cpu/ram of nodes

### DIFF
--- a/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
@@ -24,6 +24,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.7

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
@@ -24,6 +24,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.8

--- a/.github/workflows/cli-k3s-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_stable.yaml
@@ -24,5 +24,5 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 3

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
@@ -25,7 +25,7 @@ jobs:
       cluster_number: 20
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
       test_type: multi_cli
       zone: us-central1-b

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -38,7 +38,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -49,7 +49,7 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
@@ -22,6 +22,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.7
       reset: true

--- a/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
@@ -22,6 +22,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.8
       reset: true

--- a/.github/workflows/cli-k3s-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_stable.yaml
@@ -22,5 +22,5 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       reset: true

--- a/.github/workflows/cli-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.7.yaml
@@ -22,5 +22,5 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.7

--- a/.github/workflows/cli-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.8.yaml
@@ -22,5 +22,5 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.8

--- a/.github/workflows/cli-k3s-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-rm_stable.yaml
@@ -22,4 +22,4 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2

--- a/.github/workflows/cli-k3s-sequential-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-sequential-rm_head_2.7.yaml
@@ -22,6 +22,6 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.7
       sequential: true

--- a/.github/workflows/cli-k3s-sequential-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-sequential-rm_head_2.8.yaml
@@ -22,6 +22,6 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: latest/devel/2.8
       sequential: true

--- a/.github/workflows/cli-k3s-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rm_stable.yaml
@@ -22,6 +22,6 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       rancher_version: stable/latest/none
       sequential: true

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: boolean
       k8s_version:
         description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
-        default: v1.26.8+k3s1
+        default: v1.26.10+k3s2
         type: string
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.7
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.8
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_stable.yaml
@@ -24,6 +24,6 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 3
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -33,4 +33,4 @@ jobs:
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -33,4 +33,4 @@ jobs:
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -24,7 +24,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -34,4 +34,4 @@ jobs:
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -26,8 +26,8 @@ jobs:
       cluster_number: 20
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
       test_type: multi_cli
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2
       zone: us-central1-f

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -39,8 +39,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
@@ -24,7 +24,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -32,4 +32,4 @@ jobs:
       rancher_version: latest/devel/2.7
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
@@ -24,7 +24,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -32,4 +32,4 @@ jobs:
       rancher_version: latest/devel/2.8
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -32,4 +32,4 @@ jobs:
       rancher_version: stable/latest/none
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -50,7 +50,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}
@@ -58,4 +58,4 @@ jobs:
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro-rancher/${{ inputs.slem_version }}:latest
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2
       reset: true

--- a/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2
       reset: true

--- a/.github/workflows/cli-rke2-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_stable.yaml
@@ -23,6 +23,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
-      upstream_cluster_version: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
+      upstream_cluster_version: v1.26.10+rke2r2
       reset: true

--- a/.github/workflows/cli-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.7.yaml
@@ -23,6 +23,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.8.yaml
@@ -23,6 +23,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-rm_stable.yaml
@@ -23,5 +23,5 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
-      upstream_cluster_version: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-scalability-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-scalability-rm_stable.yaml
@@ -24,8 +24,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       node_number: 60
       rancher_version: stable/latest/none
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-sequential-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_head_2.7.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       sequential: true
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-sequential-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_head_2.8.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       sequential: true
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: stable/latest/none
       sequential: true
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -135,7 +135,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.26.8+k3s1
+        default: v1.26.10+k3s2
         type: string
       zone:
         description: GCP zone to host the runner

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -68,9 +68,6 @@ on:
         description: Choose booting from ISO
         default: false
         type: boolean
-      k3s_flags:
-        description: Argument to configure INSTALL_K3S_EXEC env variable 
-        type: string
       k8s_version_to_provision:
         description: Name and version of installed K8s distribution
         required: true

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -410,11 +410,11 @@ jobs:
         run: |
           # Only use ISO boot if the upstream cluster is RKE2
           # due to issue with pxe, dhcp traffic
-          # Set RAM to 8GB for RKE2 and vCPU to 4, it's the recommended values
+          # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
           if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
             export ISO_BOOT=true
-            export VM_MEM=8192
-            export VM_CPU=4
+            export VM_MEM=10240
+            export VM_CPU=6
           fi
           # Execute bootstrapping test
           if ${{ inputs.sequential == true }}; then
@@ -431,7 +431,13 @@ jobs:
         env:
           CLUSTER_NUMBER: ${{ inputs.cluster_number }}
           ISO_BOOT: ${{ inputs.iso_boot }}
-        run: cd tests && make e2e-multi-cluster
+        run: |
+          # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
+          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+            export VM_MEM=10240
+            export VM_CPU=6
+          fi
+          cd tests && make e2e-multi-cluster
       - name: Install a simple application
         if: ${{ inputs.test_type == 'single_cli' && contains(inputs.upstream_cluster_version, 'k3s') }}
         run: cd tests && make e2e-install-app && make e2e-check-app
@@ -546,10 +552,10 @@ jobs:
           VM_START: 4
           VM_END: ${{ inputs.node_number }}
         run: |
-          # Set RAM to 8GB for RKE2 and vCPU to 4, it's the recommended values
+          # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
           if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
-            export VM_MEM=8192
-            export VM_CPU=4
+            export VM_MEM=10240
+            export VM_CPU=6
           fi
           if ${{ inputs.sequential == true }}; then
             # Force node bootstrapping in sequential instead of parallel

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -41,7 +41,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -45,7 +45,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.7.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.8.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-rm_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: string
       k8s_version_to_provision:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
-        default: v1.26.8+k3s1
+        default: v1.26.10+k3s2
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -39,8 +39,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -35,8 +35,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -35,8 +35,8 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -37,9 +37,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -37,9 +37,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -41,10 +41,10 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -46,10 +46,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.7.yaml
@@ -31,7 +31,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.8.yaml
@@ -31,7 +31,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-rm_stable.yaml
@@ -34,7 +34,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.8+rke2r1
+      k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upstream_cluster_version: v1.26.8+rke2r1
+      upstream_cluster_version: v1.26.10+rke2r2

--- a/tests/assets/cluster-multi.yaml
+++ b/tests/assets/cluster-multi.yaml
@@ -9,6 +9,9 @@ spec:
       disableSnapshots: true
     machineGlobalConfig:
       cni: canal
+      disable:
+        - rke2-metrics-server
+        - metrics-server
       etcd-expose-metrics: false
       profile: null
     machinePools:

--- a/tests/assets/cluster.yaml
+++ b/tests/assets/cluster.yaml
@@ -9,6 +9,9 @@ spec:
       disableSnapshots: true
     machineGlobalConfig:
       cni: canal
+      disable:
+        - rke2-metrics-server
+        - metrics-server
       etcd-expose-metrics: false
       profile: null
     machinePools:

--- a/tests/assets/config_rke2.yaml
+++ b/tests/assets/config_rke2.yaml
@@ -1,0 +1,3 @@
+write-kubeconfig-mode: "0644"
+disable:
+  - rke2-metrics-server

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -82,8 +82,9 @@ var _ = Describe("E2E - Install Backup/Restore Operator", Label("install-backup-
 
 		By("Waiting for rancher-backup-operator pod", func() {
 			// Wait for pod to be started
-			err := rancher.CheckPod(k, [][]string{{"cattle-resources-system", "app.kubernetes.io/name=rancher-backup"}})
-			Expect(err).To(Not(HaveOccurred()))
+			Eventually(func() error {
+				return rancher.CheckPod(k, [][]string{{"cattle-resources-system", "app.kubernetes.io/name=rancher-backup"}})
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 		})
 	})
 })

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -54,8 +54,9 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					"-o", "jsonpath={.status.registrationURL}")
 				Expect(err).To(Not(HaveOccurred()))
 
-				err = tools.GetFileFromURL(tokenURL, installConfigYaml, false)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return tools.GetFileFromURL(tokenURL, installConfigYaml, false)
+				}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
 			})
 
 			By("Configuring iPXE boot script for network installation", func() {

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -106,8 +106,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 					{"kube-system", "app=rke2-metrics-server"},
 					{"kube-system", "app.kubernetes.io/name=rke2-ingress-nginx"},
 				}
-				err = rancher.CheckPod(k, checkList)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return rancher.CheckPod(k, checkList)
+				}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 
 				err = k.WaitLabelFilter("kube-system", "Ready", "rke2-ingress-nginx-controller", "app.kubernetes.io/name=rke2-ingress-nginx")
 				Expect(err).To(Not(HaveOccurred()))
@@ -154,8 +155,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 					{"kube-system", "app.kubernetes.io/name=traefik"},
 					{"kube-system", "svccontroller.k3s.cattle.io/svcname=traefik"},
 				}
-				err := rancher.CheckPod(k, checkList)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return rancher.CheckPod(k, checkList)
+				}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 			})
 		}
 
@@ -202,8 +204,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 					{"cert-manager", "app.kubernetes.io/component=webhook"},
 					{"cert-manager", "app.kubernetes.io/component=cainjector"},
 				}
-				err := rancher.CheckPod(k, checkList)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return rancher.CheckPod(k, checkList)
+				}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 			})
 		}
 
@@ -235,8 +238,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				{"cattle-fleet-local-system", "app=fleet-agent"},
 				{"cattle-system", "app=rancher-webhook"},
 			}
-			err = rancher.CheckPod(k, checkList)
-			Expect(err).To(Not(HaveOccurred()))
+			Eventually(func() error {
+				return rancher.CheckPod(k, checkList)
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 
 			// We have to restart Rancher Manager to be sure that Private CA is used
 			if caType == "private" {
@@ -332,8 +336,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				}
 
 				// Wait for pod to be started
-				err := rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
+				}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 			})
 		}
 	})

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -61,8 +61,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			By("Installing RKE2", func() {
 				// Get RKE2 installation script
 				fileName := "rke2-install.sh"
-				err := tools.GetFileFromURL("https://get.rke2.io", fileName, true)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return tools.GetFileFromURL("https://get.rke2.io", fileName, true)
+				}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
 
 				// Retry in case of (sporadic) failure...
 				count := 1
@@ -121,8 +122,9 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			By("Installing K3s", func() {
 				// Get K3s installation script
 				fileName := "k3s-install.sh"
-				err := tools.GetFileFromURL("https://get.k3s.io", fileName, true)
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					return tools.GetFileFromURL("https://get.k3s.io", fileName, true)
+				}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
 
 				// Set command and arguments
 				installCmd := exec.Command("sh", fileName)

--- a/tests/e2e/multi-cluster_test.go
+++ b/tests/e2e/multi-cluster_test.go
@@ -109,8 +109,9 @@ var _ = Describe("E2E - Bootstrapping node", Label("multi-cluster"), func() {
 				"-o", "jsonpath={.status.registrationURL}")
 			Expect(err).To(Not(HaveOccurred()))
 
-			err = tools.GetFileFromURL(tokenURL, installConfigYaml, false)
-			Expect(err).To(Not(HaveOccurred()))
+			Eventually(func() error {
+				return tools.GetFileFromURL(tokenURL, installConfigYaml, false)
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
 		})
 
 		By("Creating ISO from SeedImage", func() {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -35,6 +35,7 @@ const (
 	backupYaml            = "../assets/backup.yaml"
 	ciTokenYaml           = "../assets/local-kubeconfig-token-skel.yaml"
 	configPrivateCAScript = "../scripts/config-private-ca"
+	configRKE2Yaml        = "../assets/config_rke2.yaml"
 	dumbRegistrationYaml  = "../assets/dumb_machineRegistration.yaml"
 	emulateTPMYaml        = "../assets/emulateTPM.yaml"
 	getOSScript           = "../scripts/get-name-from-managedosversion"

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -42,8 +42,9 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Get the YAML config file
-			err = tools.GetFileFromURL(tokenURL, installConfigYaml, false)
-			Expect(err).To(Not(HaveOccurred()))
+			Eventually(func() error {
+				return tools.GetFileFromURL(tokenURL, installConfigYaml, false)
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
 		})
 
 		By("Starting default network", func() {

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -145,8 +145,9 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 			}
 
 			// Wait for pod to be started
-			err := rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
-			Expect(err).To(Not(HaveOccurred()))
+			Eventually(func() error {
+				return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 		})
 
 		By("Creating a dumb MachineRegistration", func() {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -67,8 +67,9 @@ var _ = Describe("E2E - Upgrading Elemental Operator", Label("upgrade-operator")
 		}
 
 		// Wait for all pods to be started
-		err = rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
-		Expect(err).To(Not(HaveOccurred()))
+		Eventually(func() error {
+			return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
+		}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
 	})
 })
 

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -26,10 +26,10 @@ if (( NR_HUGEPAGES == 0 && USE_HUGEPAGES != 0 )); then
     && sudo bash -c "echo ${VALUE} > /proc/sys/vm/nr_hugepages"
 
   # Set memory config on command line
-  INSTALL_FLAG+=" --memorybacking hugepages=yes,size=2,unit=M,locked=yes --memory ${VM_MEM:-2048},hugepages=yes"
+  INSTALL_FLAG+=" --memorybacking hugepages=yes,size=2,unit=M,locked=yes --memory ${VM_MEM:-4096},hugepages=yes"
 else
   # Set memory config on command line
-  INSTALL_FLAG+=" --memory ${VM_MEM:-2048}"
+  INSTALL_FLAG+=" --memory ${VM_MEM:-4096}"
 fi
 
 # Don't configure TPM if software emulation (EMULATE_TPM=true) is used
@@ -87,7 +87,7 @@ CMD="sudo virt-install \
        --machine q35 \
        --boot loader=${FW_CODE},loader.readonly=yes,loader.secure=yes,loader.type=pflash,nvram.template=${FW_VARS} \
        --features smm.state=yes \
-       --vcpus ${VM_CPU:-2} \
+       --vcpus ${VM_CPU:-4} \
        --cpu host \
        --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=35 \
        --check disk_size=off \


### PR DESCRIPTION
`metrics-server` is not useful for QA, so better to remove it to save some resources. This also remove/workaround some sporadic issues we have with the installation of CertManager.

This also fixes some other sporadic issues. It should fix #1087.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7030769541)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7030771891)
- [CLI-RKE2-Multi_Cluster-RM_Stable](https://github.com/rancher/elemental/actions/runs/7031077669)
- [UI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7031386892)
- [UI-RKE2-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7031388463)