### PR TITLE
ci/cli: fix upgrade tests

### DIFF
--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -31,5 +31,5 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.7
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -29,6 +29,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      rancher_upgrade: latest/devel/2.8
       rancher_version: latest/devel/2.7
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -31,5 +31,5 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.8
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -32,5 +32,5 @@ jobs:
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -29,7 +29,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel
+      rancher_upgrade: latest/devel/2.7
       rancher_version: stable/latest/none
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
@@ -27,6 +27,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      rancher_upgrade: latest/devel/2.8
       rancher_version: latest/devel/2.7
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.7.yaml
@@ -28,5 +28,5 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.7
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_head_2.8.yaml
@@ -28,5 +28,5 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.8
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -27,7 +27,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel
+      rancher_upgrade: latest/devel/2.7
       rancher_version: stable/latest/none
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -29,5 +29,5 @@ jobs:
       os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -56,4 +56,4 @@ jobs:
       os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro-rancher/${{ inputs.slem_version }}:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro/${{ inputs.slem_version }}:latest

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -18,6 +18,7 @@ on:
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
+        default: latest/devel/2.7
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -31,6 +31,6 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.7
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.7.yaml
@@ -29,6 +29,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      rancher_upgrade: latest/devel/2.8
       rancher_version: latest/devel/2.7
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_head_2.8.yaml
@@ -31,6 +31,6 @@ jobs:
       os_to_test: stable
       rancher_version: latest/devel/2.8
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -29,7 +29,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel
+      rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       reset: true
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -32,6 +32,6 @@ jobs:
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
       reset: true
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
@@ -30,6 +30,6 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.7
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.7.yaml
@@ -29,6 +29,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      rancher_upgrade: latest/devel/2.8
       rancher_version: latest/devel/2.7
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_head_2.8.yaml
@@ -30,6 +30,6 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       rancher_version: latest/devel/2.8
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -28,7 +28,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel
+      rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -30,6 +30,6 @@ jobs:
       os_to_test: stable
       rancher_upgrade: latest/devel
       rancher_version: stable/latest/none
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro-rancher/5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
       upgrade_os_channel: dev
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -57,5 +57,5 @@ jobs:
       os_to_test: stable
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro-rancher/${{ inputs.slem_version }}:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro/${{ inputs.slem_version }}:latest
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -18,6 +18,7 @@ on:
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
+        default: latest/devel/2.8
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -55,45 +55,46 @@ const (
 )
 
 var (
-	arch                  string
-	backupRestoreVersion  string
-	caType                string
-	CertManagerVersion    string
-	clusterName           string
-	clusterNS             string
-	clusterType           string
-	clusterYaml           string
-	elementalSupport      string
-	emulateTPM            bool
-	rancherHostname       string
-	isoBoot               bool
-	k8sUpstreamVersion    string
-	k8sVersion            string
-	numberOfClusters      int
-	numberOfVMs           int
-	operatorUpgrade       string
-	operatorRepo          string
-	os2Test               string
-	poolType              string
-	proxy                 string
-	rancherChannel        string
-	rancherHeadVersion    string
-	rancherLogCollector   string
-	rancherVersion        string
-	rancherUpgrade        string
-	rancherUpgradeChannel string
-	rancherUpgradeVersion string
-	registrationYaml      string
-	seedImageYaml         string
-	selectorYaml          string
-	sequential            bool
-	testType              string
-	upgradeImage          string
-	upgradeOSChannel      string
-	upgradeType           string
-	usedNodes             int
-	vmIndex               int
-	vmName                string
+	arch                      string
+	backupRestoreVersion      string
+	caType                    string
+	CertManagerVersion        string
+	clusterName               string
+	clusterNS                 string
+	clusterType               string
+	clusterYaml               string
+	elementalSupport          string
+	emulateTPM                bool
+	rancherHostname           string
+	isoBoot                   bool
+	k8sUpstreamVersion        string
+	k8sVersion                string
+	numberOfClusters          int
+	numberOfVMs               int
+	operatorUpgrade           string
+	operatorRepo              string
+	os2Test                   string
+	poolType                  string
+	proxy                     string
+	rancherChannel            string
+	rancherHeadVersion        string
+	rancherLogCollector       string
+	rancherVersion            string
+	rancherUpgrade            string
+	rancherUpgradeChannel     string
+	rancherUpgradeHeadVersion string
+	rancherUpgradeVersion     string
+	registrationYaml          string
+	seedImageYaml             string
+	selectorYaml              string
+	sequential                bool
+	testType                  string
+	upgradeImage              string
+	upgradeOSChannel          string
+	upgradeType               string
+	usedNodes                 int
+	vmIndex                   int
+	vmName                    string
 )
 
 /**
@@ -475,6 +476,7 @@ var _ = BeforeSuite(func() {
 		s := strings.Split(rancherUpgrade, "/")
 		rancherUpgradeChannel = s[0]
 		rancherUpgradeVersion = s[1]
+		rancherUpgradeHeadVersion = s[2]
 	}
 
 	// Enable multi-cluster support if needed

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -94,7 +94,13 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 		Expect(err).To(Not(HaveOccurred()))
 
 		// Upgrade Rancher Manager
-		err = rancher.DeployRancherManager(rancherHostname, rancherUpgradeChannel, rancherUpgradeVersion, rancherHeadVersion, caType, proxy)
+		err = rancher.DeployRancherManager(
+			rancherHostname,
+			rancherUpgradeChannel,
+			rancherUpgradeVersion,
+			rancherUpgradeHeadVersion,
+			caType, proxy,
+		)
 		Expect(err).To(Not(HaveOccurred()))
 
 		// Wait for Rancher Manager to be restarted


### PR DESCRIPTION
`sle-micro` should now be used instead of `sle-micro-rancher`. Also set the correct version of Rancher Manager for the upgrade step.

Verification runs:
- [CLI-K3s-Hardened-Upgrade-Reset-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7085645959) :white_check_mark:
- [CLI-RKE2-Hardened-Upgrade-Reset-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7085650373) :white_check_mark:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7088854870) :white_check_mark:
- [CLI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7088360292) :white_check_mark:
- [CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7088838627) :hourglass_flowing_sand:
- [CLI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7088847019) :hourglass_flowing_sand:

**NOTE:**
- `CLI-RKE2-OS-Upgrade-RM_head_2.7` is failing for a sporadic issue not related to this PR/
- `CLI-RKE2-OS-Upgrade-RM_Stable` seems to fail because of an issue while synchronizing `ManagedOSVersionChannel`, this will be investigated/fix in a separate issue/PR if it happens in CI/