### PR TITLE
ci: bump k8s to v1.27.10

### DIFF
--- a/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
@@ -22,8 +22,8 @@ jobs:
       cert-manager_version: v1.12.2
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.27.10+k3s2
       os_to_test: dev
       rancher_version: latest/devel/2.7
       test_type: airgap
-      upstream_cluster_version: 1.26.8
+      upstream_cluster_version: 1.26.10

--- a/.github/workflows/cli-k3s-airgap_rm_stable.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_stable.yaml
@@ -26,9 +26,9 @@ jobs:
       cert-manager_version: v1.12.2
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.8+k3s1
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: dev
       rancher_version: stable/latest/2.7
       test_type: airgap
-      upstream_cluster_version: 1.26.8
+      upstream_cluster_version: 1.26.10

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_stable.yaml
@@ -23,6 +23,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -35,7 +35,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
@@ -28,7 +28,7 @@ jobs:
       cluster_number: 20
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -35,7 +35,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -35,7 +35,7 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -21,7 +21,7 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -47,7 +47,7 @@ jobs:
       test_description: "Manual - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
@@ -21,7 +21,7 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.7
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
@@ -21,7 +21,7 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.8
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
@@ -21,7 +21,7 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.9
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_stable.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.7.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.8.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.9.yaml
@@ -21,6 +21,6 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-rm_stable.yaml
@@ -21,5 +21,5 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       test_type: cli

--- a/.github/workflows/cli-k3s-scalability-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-scalability-rm_stable.yaml
@@ -26,7 +26,7 @@ jobs:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 60
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none

--- a/.github/workflows/cli-k3s-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rm_stable.yaml
@@ -25,7 +25,7 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none
       test_type: cli

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: boolean
       k8s_version:
         description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
-        default: v1.26.10+k3s2
+        default: v1.27.10+k3s2
         type: string
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 3
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 3
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 3
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 3
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -29,7 +29,7 @@ jobs:
       cluster_number: 10
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -48,7 +48,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.7
       reset: true
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.8
       reset: true
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.9
       reset: true
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       reset: true
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.7
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.8
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.9.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: latest/devel/2.9
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-rm_stable.yaml
@@ -22,6 +22,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       test_type: cli
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_stable.yaml
@@ -26,7 +26,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none
       sequential: true

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -107,6 +107,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
+        #default: v1.27.10+k3s2
         default: v1.26.10+k3s2
         type: string
       zone:

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -35,7 +35,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -35,7 +35,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -38,7 +38,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -38,7 +38,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
@@ -38,7 +38,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -31,7 +31,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.7.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.8.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.9.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-rm_stable.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+k3s2
+      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -17,7 +17,7 @@ on:
         type: string
       k8s_version_to_provision:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
-        default: v1.26.10+k3s2
+        default: v1.27.10+k3s2
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.suse.com/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.7.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.8.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.9.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
       upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-rm_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.26.10+rke2r2
+      k8s_version_to_provision: v1.27.10+rke2r1
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
       upstream_cluster_version: v1.26.10+rke2r2


### PR DESCRIPTION
Fix #1206 

Bump k8s versions for downstream clusters only:
k3s --> `v1.27.10+k3s2`
rke2 --> `v1.27.10+rke2r2`

## Verification runs
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7959624892) ✅ 
[CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/7959719375) ✅  
[UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7960798729) ✅  
[CLI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7960802088) ✅ 

I hit this bug when I bumped the upstream cluster so it will be done later: https://github.com/rancher/elemental-operator/issues/636