### PR TITLE
ci: add device-selector test

### DIFF
--- a/tests/assets/machineRegistration.yaml
+++ b/tests/assets/machineRegistration.yaml
@@ -33,6 +33,20 @@ spec:
       install:
         reboot: false
         poweroff: true
-        device: /dev/sda
+        device-selector:
+        - key: Name
+          operator: In
+          values:
+          - /dev/sda
+          - /dev/vda
+          - /dev/nvme0
+        - key: Size
+          operator: Lt
+          values:
+          - 35Gi
+        - key: Size
+          operator: Gt
+          values:
+          - 25Gi
         debug: true
   machineName: %VM_NAME%-${System Information/UUID}

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -3,12 +3,13 @@
 set -e -x
 
 # Variable(s) and default values
-VM_NAME=$1
-MAC=$2
 ARCH=$(uname -m)
+EMULATED_TPM="none"
 FW_CODE=/usr/share/qemu/ovmf-${ARCH}-smm-suse-code.bin
 FW_VARS=$(realpath ../assets/ovmf-template-vars.fd)
-EMULATED_TPM="none"
+HDD_SIZE=30
+MAC=$2
+VM_NAME=$1
 
 # Configure hugepages if needed
 NR_HUGEPAGES=$(</proc/sys/vm/nr_hugepages)
@@ -89,7 +90,7 @@ CMD="sudo virt-install \
        --features smm.state=yes \
        --vcpus ${VM_CPU:-4} \
        --cpu host \
-       --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=35 \
+       --disk path=${VM_NAME}/${VM_NAME}.img,bus=scsi,size=${HDD_SIZE} \
        --check disk_size=off \
        --graphics none \
        --serial pty \


### PR DESCRIPTION
Add a test for the new `device-selector` field.
Note that the former `device` field is still supported and tested in the mutli-cluster test.

This PR will fix #1122.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7211662843)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7211680483)