### PR TITLE
Add back recovery hostname

### DIFF
--- a/framework/files/system/oem/03_branding.yaml
+++ b/framework/files/system/oem/03_branding.yaml
@@ -1,0 +1,7 @@
+name: "Branding"
+stages:
+   boot:
+    - name: "Recovery"
+      if: '[ -f "/run/elemental/recovery_mode" ]'
+      hostname: "recovery"
+


### PR DESCRIPTION
Hostname is no longer set since the branding files in the toolkit was moved to `cloud-config-defaults` feature which we no longer install in elemental.

Fixes https://github.com/rancher/elemental-operator/issues/608