### PR TITLE
ci: fix Rancher Manager upgrade

### DIFF
--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -28,7 +28,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel/2.7
+      rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -26,7 +26,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      rancher_upgrade: latest/devel/2.7
+      rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest

--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -170,7 +170,6 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 			// Set flags for Rancher Manager installation
 			flags := []string{
 				"upgrade", "--install", "rancher", string(rancherAirgapVersion),
-				//"upgrade", "--install", "rancher", "/opt/rancher/helm/rancher-" + rancherHeadVersion + ".tgz",
 				"--namespace", "cattle-system",
 				"--create-namespace",
 				"--set", "hostname=rancher-manager.test",

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231019143409-a8e92d67d1e4
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -130,8 +130,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231019143409-a8e92d67d1e4 h1:NIoMaiQgvl0aKNbJVoHshacD3OO30HEO9rpQ8T2ilpc=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231019143409-a8e92d67d1e4/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849 h1:RNHdLRAv57ZylRBl8XKsGpxgue1PAV7JvShYTXqQjJw=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
With the update of K8s version on the downstream cluster it seems that some warning can appears on some `kubectl` commands. This usually doesn't have impact but when the output of `kubectl` command is needed then it could break the test as by default the `stderr` is returned too.

This PR use the new function `RunWithoutErr` from `ele-testhelpers` when needed to fix this.

Verification run:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/7985543251)