### PR TITLE
ci: use new version of GCP template

### DIFF
--- a/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
@@ -26,6 +26,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi_cli
       zone: us-central1-b

--- a/.github/workflows/cli-k3s-scalability-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-scalability-rm_stable.yaml
@@ -26,4 +26,4 @@ jobs:
       k8s_version_to_provision: v1.26.10+k3s2
       node_number: 60
       rancher_version: stable/latest/none
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5

--- a/.github/workflows/cli-k3s-scalability-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-scalability-rm_stable.yaml
@@ -27,3 +27,4 @@ jobs:
       node_number: 60
       rancher_version: stable/latest/none
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
+      zone: us-central1-f

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -37,7 +37,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v4
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
         type: string
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -30,4 +30,4 @@ jobs:
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi_cli
       upstream_cluster_version: v1.26.10+rke2r2
-      zone: us-central1-f
+      zone: us-central1-b

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -27,7 +27,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
-      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-64-v4
+      runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi_cli
       upstream_cluster_version: v1.26.10+rke2r2
       zone: us-central1-f

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -107,7 +107,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v4
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
         type: string
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)
@@ -236,6 +236,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: tests/go.mod
+      - name: Define needed system variables
+        run: |
+          # Add missing PATH, removed in recent distributions for security reasons...
+          echo "/usr/local/bin" >> ${GITHUB_PATH}
       - name: Deploy Proxy
         if: ${{ inputs.proxy == 'elemental' || inputs.proxy == 'rancher' }}
         run: docker run -d --name squid_proxy -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -156,9 +156,12 @@ jobs:
       - name: Generate UUID and Runner hostname
         id: generator
         run: |
+          # NOTE: keep the runner name to less than 63 characters!
           UUID=$(uuidgen)
-          echo "uuid=${UUID}" >> ${GITHUB_OUTPUT}
-          echo "runner=elemental-ci-${UUID}" >> ${GITHUB_OUTPUT}
+          GH_REPO_FULL=${{ github.repository }}
+          GH_REPO=${GH_REPO_FULL#*/}
+          echo "uuid=${UUID//-}" >> ${GITHUB_OUTPUT}
+          echo "runner=${GH_REPO//\//-}-ci-${UUID//-}" >> ${GITHUB_OUTPUT}
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1
         with:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -690,9 +690,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  delete-runner:
-    if: ${{ always() && needs.create-runner.result == 'success' && inputs.destroy_runner == true }}
-    needs: [create-runner, e2e]
+  clean-runner:
+    if: ${{ always() }}
+    needs: e2e
     runs-on: ubuntu-latest
     steps:
       # actions/checkout MUST come before auth
@@ -704,9 +704,24 @@ jobs:
           credentials_json: ${{ secrets.credentials }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v1
-      - name: Delete PAT token secret
+      - name: Delete GCP secrets
         run: |
-          gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }}
+          gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }} || true
+          gcloud --quiet secrets delete GH_REPO_${{ needs.create-runner.outputs.uuid }} || true
+  delete-runner:
+    if: ${{ always() && needs.create-runner.result == 'success' && inputs.destroy_runner == true }}
+    needs: [create-runner, clean-runner]
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout MUST come before auth
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.credentials }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
       - name: Delete runner
         run: |
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -33,7 +33,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v4
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
         type: string
 
 jobs:

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -5,6 +5,9 @@
 
 set -e -x
 
+# Add missing PATH, removed in recent distributions for security reasons...
+PATH+=:/usr/local/bin
+
 # Create a systemctl file for chartmuseum
 cat > /etc/systemd/system/chartmuseum.service << EOF
 [Unit]


### PR DESCRIPTION
**NOTE:** do not merge before creating the new templates!

- Use new version of GCP template
- Delete `GH_REPO_*` secrets as the end
- Use the new GCP templates for GH runner
- Spread jobs in differents GCP zones

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7289730965) :white_check_mark:
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7289736097) :white_check_mark:
- [CLI-K3s-Scalability-RM_Stable](https://github.com/rancher/elemental/actions/runs/7288750695) :white_check_mark:
- [CLI-K3s-Scalability-RM_Stable - 2nd](https://github.com/rancher/elemental/actions/runs/7299354778) :white_check_mark:
- [CLI-K3s-Multi_Cluster-RM_Stable](https://github.com/rancher/elemental/actions/runs/7297945877) :white_check_mark:
- [CLI-RKE2-Multi_Cluster-RM_Stable](https://github.com/rancher/elemental/actions/runs/7297947267) :white_check_mark:
- [UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7290598112) :white_check_mark:
- [UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7290599657) :white_check_mark:

**NOTE:** Multi-cluster test fails for another reason not related to this PR.