### PR TITLE
ci/cli: fix OBS Staging tests

### DIFF
--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -40,5 +40,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
-      os_to_test: staging
+      os_to_test: unstable
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -14,7 +14,7 @@ on:
         type: boolean
       operator_repo:
         description: Operator version to use for initial deployment
-        default: oci://registry.opensuse.org/rancher
+        default: oci://registry.suse.com/rancher
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
@@ -58,3 +58,4 @@ jobs:
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro/${{ inputs.slem_version }}:latest
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -41,6 +41,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
-      os_to_test: staging
+      os_to_test: unstable
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -14,7 +14,7 @@ on:
         type: boolean
       operator_repo:
         description: Operator version to use for initial deployment
-        default: oci://registry.opensuse.org/rancher
+        default: oci://registry.suse.com/rancher
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
@@ -59,4 +59,5 @@ jobs:
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro/${{ inputs.slem_version }}:latest
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: v1.26.10+rke2r2


### PR DESCRIPTION
`Staging` is a mix between `Dev` and `Stable` so it needs some specifics configuration to work.

Verification run:
- [CLI-K3s-OBS_Staging](https://github.com/rancher/elemental/actions/runs/7169104514) :white_check_mark:
- [CLI-K3s-OBS_Staging (hardened)](https://github.com/rancher/elemental/actions/runs/7171033111) :white_check_mark:
- [CLI-RKE2-OBS_Staging](https://github.com/rancher/elemental/actions/runs/7169419838) :white_check_mark:
- [CLI-RKE2-OBS_Staging (hardened](https://github.com/rancher/elemental/actions/runs/7170729300) :white_check_mark:
- [CLI-K3s-OS-Upgrade (with upgrade to Rancher Manager 2.7-HEAD)](https://github.com/rancher/elemental/actions/runs/7169090069) :negative_squared_cross_mark: Fails because of [#577](https://github.com/rancher/elemental-operator/issues/577)
- [CLI-RKE2-OS-Upgrade (with upgrade to Rancher Manager 2.8-HEAD)](https://github.com/rancher/elemental/actions/runs/7169612255) :negative_squared_cross_mark: Fails because of [#577](https://github.com/rancher/elemental-operator/issues/577)