### PR TITLE
ci/ui: use auto qase run id mode

### DIFF
--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -35,7 +36,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS Deployment test with Standard K3s"
-      qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
@@ -44,5 +44,6 @@ jobs:
       k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -31,7 +32,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
-      qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
@@ -40,5 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -31,7 +32,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard K3s"
-      qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       cypress_tags: main
       destroy_runner: ${{ inputs.destroy_runner }}
@@ -40,5 +40,6 @@ jobs:
       k8s_version_to_provision: v1.26.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -35,7 +36,6 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      qase_run_id: ${{ inputs.qase_run_id }}
       cluster_name: cluster-k3s
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
@@ -43,6 +43,7 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.26.10+k3s2
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       upgrade_image: ${{ inputs.upgrade_image }}

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -31,8 +32,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS Deployment test with Standard RKE2"
-      ui_account: user
-      qase_run_id: ${{ inputs.qase_run_id }}
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
@@ -41,6 +40,8 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      ui_account: user
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -27,8 +28,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
-      ui_account: user
-      qase_run_id: ${{ inputs.qase_run_id }}
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
@@ -37,6 +36,8 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      ui_account: user
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -27,8 +28,6 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       test_description: "Manual - Fully customizable - UI - IBS/OBS Deployment test with Standard RKE2"
-      ui_account: user
-      qase_run_id: ${{ inputs.qase_run_id }}
       ca_type: private
       cluster_name: cluster-rke2
       cypress_tags: main
@@ -37,6 +36,8 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      ui_account: user
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -6,6 +6,7 @@ on:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         required: false
         type: string
       destroy_runner:
@@ -35,8 +36,6 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
-      qase_run_id: ${{ inputs.qase_run_id }}
-      ui_account: user
       cluster_name: cluster-rke2
       cypress_tags: upgrade
       destroy_runner: ${{ inputs.destroy_runner }}
@@ -44,7 +43,9 @@ jobs:
       iso_boot: true
       k8s_version_to_provision: v1.26.10+rke2r2
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
+      ui_account: user
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: v1.26.10+rke2r2


### PR DESCRIPTION
Set QASE_RUN_ID to auto to use the same RUN_ID in every steps.

## Verification run
[QASE result](https://app.qase.io/run/ELEMENTAL/dashboard/312)
[UI-K3S-OBS-DEV](https://github.com/rancher/elemental/actions/runs/7665985174/job/20892934155)