### PR TITLE
ci/cli: add RunSSHWithRetry function

### DIFF
--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -125,8 +125,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 						CheckSSH(cl)
 
 						// Check that the cloud-config is correctly applied by checking the presence of a file
-						_, err := cl.RunSSH("ls /etc/elemental-test")
-						Expect(err).To(Not(HaveOccurred()))
+						_ = RunSSHWithRetry(cl, "ls /etc/elemental-test")
 
 						// Check that the installation is completed before halting the VM
 						Eventually(func() error {
@@ -136,8 +135,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 						}, tools.SetTimeout(8*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))
 
 						// Halt the VM
-						_, err = cl.RunSSH("setsid -f init 0")
-						Expect(err).To(Not(HaveOccurred()))
+						_ = RunSSHWithRetry(cl, "setsid -f init 0")
 					})
 				}(hostName, client)
 			}
@@ -244,15 +242,11 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					if t == true {
 						testValue = "! -e"
 					}
-					Eventually(func() error {
-						_, err := cl.RunSSH("[[ " + testValue + " /dev/tpm0 ]]")
-						return err
-					}, tools.SetTimeout(1*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
+					_ = RunSSHWithRetry(cl, "[[ "+testValue+" /dev/tpm0 ]]")
 				})
 
 				By("Checking OS version on "+h, func() {
-					out, err := cl.RunSSH("cat /etc/os-release")
-					Expect(err).To(Not(HaveOccurred()))
+					out := RunSSHWithRetry(cl, "cat /etc/os-release")
 					GinkgoWriter.Printf("OS Version on %s:\n%s\n", h, out)
 				})
 			}(clusterNS, hostName, index, emulateTPM, client)
@@ -287,14 +281,10 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 							// Wait a little to be sure that RKE2 installation has started
 							// Otherwise the directory is not available!
-							Eventually(func() error {
-								_, err := cl.RunSSH("[[ -d " + dir + " ]]")
-								return err
-							}, tools.SetTimeout(3*time.Minute), 5*time.Second).Should(Not(HaveOccurred()))
+							_ = RunSSHWithRetry(cl, "[[ -d "+dir+" ]]")
 
 							// Configure kubectl
-							_, err := cl.RunSSH("I=" + dir + "/kubectl; if [[ -x ${I} ]]; then ln -s ${I} bin/; echo " + kubeCfg + " >> .bashrc; fi")
-							Expect(err).To(Not(HaveOccurred()))
+							_ = RunSSHWithRetry(cl, "I="+dir+"/kubectl; if [[ -x ${I} ]]; then ln -s ${I} bin/; echo "+kubeCfg+" >> .bashrc; fi")
 						})
 					}
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -206,7 +206,7 @@ func WaitCluster(ns, cn string) {
 
 								// Restart rancher-system-agent service on the node
 								// NOTE: wait a little to be sure that all is restarted before continuing
-								cl.RunSSH("systemctl restart rancher-system-agent.service")
+								RunSSHWithRetry(cl, "systemctl restart rancher-system-agent.service")
 								time.Sleep(tools.SetTimeout(15 * time.Second))
 							}
 						}
@@ -369,6 +369,24 @@ func RunHelmCmdWithRetry(s ...string) {
 	Eventually(func() error {
 		return kubectl.RunHelmBinaryWithCustomErr(s...)
 	}, tools.SetTimeout(2*time.Minute), 20*time.Second).Should(Not(HaveOccurred()))
+}
+
+/**
+ * Execute SSH command with retry
+ * @param cl Client (node) informations
+ * @param cmd Command to execute
+ * @returns result of the executed command
+ */
+func RunSSHWithRetry(cl *tools.Client, cmd string) string {
+	var err error
+	var out string
+
+	Eventually(func() error {
+		out, err = cl.RunSSH(cmd)
+		return err
+	}, tools.SetTimeout(2*time.Minute), 20*time.Second).Should(Not(HaveOccurred()))
+
+	return out
 }
 
 func FailWithReport(message string, callerSkip ...int) {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -169,8 +169,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				defer GinkgoRecover()
 
 				By("Checking OS version on "+h+" before upgrade", func() {
-					out, err := client.RunSSH("cat /etc/os-release")
-					Expect(err).To(Not(HaveOccurred()))
+					out := RunSSHWithRetry(cl, "cat /etc/os-release")
 					GinkgoWriter.Printf("OS Version on %s:\n%s\n", h, out)
 				})
 			}(hostName, client)
@@ -260,8 +259,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				Expect(client).To(Not(BeNil()))
 
 				// Get *REAL* hostname
-				hostname, err := client.RunSSH("hostname")
-				Expect(err).To(Not(HaveOccurred()))
+				hostname := RunSSHWithRetry(client, "hostname")
 				hostname = strings.Trim(hostname, "\n")
 
 				label := "kubernetes.io/hostname"
@@ -308,7 +306,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				By("Checking VM upgrade on "+h, func() {
 					Eventually(func() string {
 						// Use grep here in case of comment in the file!
-						out, _ := client.RunSSH("eval $(grep -v ^# /etc/os-release) && echo ${IMAGE}")
+						out, _ := cl.RunSSH("eval $(grep -v ^# /etc/os-release) && echo ${IMAGE}")
 
 						// This remove the version and keep only the repo, as in the file
 						// we have the exact version and we don't know it before the upgrade
@@ -317,8 +315,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				})
 
 				By("Checking OS version on "+h+" after upgrade", func() {
-					out, err := client.RunSSH("cat /etc/os-release")
-					Expect(err).To(Not(HaveOccurred()))
+					out := RunSSHWithRetry(cl, "cat /etc/os-release")
 					GinkgoWriter.Printf("OS Version on %s:\n%s\n", h, out)
 				})
 			}(hostName, client)

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -216,7 +216,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 						value, _ := exec.Command(getOSScript, upgradeOSChannel).Output()
 
 						return string(value)
-					}, tools.SetTimeout(1*time.Minute), 15*time.Second).Should(Not(BeEmpty()))
+					}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(Not(BeEmpty()))
 
 					// We should now have an OS version!
 					OSVersion, err = exec.Command(getOSScript, upgradeOSChannel).Output()


### PR DESCRIPTION
This allows to run SSH command with automatic retry more easily. This PR also increase the timeout of `ManagedOSVersionChannel` sync to avoid/reduce sporadic failures.

Verification runs:
- [CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7102002337) :white_check_mark:
- [CLI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7102007517) :white_check_mark:
- [CLI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7103833470) :white_check_mark: