### PR TITLE
ci: use new kubectl.RunWithoutErr function

### DIFF
--- a/tests/e2e/app_test.go
+++ b/tests/e2e/app_test.go
@@ -64,7 +64,7 @@ var _ = Describe("E2E - Checking a simple application", Label("check-app"), func
 			nodeNumber := len(strings.Fields(nodeList))
 			Expect(nodeNumber).To(Not(BeNil()))
 
-			out, err := kubectl.Run("scale", "--replicas="+fmt.Sprint(nodeNumber), "deployment/"+appName)
+			out, err := kubectl.RunWithoutErr("scale", "--replicas="+fmt.Sprint(nodeNumber), "deployment/"+appName)
 			Expect(err).To(Not(HaveOccurred()), out)
 			Expect(out).To(ContainSubstring("deployment.apps/" + appName + " scaled"))
 		})
@@ -73,7 +73,7 @@ var _ = Describe("E2E - Checking a simple application", Label("check-app"), func
 			// Wait for application to be started
 			// NOTE: 1st or 2nd rollout command can sporadically fail, so better to use Eventually here
 			Eventually(func() string {
-				status, _ := kubectl.Run("rollout", "status", "deployment/"+appName)
+				status, _ := kubectl.RunWithoutErr("rollout", "status", "deployment/"+appName)
 				return status
 			}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(ContainSubstring("successfully rolled out"))
 		})

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -106,14 +106,14 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 		})
 
 		By("Checking that the backup has been done", func() {
-			out, err := kubectl.Run("get", "backup", backupResourceName,
+			out, err := kubectl.RunWithoutErr("get", "backup", backupResourceName,
 				"-o", "jsonpath={.metadata.name}")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(out).To(ContainSubstring(backupResourceName))
 
 			// Check operator logs
 			Eventually(func() string {
-				out, _ := kubectl.Run("logs", "-l app.kubernetes.io/name=rancher-backup",
+				out, _ := kubectl.RunWithoutErr("logs", "-l app.kubernetes.io/name=rancher-backup",
 					"--tail=-1", "--since=5m",
 					"--namespace", "cattle-resources-system")
 				return out
@@ -128,14 +128,14 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 		By("Deleting some Elemental resources", func() {
 			for _, obj := range []string{"MachineRegistration", "MachineInventorySelectorTemplate"} {
 				// List the resources
-				list, err := kubectl.Run("get", obj,
+				list, err := kubectl.RunWithoutErr("get", obj,
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				Expect(err).To(Not(HaveOccurred()))
 
 				// Delete the resources
 				for _, rsc := range strings.Split(list, " ") {
-					_, err := kubectl.Run("delete", obj, "--namespace", clusterNS, rsc)
+					_, err := kubectl.RunWithoutErr("delete", obj, "--namespace", clusterNS, rsc)
 					Expect(err).To(Not(HaveOccurred()))
 				}
 			}
@@ -143,7 +143,7 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 
 		By("Adding a restore resource", func() {
 			// Get the backup file from the previous backup
-			backupFile, err := kubectl.Run("get", "backup", backupResourceName, "-o", "jsonpath={.status.filename}")
+			backupFile, err := kubectl.RunWithoutErr("get", "backup", backupResourceName, "-o", "jsonpath={.status.filename}")
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Set the backup file in the restore resource
@@ -158,14 +158,14 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 		By("Checking that the restore has been done", func() {
 			// Wait until resources are available again
 			Eventually(func() string {
-				out, _ := kubectl.Run("get", "restore", restoreResourceName,
+				out, _ := kubectl.RunWithoutErr("get", "restore", restoreResourceName,
 					"-o", "jsonpath={.metadata.name}")
 				return out
 			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(ContainSubstring(restoreResourceName))
 
 			// Check operator logs
 			Eventually(func() string {
-				out, _ := kubectl.Run("logs", "-l app.kubernetes.io/name=rancher-backup",
+				out, _ := kubectl.RunWithoutErr("logs", "-l app.kubernetes.io/name=rancher-backup",
 					"--tail=-1", "--since=5m",
 					"--namespace", "cattle-resources-system")
 				return out

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -52,7 +52,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 			By("Downloading MachineRegistration file", func() {
 				// Download the new YAML installation config file
 				machineRegName := "machine-registration-" + poolType + "-" + clusterName
-				tokenURL, err := kubectl.Run("get", "MachineRegistration",
+				tokenURL, err := kubectl.RunWithoutErr("get", "MachineRegistration",
 					"--namespace", clusterNS, machineRegName,
 					"-o", "jsonpath={.status.registrationURL}")
 				Expect(err).To(Not(HaveOccurred()))
@@ -189,7 +189,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 			// Check that the selector has been correctly created
 			Eventually(func() string {
-				out, _ := kubectl.Run("get", "MachineInventorySelector",
+				out, _ := kubectl.RunWithoutErr("get", "MachineInventorySelector",
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out

--- a/tests/e2e/helpers/elemental/elemental.go
+++ b/tests/e2e/helpers/elemental/elemental.go
@@ -58,7 +58,7 @@ Get state of the cluster
   - @returns The YAML structure or an error
 */
 func GetClusterState(ns, cluster, condition string) (string, error) {
-	out, err := kubectl.Run("get", "cluster", "--namespace", ns, cluster, "-o", "jsonpath="+condition)
+	out, err := kubectl.RunWithoutErr("get", "cluster", "--namespace", ns, cluster, "-o", "jsonpath="+condition)
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +72,7 @@ Get nodeName from MachineInventory
   - @returns Corresponding external machine name
 */
 func GetExternalMachine(ns, machine string) (string, error) {
-	node, err := kubectl.Run("get", "Machine",
+	node, err := kubectl.RunWithoutErr("get", "Machine",
 		"--namespace", ns, machine,
 		"-o", "jsonpath={.status.addresses[?(@.type==\"Hostname\")].address}")
 	if err != nil {
@@ -89,7 +89,7 @@ Get IP from MachineInventory
   - @returns Corresponding machine IP
 */
 func GetExternalMachineIP(ns, machine string) (string, error) {
-	node, err := kubectl.Run("get", "Machine",
+	node, err := kubectl.RunWithoutErr("get", "Machine",
 		"--namespace", ns, machine,
 		"-o", "jsonpath={.status.addresses[?(@.type==\"InternalIP\")].address}")
 	if err != nil {
@@ -106,7 +106,7 @@ Get container URI from ManagedOSVersion
   - @returns URI of container image
 */
 func GetImageURI(ns, os string) (string, error) {
-	uri, err := kubectl.Run("get", "ManagedOSVersion",
+	uri, err := kubectl.RunWithoutErr("get", "ManagedOSVersion",
 		"--namespace", ns, os,
 		"-o", "jsonpath={.spec.metadata.uri}")
 
@@ -124,7 +124,7 @@ Get Machine from MachineInventory
   - @returns Corresponding internal machine name
 */
 func GetInternalMachine(ns, machineInventory string) (string, error) {
-	machine, err := kubectl.Run("get", "Machine",
+	machine, err := kubectl.RunWithoutErr("get", "Machine",
 		"--namespace", ns,
 		"-o", "jsonpath={.items[?(@.status.nodeRef.name==\""+machineInventory+"\")].metadata.name}")
 	if err != nil {
@@ -139,7 +139,7 @@ Get container image used for Elemental operator
   - @returns The container image used or an error
 */
 func GetOperatorImage() (string, error) {
-	operatorImage, err := kubectl.Run("get", "pod",
+	operatorImage, err := kubectl.RunWithoutErr("get", "pod",
 		"--namespace", "cattle-elemental-system",
 		"-l", "app=elemental-operator", "-o", "jsonpath={.items[*].status.containerStatuses[*].image}")
 	if err != nil {
@@ -172,7 +172,7 @@ Get MachineInventory name (aka. server id)
   - @returns The name/id of the server or an error
 */
 func GetServerID(ns string, index int) (string, error) {
-	serverID, err := kubectl.Run("get", "MachineInventories",
+	serverID, err := kubectl.RunWithoutErr("get", "MachineInventories",
 		"--namespace", ns,
 		"-o", "jsonpath={.items["+fmt.Sprint(index-1)+"].metadata.name}")
 	if err != nil {
@@ -209,7 +209,7 @@ Set a label on MachineInventory
   - @returns Nothing or an error
 */
 func SetMachineInventoryLabel(ns, node, key, value string) error {
-	_, err := kubectl.Run("label", "machineinventory",
+	_, err := kubectl.RunWithoutErr("label", "machineinventory",
 		"--namespace", ns, node,
 		"--overwrite", key+"="+value)
 	if err != nil {

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -30,14 +30,14 @@ import (
 func rolloutDeployment(ns, d string) {
 	// NOTE: 1st or 2nd rollout command can sporadically fail, so better to use Eventually here
 	Eventually(func() string {
-		status, _ := kubectl.Run("rollout", "restart", "deployment/"+d,
+		status, _ := kubectl.RunWithoutErr("rollout", "restart", "deployment/"+d,
 			"--namespace", ns)
 		return status
 	}, tools.SetTimeout(1*time.Minute), 20*time.Second).Should(ContainSubstring("restarted"))
 
 	// Wait for deployment to be restarted
 	Eventually(func() string {
-		status, _ := kubectl.Run("rollout", "status", "deployment/"+d,
+		status, _ := kubectl.RunWithoutErr("rollout", "status", "deployment/"+d,
 			"--namespace", ns)
 		return status
 	}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(ContainSubstring("successfully rolled out"))
@@ -234,7 +234,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 		// Inject secret for Private CA
 		if caType == "private" {
-			_, err := kubectl.Run("create", "secret",
+			_, err := kubectl.RunWithoutErr("create", "secret",
 				"--namespace", "cattle-system",
 				"tls", "tls-rancher-ingress",
 				"--cert=tls.crt",
@@ -242,7 +242,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			)
 			Expect(err).To(Not(HaveOccurred()))
 
-			_, err = kubectl.Run("create", "secret",
+			_, err = kubectl.RunWithoutErr("create", "secret",
 				"--namespace", "cattle-system",
 				"generic", "tls-ca",
 				"--from-file=cacerts.pem=./cacerts.pem",
@@ -283,7 +283,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 
 		By("Configuring kubectl to use Rancher admin user", func() {
 			// Getting internal username for admin
-			internalUsername, err := kubectl.Run("get", "user",
+			internalUsername, err := kubectl.RunWithoutErr("get", "user",
 				"-o", "jsonpath={.items[?(@.username==\"admin\")].metadata.name}",
 			)
 			Expect(err).To(Not(HaveOccurred()))
@@ -299,7 +299,7 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 			// NOTE: loop until the cmd return something, it could take some time
 			var rancherCA string
 			Eventually(func() error {
-				rancherCA, err = kubectl.Run("get", "secret",
+				rancherCA, err = kubectl.RunWithoutErr("get", "secret",
 					"--namespace", "cattle-system",
 					"tls-rancher-ingress",
 					"-o", "jsonpath={.data.tls\\.crt}",

--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -87,7 +87,7 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 			var getResources []getResourceLog = []getResourceLog{Bundles}
 			for _, r := range getResources {
 				for _, v := range r.Verb {
-					outcmd, err := kubectl.Run(v, r.Name, "--all-namespaces")
+					outcmd, err := kubectl.RunWithoutErr(v, r.Name, "--all-namespaces")
 					checkRC(err)
 					err = os.WriteFile(r.Name+"-"+v+".log", []byte(outcmd), os.ModePerm)
 					checkRC(err)

--- a/tests/e2e/multi-cluster_test.go
+++ b/tests/e2e/multi-cluster_test.go
@@ -116,7 +116,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 
 		By("Downloading MachineRegistration file", func() {
 			// Download the new YAML installation config file
-			tokenURL, err := kubectl.Run("get", "MachineRegistration",
+			tokenURL, err := kubectl.RunWithoutErr("get", "MachineRegistration",
 				"--namespace", clusterNS, machineRegName,
 				"-o", "jsonpath={.status.registrationURL}")
 			Expect(err).To(Not(HaveOccurred()))
@@ -284,7 +284,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 				ip := GetNodeIP(hostName)
 
 				// Get MachineInventory name
-				nodeName, err := kubectl.Run("get", "MachineInventory",
+				nodeName, err := kubectl.RunWithoutErr("get", "MachineInventory",
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[?(@.metadata.annotations.elemental\\.cattle\\.io/registration-ip==\""+ip+"\")].metadata.name}")
 				Expect(err).To(Not(HaveOccurred()))

--- a/tests/e2e/reset_test.go
+++ b/tests/e2e/reset_test.go
@@ -31,7 +31,7 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 		testCaseID = 54
 
 		// Get the machine inventory name list
-		machineInventory, err := kubectl.Run("get", "MachineInventory",
+		machineInventory, err := kubectl.RunWithoutErr("get", "MachineInventory",
 			"--namespace", clusterNS,
 			"-o", "jsonpath='{.items[*].metadata.name}'")
 		Expect(err).To(Not(HaveOccurred()))
@@ -39,7 +39,7 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 
 		By("Configuring reset at MachineInventory level", func() {
 			// Patch the first machine inventory to enable reset
-			_, err = kubectl.Run("patch", "MachineInventory", firstMachineInventory,
+			_, err = kubectl.RunWithoutErr("patch", "MachineInventory", firstMachineInventory,
 				"--namespace", clusterNS, "--type", "merge",
 				"--patch-file", resetMachineInv)
 			Expect(err).To(Not(HaveOccurred()))
@@ -48,14 +48,14 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 		By("Deleting and removing the node from the cluster", func() {
 			machineToRemove, err := elemental.GetInternalMachine(clusterNS, firstMachineInventory)
 			Expect(err).To(Not(HaveOccurred()))
-			_, err = kubectl.Run("delete", "machines", machineToRemove,
+			_, err = kubectl.RunWithoutErr("delete", "machines", machineToRemove,
 				"--namespace", clusterNS)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
 		By("Checking that MachineInventory is deleted", func() {
 			Eventually(func() string {
-				out, _ := kubectl.Run("get", "MachineInventory",
+				out, _ := kubectl.RunWithoutErr("get", "MachineInventory",
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out
@@ -64,7 +64,7 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 
 		By("Checking that MachineInventory is back after the reset", func() {
 			Eventually(func() string {
-				out, _ := kubectl.Run("get", "MachineInventory",
+				out, _ := kubectl.RunWithoutErr("get", "MachineInventory",
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -68,7 +68,7 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 
 			// Set poweroff to false for master pool to have time to check SeedImage cloud-config
 			if poolType == "master" && isoBoot {
-				_, err := kubectl.Run("patch", "MachineRegistration",
+				_, err := kubectl.RunWithoutErr("patch", "MachineRegistration",
 					"--namespace", clusterNS, machineRegName,
 					"--type", "merge", "--patch",
 					"{\"spec\":{\"config\":{\"elemental\":{\"install\":{\"poweroff\":false}}}}}")
@@ -90,7 +90,7 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 				Expect(err).To(Not(HaveOccurred()))
 
 				// And apply it
-				_, err = kubectl.Run("patch", "MachineRegistration",
+				_, err = kubectl.RunWithoutErr("patch", "MachineRegistration",
 					"--namespace", clusterNS, machineRegName,
 					"--type", "merge", "--patch-file", emulatedTmp,
 				)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -226,7 +226,7 @@ Check that Cluster resource has been correctly created
 func CheckCreatedCluster(ns, cn string) {
 	// Check that the cluster is correctly created
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "cluster",
+		out, _ := kubectl.RunWithoutErr("get", "cluster",
 			"--namespace", ns,
 			cn, "-o", "jsonpath={.metadata.name}")
 		return out
@@ -241,7 +241,7 @@ Check that Cluster resource has been correctly created
 */
 func CheckCreatedRegistration(ns, rn string) {
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "MachineRegistration",
+		out, _ := kubectl.RunWithoutErr("get", "MachineRegistration",
 			"--namespace", clusterNS,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		return out
@@ -256,7 +256,7 @@ Check that a SelectorTemplate resource has been correctly created
 */
 func CheckCreatedSelectorTemplate(ns, sn string) {
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "MachineInventorySelectorTemplate",
+		out, _ := kubectl.RunWithoutErr("get", "MachineInventorySelectorTemplate",
 			"--namespace", ns,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		return out
@@ -270,7 +270,7 @@ Wait for OSVersion to be populated
 */
 func WaitForOSVersion(ns string) {
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "ManagedOSVersion",
+		out, _ := kubectl.RunWithoutErr("get", "ManagedOSVersion",
 			"--namespace", ns,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		return out
@@ -302,7 +302,7 @@ func DownloadBuiltISO(ns, seedName, filename string) {
 
 	// Check that the seed image is correctly created
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "SeedImage",
+		out, _ := kubectl.RunWithoutErr("get", "SeedImage",
 			"--namespace", ns,
 			seedName,
 			"-o", "jsonpath={.status}")
@@ -310,7 +310,7 @@ func DownloadBuiltISO(ns, seedName, filename string) {
 	}, tools.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("downloadURL"))
 
 	// Get URL
-	seedImageURL, err := kubectl.Run("get", "SeedImage",
+	seedImageURL, err := kubectl.RunWithoutErr("get", "SeedImage",
 		"--namespace", ns,
 		seedName,
 		"-o", "jsonpath={.status.downloadURL}")

--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -36,7 +36,7 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 
 	It("Configure libvirt and bootstrap a node", func() {
 		By("Downloading MachineRegistration", func() {
-			tokenURL, err := kubectl.Run("get", "MachineRegistration",
+			tokenURL, err := kubectl.RunWithoutErr("get", "MachineRegistration",
 				"--namespace", clusterNS,
 				"machine-registration", "-o", "jsonpath={.status.registrationURL}")
 			Expect(err).To(Not(HaveOccurred()))

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func deleteFinalizers(ns, object, value string) {
-	_, err := kubectl.Run("patch", object,
+	_, err := kubectl.RunWithoutErr("patch", object,
 		"--namespace", ns, value, "--type", "merge",
 		"--patch", "{\"metadata\":{\"finalizers\":null}}")
 	Expect(err).To(Not(HaveOccurred()))
@@ -37,7 +37,7 @@ func deleteFinalizers(ns, object, value string) {
 
 func testClusterAvailability(ns, cluster string) {
 	Eventually(func() string {
-		out, _ := kubectl.Run("get", "cluster",
+		out, _ := kubectl.RunWithoutErr("get", "cluster",
 			"--namespace", ns, cluster,
 			"-o", "jsonpath={.metadata.name}")
 		return out
@@ -92,7 +92,7 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 			By("Deleting cluster resource", func() {
 				Eventually(func() error {
-					_, err := kubectl.Run("delete", "cluster",
+					_, err := kubectl.RunWithoutErr("delete", "cluster",
 						"--namespace", ns, name)
 					return err
 				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))
@@ -104,7 +104,7 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 			// NOTE: wait a bit for the cluster deletion to be started (it's running in background)
 			time.Sleep(1 * time.Minute)
 
-			machineList, err := kubectl.Run("get", "MachineInventory",
+			machineList, err := kubectl.RunWithoutErr("get", "MachineInventory",
 				"--namespace", clusterNS, "-o", "jsonpath={.items[*].metadata.name}")
 			Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -95,7 +95,7 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 			"-l", "app=rancher",
 			"-o", "jsonpath={.items[*].status.containerStatuses[*].image}",
 		}
-		versionBeforeUpgrade, err := kubectl.Run(getImageVersion...)
+		versionBeforeUpgrade, err := kubectl.RunWithoutErr(getImageVersion...)
 		Expect(err).To(Not(HaveOccurred()))
 
 		// Upgrade Rancher Manager
@@ -111,7 +111,7 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 		// Wait for Rancher Manager to be restarted
 		// NOTE: 1st or 2nd rollout command can sporadically fail, so better to use Eventually here
 		Eventually(func() string {
-			status, _ := kubectl.Run(
+			status, _ := kubectl.RunWithoutErr(
 				"rollout",
 				"--namespace", "cattle-system",
 				"status", "deployment/rancher",
@@ -134,13 +134,13 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 
 		// Check that all pods are using the same version
 		Eventually(func() int {
-			out, _ := kubectl.Run(getImageVersion...)
+			out, _ := kubectl.RunWithoutErr(getImageVersion...)
 			return len(strings.Fields(out))
 		}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(Equal(1))
 
 		// Get after-upgrade Rancher Manager version
 		// and check that it's different to the before-upgrade version
-		versionAfterUpgrade, err := kubectl.Run(getImageVersion...)
+		versionAfterUpgrade, err := kubectl.RunWithoutErr(getImageVersion...)
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(versionAfterUpgrade).To(Not(Equal(versionBeforeUpgrade)))
 	})
@@ -206,14 +206,14 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 					GinkgoWriter.Printf("!! ManagedOSVersionChannel not synced !! Triggering a re-sync!\n")
 
 					// Get current syncInterval
-					syncValue, err := kubectl.Run("get", "managedOSVersionChannel",
+					syncValue, err := kubectl.RunWithoutErr("get", "managedOSVersionChannel",
 						"--namespace", clusterNS, channel,
 						"-o", "jsonpath={.spec.syncInterval}")
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(syncValue).To(Not(BeEmpty()))
 
 					// Reduce syncInterval to force an update
-					_, err = kubectl.Run("patch", "managedOSVersionChannel",
+					_, err = kubectl.RunWithoutErr("patch", "managedOSVersionChannel",
 						"--namespace", clusterNS, channel,
 						"--type", "merge",
 						"--patch", "{\"spec\":{\"syncInterval\":\"1m\"}}")
@@ -232,7 +232,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 					Expect(OSVersion).To(Not(BeEmpty()))
 
 					// Re-patch syncInterval to the initial value
-					_, err = kubectl.Run("patch", "managedOSVersionChannel",
+					_, err = kubectl.RunWithoutErr("patch", "managedOSVersionChannel",
 						"--namespace", clusterNS, channel,
 						"--type", "merge",
 						"--patch", "{\"spec\":{\"syncInterval\":\""+syncValue+"\"}}")
@@ -243,7 +243,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 				value = string(OSVersion)
 
 				// Extract the value to check after the upgrade
-				out, err := kubectl.Run("get", "ManagedOSVersion",
+				out, err := kubectl.RunWithoutErr("get", "ManagedOSVersion",
 					"--namespace", clusterNS, value,
 					"-o", "jsonpath={.spec.metadata.upgradeImage}")
 				Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
As we already rely on the return code to trap the failure, and the current implementation can lead to sporadic issues in some cases, it is better to simply use the new RunWithoutErr function and get rid of the stderr output.

Verification runs:
- [CLI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/7989240495)
- [UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/7987764209)