### PR TITLE
ci/ui: Rancher stable is now bumped to 2.8.1

### DIFF
--- a/.github/workflows/ui-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.9.yaml
@@ -21,9 +21,6 @@ on:
 
 jobs:
   ui:
-    strategy:
-      matrix:
-        rancher_version: [latest/devel/2.8, latest/devel/2.9]
     uses: ./.github/workflows/master-e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -28,8 +28,8 @@ filterTests(['main', 'upgrade'], () => {
       cypressLib.burgerMenuToggle();
     });
 
-    // Install the dev operator in the main scenario for Rancher 2.8.x
-    if (isCypressTag('main') && isRancherManagerVersion('2.8')){
+    // Install the dev operator in the main scenario for Rancher >= 2.8.x
+    if (isCypressTag('main') && !isRancherManagerVersion('2.7')){
       qase(11,
         it('Add local chartmuseum repo', () => {
           cypressLib.addRepository('elemental-operator', Cypress.env('chartmuseum_repo')+':8080', 'helm', 'none');
@@ -37,7 +37,7 @@ filterTests(['main', 'upgrade'], () => {
       );
     };
   
-    if (isRancherManagerVersion('2.8')) {
+    if (!isRancherManagerVersion('2.7')) {
       qase(13,
         it('Install Elemental operator', () => {
           cy.contains('local')

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -105,17 +105,21 @@ Cypress.Commands.add('createMachReg', (
     // Build the ISO according to the elemental operator version
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
-    if (utils.isUIVersion('stable')) {
-      cy.getBySel('select-os-version-build-iso')
-        .click();
-    } else {
-      cy.getBySel('select-media-type-build-media')
-        .click();
-      cy.contains('Iso')
-        .click();
-      cy.getBySel('select-os-version-build-media')
-        .click();
-    }
+    
+    // Revert in ui extension, will be needed again soon
+    //if (utils.isUIVersion('stable')) {
+    //  cy.getBySel('select-os-version-build-iso')
+    //    .click();
+    //} else {
+    //  cy.getBySel('select-media-type-build-media')
+    //    .click();
+    //  cy.contains('Iso')
+    //    .click();
+    //  cy.getBySel('select-os-version-build-media')
+    //    .click();
+    //}
+    cy.getBySel('select-os-version-build-media')
+      .click();
     // Never build from dev ISO in upgrade scenario
     if (utils.isCypressTag('upgrade')) {
       // Stable operator version is hardcoded for now

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -17,7 +17,6 @@ package e2e_test
 import (
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
 
@@ -338,10 +337,8 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 		}
 	})
 
-	// Deploy operator in CLI test or if Rancher version is < 2.8
-	// because operator can not be installed trough Marketplace in Rancher 2.7.x
-	matched, _ := regexp.MatchString(`2.8`, rancherHeadVersion)
-	if strings.Contains(testType, "cli") || matched == false {
+	// Deploy operator in CLI test
+	if strings.Contains(testType, "cli") {
 		It("Installing Elemental Operator", func() {
 			// Report to Qase
 			testCaseID = 62


### PR DESCRIPTION
This PR adds fixes for:
- New RM Stable is `2.8.1`
- New version of the Elemental UI extension is `1.3.0-rc2`
## Verification run
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7753532582) ✅ 
[UI-K3s-RM_head_2.9](https://github.com/rancher/elemental/actions/runs/7756744134/job/21154711088) ✅ 
[UI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/7757339908/job/21156608425) ✅ 
[UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7758260662/job/21159651872)  ✅ 
[UI-RKE2-RM_head_2.9](https://github.com/rancher/elemental/actions/runs/7758262748/job/21159648722) ✅ 