### PR TITLE
ci/cli: fix upgrade to Staging tests

### DIFF
--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -40,5 +40,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
-      os_to_test: unstable
+      os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -41,6 +41,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
-      os_to_test: unstable
+      os_to_test: staging
       rancher_version: ${{ inputs.rancher_version }}
       upstream_cluster_version: v1.26.10+rke2r2

--- a/tests/scripts/get-name-from-managedosversion
+++ b/tests/scripts/get-name-from-managedosversion
@@ -12,7 +12,7 @@ GREP_OPTS="-v"
 
 # Define if we check for stable or unstable OS
 case ${KIND_OF_OS} in
-  dev|unstable)
+  dev|staging)
     unset INVERTED
     ;;
 esac


### PR DESCRIPTION
Finally it's easier and more coherent to search for `unstable` in Dev and Staging and keep `staging` as a value for `os_to_test`.

Verification runs:
- [CLI-K3s-OBS_Staging](https://github.com/rancher/elemental/actions/runs/7182436353) :white_check_mark:
- [CLI-K3s-OBS_Staging (hardened)](https://github.com/rancher/elemental/actions/runs/7183083255) :white_check_mark:
- [CLI-RKE2-OBS_Staging](https://github.com/rancher/elemental/actions/runs/7182448025) :white_check_mark:
- [CLI-RKE2-OBS_Staging](https://github.com/rancher/elemental/actions/runs/7183057715) :white_check_mark:
- [CLI-K3s-OS-Upgrade (with upgrade to Rancher Manager 2.7-HEAD)](https://github.com/rancher/elemental/actions/runs/7182430019) :white_check_mark:
- [CLI-RKE2-OS-Upgrade (with upgrade to Rancher Manager 2.8-HEAD)](https://github.com/rancher/elemental/actions/runs/7182727348) :white_check_mark: