### PR TITLE
ci/ui: deploy elemental operator when using RM2.7

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -29,23 +29,19 @@ filterTests(['main', 'upgrade'], () => {
       cy.visit('/');
       cypressLib.burgerMenuToggle();
     });
-
-    // Install the dev operator in the main scenario except for Rancher 2.7.x
-    if (isCypressTag('main') && !isRancherManagerVersion('2.7')){
+    // Add dev repo for main test or if the test runs on rancher 2.7 (because operator is not in the 2.7 marketplace)
+    if (isCypressTag('main') || isRancherManagerVersion('2.7')) {
       it('Add local chartmuseum repo', () => {
         cypressLib.addRepository('elemental-operator', Cypress.env('chartmuseum_repo')+':8080', 'helm', 'none');
-      })
-    };
-  
-    if (!isRancherManagerVersion('2.7') && isCypressTag('main')) {
+      });
       qase(10,
-        it('Install latest stable Elemental operator', () => {
+        it('Install latest dev Elemental operator', () => {
           elemental.installElementalOperator();
         })
       );
-    } else if (!isRancherManagerVersion('2.7') && isCypressTag('upgrade')) {
+    } else if (isCypressTag('upgrade') && !isRancherManagerVersion('2.7')) {
       qase(57,
-        it('Install latest dev Elemental operator', () => {
+        it('Install latest stable Elemental operator', () => {
           elemental.installElementalOperator();
         })
       );

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -34,9 +34,9 @@ filterTests(['main', 'upgrade'], () => {
       })
     );
 
-    // Add rancher-ui-plugin-charts repo because its part of Rancher Prime
+    // Add rancher-ui-plugin-charts repo because its part of Rancher Prime in 2.8 and 2.9-head
     it('Add rancher-ui-plugin-charts repo', () => {
-      isRancherManagerVersion('head') ? cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main') : null;
+      isRancherManagerVersion('2.8-head') || isRancherManagerVersion('2.9-head') ? cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main') : null;
     });
     
     qase(12,

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -42,9 +42,9 @@ describe('Upgrade tests', () => {
 
   filterTests(['upgrade'], () => {
     // Add dev OS Version Channel if stable operator is installed
-    // because we do not update the operator in UI test so far
+    // because we do not update the operator in RKE2 UI test so far
     // Only RKE2 tests use os version channel
-    if (utils.isK8sVersion("rke2") && utils.isRancherManagerVersion('2.8')) {
+    if (utils.isK8sVersion("rke2") && !utils.isRancherManagerVersion('2.7')) {
       it('Add dev channel for RKE2 upgrade', () => {
         cy.addOsVersionChannel('dev');
       })

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { isCypressTag } from '~/support/utils';
+import { isCypressTag, isRancherManagerVersion } from '~/support/utils';
 export class Elemental {
   // Go into the cluster creation menu
   accessClusterMenu() {
@@ -66,7 +66,7 @@ export class Elemental {
     cy.contains('.outer-container > .header', 'Elemental');
     cy.clickButton('Next');
     // Workaround for https://github.com/rancher/rancher/issues/43379
-    if (isCypressTag('upgrade')) {
+    if (isCypressTag('upgrade') && !isRancherManagerVersion('2.7')) {
       cy.get('[data-testid="string-input-channel.repository"]')
         .type('registry.suse.com/rancher/elemental-teal-channel')
       cy.get('[data-testid="string-input-channel.tag"]')


### PR DESCRIPTION
# Verification runs
## Rancher 2.7
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7917701271/job/21614421207) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7916255838/job/21609767238) ✅ 
[UI-K3s-RM_head_2.7 ](https://github.com/rancher/elemental/actions/runs/7918235468) ✅ 
[UI-RKE2-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7918250536) ✅ 

## Rancher 2.8
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7918274070) ✅ 
[UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7918275465) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7918276462) ✅ 
[UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7918277781) ✅ 
