### PR TITLE
Don't set the hostname

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -5,8 +5,7 @@ stages:
       commands:
       - |
         if [ ! -e /run/elemental/persistent/etc/hostname ]; then
-          mkdir -p /run/elemental/persistent/etc
-          echo rancher-${RANDOM} > /run/elemental/persistent/etc/hostname
+          sysctl kernel.hostname=rancher-${RANDOM}
         fi
         ln -sf /run/elemental/persistent/etc/hostname /etc/hostname
     - if: '[ ! -f "/run/elemental/recovery_mode" ]'


### PR DESCRIPTION
If the (static) hostname is not set, we used to set a rancher-${RANDOM} one. This anyway prevents DHCP to serve a transient hostname. In Elemental, at registration time, the hostname is recorded as the MachineInventory name and from that point onwards it could not be changed. It will be enforced as the static hostname during the k3s/RKE2 provisioning.
Since we do registration just after the ISO boot, in order to use the DHCP provided hostname, we should allow the transient name to be set by the dhcp client (which happens only if the static hostname is not set) and then take advantage of the new templating value: ${System Data/Runtime/Hostname}
(see https://github.com/rancher/elemental-operator/pull/593)

Let's anyway set the racher-${RANDOM} hostname but as a transient one  and before the network stage (so it may be replaced by the DHCP provided one).

This is a change in behavior: on Elemental booting (before provisioning) if a hostname has not been set and DHCP provides one, the DHCP hostname takes precedence over the rancher-${RANDOM} one.

Fixes #1172 