### PR TITLE
ci/ui: automate ui-extension upgrade

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -362,6 +362,7 @@ jobs:
             /workdir/e2e/unit_tests/machine_inventory.spec.ts
             /workdir/e2e/unit_tests/reset.spec.ts
             /workdir/e2e/unit_tests/deploy_app.spec.ts
+            /workdir/e2e/unit_tests/upgrade-ui-extension.spec.ts
             /workdir/e2e/unit_tests/upgrade.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -37,7 +37,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -37,7 +37,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -30,7 +30,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -39,7 +39,7 @@ jobs:
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -31,10 +31,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      # Using user account has to be disable due to this bug
-      # https://github.com/rancher/elemental-ui/issues/64
-      # Fixed in elemental-ui 1.1.0
-      #ui_account: user
+      ui_account: user
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: upgrade

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
@@ -1,0 +1,88 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Elemental } from '~/support/elemental';
+import '~/support/commands';
+import 'cypress-file-upload';
+import filterTests from '~/support/filterTests.js';
+import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+import * as utils from "~/support/utils";
+
+
+Cypress.config();
+describe('UI extension upgrade tests', () => {
+  const elemental     = new Elemental();
+
+  beforeEach(() => {
+    // Elemental-user can not be used here because it does not have access to the local cluster
+    cy.login();
+    cy.visit('/');
+
+    // Open the navigation menu 
+    cypressLib.burgerMenuToggle();
+  });
+
+  filterTests(['upgrade'], () => {
+    // Enable only with K3S because still too much flaky with RKE2
+    if (utils.isK8sVersion('k3s')) {
+      it('Add elemental-ui dev repo', () => {
+        cypressLib.addRepository('elemental-ui', 'https://github.com/rancher/elemental-ui.git', 'git', 'gh-pages');
+      });
+
+      qase(888,
+        it('Upgrade Elemental UI extension', () => {
+          cy.contains('Extensions')
+            .click();
+          cy.getBySel('btn-available')
+            .click();
+          cy.getBySel('extension-card-elemental')
+            .contains('elemental')
+          cy.getBySel('extension-card-install-btn-elemental')
+            .click();
+          cy.getBySel('install-ext-modal-install-btn')
+            .click();
+          cy.contains('Extensions changed - reload required', {timeout: 100000});
+          cy.clickButton('Reload');
+          cy.reload();
+          cy.getBySel('extension-card-uninstall-btn-elemental')
+        })
+      );
+      qase(888,
+        it('Check Elemental UI after upgrade', () => {
+          cy.viewport(1920, 1080);
+          // Elemental's icon should appear in the side menu
+          cypressLib.checkNavIcon('elemental')
+            .should('exist');
+
+          // Click on the Elemental's icon
+          cypressLib.accesMenu('OS Management');
+
+          // Check Elemental's side menu
+          elemental.checkElementalNav();
+
+          // Check Elemental's main page
+          // TODO: Could be improve to check everything
+          cy.get('[data-testid="card-registration-endpoints"]')
+            .contains('1');
+          cy.get('[data-testid="card-inventory-of-machines"]')
+            .contains('1');
+          cy.get('[data-testid="card-clusters"]')
+            .contains('1');
+          cy.get('[data-testid="machine-reg-block"]')
+            .contains('machine-registration');
+        })
+      );
+    };
+  });
+});

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -67,6 +67,7 @@ Cypress.Commands.add('createMachReg', (
   checkIsoBuilding=false,
   customCloudConfig='',
   checkDefaultCloudConfig=true ) => {
+  let selector
   cy.clickNavMenu(["Dashboard"]);
   cy.getBySel('button-create-registration-endpoint')
     .click();
@@ -104,12 +105,17 @@ Cypress.Commands.add('createMachReg', (
     // Build the ISO according to the elemental operator version
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
-    cy.getBySel('select-media-type-build-media')
-      .click();
-    cy.contains('Iso')
-      .click();
-    cy.getBySel('select-os-version-build-media')
-      .click();
+    if (utils.isUIVersion('stable')) {
+      cy.getBySel('select-os-version-build-iso')
+        .click();
+    } else {
+      cy.getBySel('select-media-type-build-media')
+        .click();
+      cy.contains('Iso')
+        .click();
+      cy.getBySel('select-os-version-build-media')
+        .click();
+    }
     // Never build from dev ISO in upgrade scenario
     if (utils.isCypressTag('upgrade')) {
       // Stable operator version is hardcoded for now
@@ -128,19 +134,20 @@ Cypress.Commands.add('createMachReg', (
       cy.contains('ISO x86_64 (unstable)')
         .click();
     }
-    cy.getBySel('build-media-btn')
+    utils.isUIVersion('stable') ? selector="iso" : selector="media";
+    cy.getBySel(`build-${selector}-btn`)
       .click();
-    cy.getBySel('build-media-btn')
+    cy.getBySel(`build-${selector}-btn`)
       .get('.icon-spin');
     // Download button is disabled while ISO is building
-    cy.getBySel('download-media-btn').should(($input) => {
+    cy.getBySel(`download-${selector}-btn`).should(($input) => {
       expect($input).to.have.attr('disabled')
     })
     // Download button is enabled once ISO building done
-    cy.getBySel('download-media-btn', { timeout: 600000 }).should(($input) => {
+    cy.getBySel(`download-${selector}-btn`, { timeout: 600000 }).should(($input) => {
       expect($input).to.not.have.attr('disabled')
     })
-    cy.getBySel('download-media-btn')
+    cy.getBySel(`download-${selector}-btn`)
       .click()
     cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
   }


### PR DESCRIPTION
Address partially #1094 by adding an upgrade test of the Elemental UI Extension.

After a lot of debugging, I add extension upgrade in K3S tests only, I tried with RKE2 but it added flakiness.

## Verification runs
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7258825756/job/19774823509) ✅  - Failed in `Store logs` because I disabled proxy for the test
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7258944266/job/19775176274) ✅ - Failed in `Store logs` because I disabled proxy for the test
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7258828152/job/19774822889) ✅  - Failed in `Store logs` because I disabled proxy for the test
[UI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7246097759/job/19737394011) ✅ 
[UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7245897864/job/19736818800) ✅ 
