### PR TITLE
ci/ui: update html selector for Cypress

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -79,7 +79,7 @@ describe('Upgrade tests', () => {
         cy.contains('Target Cluster')
         cy.getBySel('cluster-target')
           .click();
-        cy.get('#vs5__listbox')
+        cy.get('#vs7__listbox')
           .contains(clusterName)
           .click();
         if (utils.isK8sVersion("k3s")) {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -104,7 +104,11 @@ Cypress.Commands.add('createMachReg', (
     // Build the ISO according to the elemental operator version
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
-    cy.getBySel('select-os-version-build-iso')
+    cy.getBySel('select-media-type-build-media')
+      .click();
+    cy.contains('Iso')
+      .click();
+    cy.getBySel('select-os-version-build-media')
       .click();
     // Never build from dev ISO in upgrade scenario
     if (utils.isCypressTag('upgrade')) {
@@ -124,19 +128,19 @@ Cypress.Commands.add('createMachReg', (
       cy.contains('ISO x86_64 (unstable)')
         .click();
     }
-    cy.getBySel('build-iso-btn')
+    cy.getBySel('build-media-btn')
       .click();
-    cy.getBySel('build-iso-btn')
+    cy.getBySel('build-media-btn')
       .get('.icon-spin');
     // Download button is disabled while ISO is building
-    cy.getBySel('download-iso-btn').should(($input) => {
+    cy.getBySel('download-media-btn').should(($input) => {
       expect($input).to.have.attr('disabled')
     })
     // Download button is enabled once ISO building done
-    cy.getBySel('download-iso-btn', { timeout: 600000 }).should(($input) => {
+    cy.getBySel('download-media-btn', { timeout: 600000 }).should(($input) => {
       expect($input).to.not.have.attr('disabled')
     })
-    cy.getBySel('download-iso-btn')
+    cy.getBySel('download-media-btn')
       .click()
     cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
   }


### PR DESCRIPTION
This PR fixes new HTML selector introduced by https://github.com/rancher/elemental-ui/pull/152

## Verification runs
[UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7121574934) ✅ 
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7125372090) ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7129110473) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7129116315) 🕐 