### PR TITLE
ci/cli: fix RKE2 multi-cluster

### DIFF
--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       test_description: "CI/Manual - CLI - MultiCluster - Deployment test with Standard RKE2"
       ca_type: private
       cluster_name: cluster-rke2
-      cluster_number: 20
+      cluster_number: 10
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2


### PR DESCRIPTION
As RKE2 nodes now use 10GB of RAM each, it's needed to reduce the number of deployed cluster from 20 to 10 to avoid memory constraint.

Verification run:
- [CLI-RKE2-Multi_Cluster-RM_Stable](https://github.com/rancher/elemental/actions/runs/7128272835) :white_check_mark: