### PR TITLE
ui/ci: replace sle-micro-rancher by sle-micro

### DIFF
--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -43,4 +43,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -43,4 +43,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -33,8 +33,7 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
-      operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -12,10 +12,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      operator_repo:
-        description: Elemental operator repository to use
-        default: oci://registry.suse.com/rancher
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -27,7 +23,7 @@ on:
       # Test OS upgrade with OS image in this test ("Use image from registry")
       upgrade_image:
         description: Upgrade image to use
-        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
         type: string
 
 jobs:
@@ -46,7 +42,6 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
-      operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -40,6 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -40,6 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -42,9 +42,8 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
-      operator_repo: oci://registry.suse.com/rancher
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -12,10 +12,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      operator_repo:
-        description: Elemental operator repository to use
-        default: oci://registry.suse.com/rancher
-        type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
@@ -47,7 +43,6 @@ jobs:
       elemental_ui_version: dev
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
-      operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -43,18 +43,21 @@ describe('Upgrade tests', () => {
   filterTests(['upgrade'], () => {
     // Add dev OS Version Channel if stable operator is installed
     // because we do not update the operator in UI test so far
-    if (utils.isOperatorVersion('registry.suse.com')) {
+    // Only RKE2 tests use os version channel
+    if (utils.isK8sVersion("rke2") && utils.isRancherManagerVersion('2.8')) {
       it('Add dev channel for RKE2 upgrade', () => {
         cy.addOsVersionChannel('dev');
       })
     }
 
-    qase(33,
-      it('Check OS Versions', () => {
-        cy.clickNavMenu(["Advanced", "OS Versions"]);
-        cy.contains(new RegExp('Active.*-iso-unstable'), {timeout: 120000})
-      })
-    );
+    if (utils.isK8sVersion("rke2")) {
+      qase(33,
+        it('Check OS Versions', () => {
+          cy.clickNavMenu(["Advanced", "OS Versions"]);
+          cy.contains(new RegExp('Active.*-iso-unstable'), {timeout: 120000})
+        })
+      );
+    };
 
     qase(34,
       it('Upgrade one node (different methods if rke2 or k3s)', () => {
@@ -125,7 +128,7 @@ describe('Upgrade tests', () => {
         cy.get('.primaryheader')
           .contains('Active', {timeout: 420000}).should('not.exist');
         cy.get('.primaryheader')
-          .contains('Active', {timeout: 540000});
+          .contains('Active', {timeout: 720000});
       })
     );
 


### PR DESCRIPTION
`sle-micro-rancher` does not exist anymore, `sle-micro` has to be used instead.

## Verification runs
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7033945638) ✅ 
[UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7033946920) ✅ 

[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7034169925) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7033950093/job/19140905800) ✅ 

[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7033951607) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7020909041) ❌
This test fails but it is not related to the PR, I don't know why but `cattle-cluster-agent` fails to start:
```
cattle-system         cattle-cluster-agent-dfd7c6d6-h6cv5                               0/1     CrashLoopBackOff   3 (38s ago)     10m
```
