### PR TITLE
Add default network configuration for eth0

### DIFF
--- a/framework/files/system/oem/05_network.yaml
+++ b/framework/files/system/oem/05_network.yaml
@@ -1,0 +1,12 @@
+name: "Default network configuration"
+stages:
+   initramfs:
+     - name: "Setup network"
+       files:
+       - path: /etc/sysconfig/network/ifcfg-eth0
+         content: |
+                  BOOTPROTO='dhcp'
+                  STARTMODE='onboot'
+         permissions: 0600
+         owner: 0
+         group: 0


### PR DESCRIPTION
This adds network the configuration file that got removed from the `cloud-config-essentials` feature in elemental-toolkit in rancher/elemental-toolkit@1a1b942acdc05d5351d89a38610c44016d1af38b