### PR TITLE
ci/cli: fix tests with Rancher Manager 2.8-HEAD

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -317,7 +317,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 		// Deploy operator in CLI test or if Rancher version is < 2.8
 		// because operator can not be installed trough Marketplace in Rancher 2.7.x
 		matched, _ := regexp.MatchString(`2.8`, rancherHeadVersion)
-		if testType == "cli" || matched == false {
+		if strings.Contains(testType, "cli") || matched == false {
 			By("Installing Elemental Operator", func() {
 				for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
 					RunHelmCmdWithRetry("upgrade", "--install", chart,


### PR DESCRIPTION
Elemental operator should be installed with Helm on all CLI tests.

Verification runs:
- [CLI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7017932429)
- [CLI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7017937852)
- [UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7017953166)
- [UI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7017948694)