### PR TITLE
ci: fix delete-runner

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -796,12 +796,13 @@ jobs:
       - name: Delete runner
         if: ${{ needs.create-runner.result == 'success' && inputs.destroy_runner == true }}
         run: |
-          LOGS=$(gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
-                   --delete-disks all \
-                   --zone ${{ inputs.zone }} 2>&1)
+          # Disable failure on first error, needed for the "delete" check
+          set +e
           # If runner is already deleted we can bypass the error
           # NOTE: seems to still return an error if the VM is already deleted... To fix!
-          if (( $? )); then
+          if ! LOGS=$(gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
+                             --delete-disks all \
+                             --zone ${{ inputs.zone }} 2>&1); then
             echo "${LOGS}" | grep -q "resource .* was not found" && true || false
           fi
       - name: Delete Qase Run if job has been cancelled


### PR DESCRIPTION
If we want to check in case of failure during deletion we have to disable the "exit on 1st error" option of the shell.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7693254205) with  job cancelled in GH, so the runner was deleted by GCP
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/7693334686) with runner killed in GCP, so GH detected it and set the steps in `cancelled` state

In both cases the `delete-runner` step should exit in a "green" state, as the runner is deleted as expected, so no error to report.