### PR TITLE
ci: fix manual OBS workflow

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -69,4 +69,3 @@ jobs:
       runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}
       test_type: cli
-      upstream_cluster_version: ${{ inputs.k8s_version }}


### PR DESCRIPTION
This commit will use the default version, which is K3s and most of the tests are done with this distribution for now.