### PR TITLE
Include real time version as flavor

### DIFF
--- a/.obs/dockerfile/slem-flavored-os/Dockerfile
+++ b/.obs/dockerfile/slem-flavored-os/Dockerfile
@@ -17,6 +17,8 @@ RUN zypper in --no-recommends -y systemd-presets-branding-SLE-Micro-for-Rancher 
 RUN if [[ "%%BUILD_FLAVOR%%" == "kvm-" ]]; then \
   # replace default kernel with smaller one, sufficient to run kvm guests \
   zypper in --no-recommends -y kernel-default-base -kernel-default; \
+elif [[ "%%BUILD_FLAVOR%%" == "rt-" ]]; then \
+  zypper in --no-recommends -y kernel-rt -kernel-default; \ 
 else \
   # extend -base with baremetal and usability packages \
   zypper in --no-recommends -y procps openssl openssh vim-small less iputils kernel-firmware-all NetworkManager-wwan cryptsetup; \

--- a/.obs/dockerfile/slem-flavored-os/Dockerfile
+++ b/.obs/dockerfile/slem-flavored-os/Dockerfile
@@ -17,7 +17,8 @@ RUN zypper in --no-recommends -y systemd-presets-branding-SLE-Micro-for-Rancher 
 RUN if [[ "%%BUILD_FLAVOR%%" == "kvm-" ]]; then \
   # replace default kernel with smaller one, sufficient to run kvm guests \
   zypper in --no-recommends -y kernel-default-base -kernel-default; \
-elif [[ "%%BUILD_FLAVOR%%" == "rt-" ]]; then \
+elif [[ "%%BUILD_FLAVOR%%" == "rt-" ]] && [ $(uname -m) = "x86_64" ]; then \
+  #!ArchExclusiveLine x86_64
   zypper in --no-recommends -y kernel-rt -kernel-default; \ 
 else \
   # extend -base with baremetal and usability packages \

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -11,10 +11,10 @@ push_workflow:
         package: build-iso-base
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
-        package: SLE-Micro-Rancher
+        package: SLE-Micro
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
-        package: SLE-Micro-Rancher-base
+        package: SLE-Micro-base
   filters:
     branches:
       only:
@@ -34,10 +34,10 @@ tag_workflow:
         package: build-iso-base
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
-        package: SLE-Micro-Rancher
+        package: SLE-Micro
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
-        package: SLE-Micro-Rancher-base
+        package: SLE-Micro-base
   filters:
     event: tag_push
 
@@ -57,11 +57,11 @@ pr_workflow:
         target_project: isv:Rancher:Elemental:PR
     - branch_package:
         source_project: isv:Rancher:Elemental:Dev
-        source_package: SLE-Micro-Rancher
+        source_package: SLE-Micro
         target_project: isv:Rancher:Elemental:PR
     - branch_package:
         source_project: isv:Rancher:Elemental:Dev
-        source_package: SLE-Micro-Rancher-base
+        source_package: SLE-Micro-base
         target_project: isv:Rancher:Elemental:PR
   filters:
     event: pull_request


### PR DESCRIPTION
With this change rt versions of the image will referenced as an additional flavor:
 `suse/sle-micro/rt-5.5:<version>`
 
 This also allows us to drop the RT package in OBS as it will be just a flavor of SLE-Micro image.