### PR TITLE
Revert to 'old' RPi firmware

### DIFF
--- a/.obs/dockerfile/slem-base-os/Dockerfile
+++ b/.obs/dockerfile/slem-base-os/Dockerfile
@@ -28,8 +28,8 @@ RUN zypper --installroot /osimage in --no-recommends -y squashfs NetworkManager 
 
 # make ARM happy
 #!ArchExclusiveLine: aarch64
-RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y raspberrypi-firmware-uefi grub2-arm64-efi; fi
-                
+RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y grub2-arm64-efi raspberrypi-firmware raspberrypi-firmware-config raspberrypi-firmware-dt u-boot-rpiarm64; fi
+
 # make SUSE happy
 RUN zypper --installroot /osimage in --no-recommends -y SLE-Micro-Rancher-release systemd-presets-branding-SLE-Micro-for-Rancher
 


### PR DESCRIPTION
ARM's 'system ready' firmware is not ready for prime time yet:

It also only supports ACPI at this time, but not device tree.