### PR TITLE
ci/cli: fix regression on operator installation

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -225,7 +225,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 		}
 	})
 
-	It("Installing Rancher Manager", func() {
+	It("Install Rancher Manager", func() {
 		// Report to Qase
 		testCaseID = 61
 
@@ -338,27 +338,29 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 	})
 
 	// Deploy operator in CLI test
-	if strings.Contains(testType, "cli") {
-		It("Installing Elemental Operator", func() {
-			// Report to Qase
-			testCaseID = 62
+	It("Install Elemental Operator if needed", func() {
+		if strings.Contains(testType, "cli") {
+			By("Installing Operator for CLI tests", func() {
+				// Report to Qase
+				testCaseID = 62
 
-			for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
-				RunHelmCmdWithRetry("upgrade", "--install", chart,
-					operatorRepo+"/"+chart+"-chart",
-					"--namespace", "cattle-elemental-system",
-					"--create-namespace",
-					"--wait", "--wait-for-jobs",
-				)
+				for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
+					RunHelmCmdWithRetry("upgrade", "--install", chart,
+						operatorRepo+"/"+chart+"-chart",
+						"--namespace", "cattle-elemental-system",
+						"--create-namespace",
+						"--wait", "--wait-for-jobs",
+					)
 
-				// Delay few seconds for all to be installed
-				time.Sleep(tools.SetTimeout(20 * time.Second))
-			}
+					// Delay few seconds for all to be installed
+					time.Sleep(tools.SetTimeout(20 * time.Second))
+				}
 
-			// Wait for pod to be started
-			Eventually(func() error {
-				return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
-			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
-		})
-	}
+				// Wait for pod to be started
+				Eventually(func() error {
+					return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
+				}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+			})
+		}
+	})
 })


### PR DESCRIPTION
Fix regression added in #1189. But weirdly we have no sign of Elemental Operator installation even before this PR, it seems to have disappear since the Qase/Ginkgo integration... But the Operator was installed, otherwise tests would have failed before.

Anyway, it seems that a `if` check in Ginkgo test before a `It` is not working, even if we have no syntax error!

Verification runs:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7781871562)
- [UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7782492119)