### PR TITLE
Adding missing manifest for the base-iso image

### DIFF
--- a/.obs/dockerfile/slem-base-iso/manifest.yaml
+++ b/.obs/dockerfile/slem-base-iso/manifest.yaml
@@ -1,0 +1,5 @@
+iso:
+  bootloader-in-rootfs: true
+  grub-entry-name: "SLE Micro for Rancher base Install"
+
+squash-no-compression: true


### PR DESCRIPTION
Realized this file was included directly in OBS. This allows to pull the file directly from SCM services and it alignes with the other `slem-iso` image.