### PR TITLE
Update rootfs settings

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -34,12 +34,13 @@ stages:
           /etc/systemd
           /etc/rancher
           /etc/ssh
-          /etc/iscsi 
+          /etc/iscsi
           /etc/cni
           /home
           /opt
           /root
           /usr/libexec
+          /usr/local
           /var/log
           /var/lib/elemental
           /var/lib/rancher


### PR DESCRIPTION
Moving persistent mount to /run/elemental/persistent makes /usr/local readonly. This commit makes /usr/local a writeable persistent mount.