### PR TITLE
ci: fix upgrade with OSVersionName/OSVersionChannel

### DIFF
--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -225,7 +225,7 @@ jobs:
       test_type: ${{ inputs.test_type }}
       ui_account: ${{ inputs.ui_account }}
       upgrade_image: ${{ inputs.upgrade_image }}
-      upgrade_os_channel: ${{ inputs.os_channel }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upgrade_type: ${{ inputs.upgrade_type }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
 

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -162,7 +162,7 @@ jobs:
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
       upgrade_image: ${{ inputs.upgrade_image }}
-      upgrade_os_channel: ${{ inputs.os_channel }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upgrade_type: ${{ inputs.upgrade_type }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
 
@@ -217,5 +217,5 @@ jobs:
       test_description: ${{ inputs.test_description }}
       ui_account: ${{ inputs.ui_account }}
       upgrade_image: ${{ inputs.upgrade_image }}
-      upgrade_os_channel: ${{ inputs.os_channel }}
+      upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upstream_cluster_version: ${{ inputs.upstream_cluster_version }}


### PR DESCRIPTION
Verification runs:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7915275624)
- [CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7915278136)
- [UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7915312050)
- [UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7915314677)

**NOTE:** the CLI-RKE2 test fails because of issue https://github.com/rancher/elemental-operator/issues/629.