### PR TITLE
ci/airgap: fix build and deploy scripts

### DIFF
--- a/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
@@ -24,6 +24,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2
       os_to_test: dev
-      rancher_version: latest/devel/2.7
+      rancher_version: latest/devel
       test_type: airgap
-      upstream_cluster_version: 1.26.10
+      upstream_cluster_version: v1.26.10+k3s2

--- a/.github/workflows/cli-k3s-airgap_rm_stable.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_stable.yaml
@@ -29,6 +29,6 @@ jobs:
       k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: dev
-      rancher_version: stable/latest/2.7
+      rancher_version: stable/latest
       test_type: airgap
-      upstream_cluster_version: 1.26.10
+      upstream_cluster_version: v1.26.10+k3s2

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -47,14 +47,17 @@ generate-readme:
 # Qase commands
 create-qase-run: deps
 	@go run qase/qase_cmd.go -create
+
 delete-qase-run: deps
 	@go run qase/qase_cmd.go -delete
+
 publish-qase-run: deps
 	@go run qase/qase_cmd.go -publish
 
 # E2E tests
 e2e-airgap-rancher: deps
 	ginkgo --label-filter airgap-rancher -r -v ./e2e
+
 e2e-bootstrap-node: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
 

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -46,7 +46,6 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 				key   string
 				value string
 			}
-			airgapImagesFile := "/opt/rancher/images/elemental/elemental-images.txt"
 
 			// Wait for list of OS versions to be populated
 			WaitForOSVersion(clusterNS)
@@ -62,7 +61,8 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 			Expect(baseImageURL).To(Not(BeEmpty()))
 
 			if testType == "airgap" {
-				isoVersion, _ := exec.Command("bash", "-c", "awk -F '/' '/sle-micro-iso/{print $NF}' "+airgapImagesFile).Output()
+				airgapImagesFile := os.Getenv("HOME") + "/airgap_rancher/images/elemental/elemental-images.txt"
+				isoVersion, _ := exec.Command("bash", "-c", "awk -F/ '/sle-micro-iso/{print $NF}' "+airgapImagesFile).Output()
 				baseImageURL = "localhost:5000/elemental/sle-micro-iso-" + string(isoVersion)
 			}
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -480,18 +480,33 @@ var _ = BeforeSuite(func() {
 
 	// Extract Rancher Manager channel/version to install
 	if rancherVersion != "" {
+		// Split rancherVersion and reset it
 		s := strings.Split(rancherVersion, "/")
+		rancherVersion = ""
+
+		// Get needed informations
 		rancherChannel = s[0]
-		rancherVersion = s[1]
-		rancherHeadVersion = s[2]
+		if len(s) > 1 {
+			rancherVersion = s[1]
+		}
+		if len(s) > 2 {
+			rancherHeadVersion = s[2]
+		}
 	}
 
 	// Extract Rancher Manager channel/version to upgrade
 	if rancherUpgrade != "" {
+		// Split rancherUpgrade and reset it
 		s := strings.Split(rancherUpgrade, "/")
+
+		// Get needed informations
 		rancherUpgradeChannel = s[0]
-		rancherUpgradeVersion = s[1]
-		rancherUpgradeHeadVersion = s[2]
+		if len(s) > 1 {
+			rancherUpgradeVersion = s[1]
+		}
+		if len(s) > 2 {
+			rancherUpgradeHeadVersion = s[2]
+		}
 	}
 
 	switch testType {

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -4,14 +4,17 @@
 
 set -e -x
 
+# Variable(s)
 K3S_UPSTREAM_VERSION=$1
 CERT_MANAGER_VERSION=$2
 RANCHER_CHANNEL=$3
 K3S_DOWNSTREAM_VERSION=$4
 ELEMENTAL_REPO=$5
+DEPLOY_AIRGAP_SCRIPT=$(realpath ../scripts/deploy-airgap)
+OPT_RANCHER=${HOME}/airgap_rancher
 
 # Set Elemental version
-case $ELEMENTAL_REPO in
+case ${ELEMENTAL_REPO} in
   *dev*)
     ELEMENTAL_VERSION=dev
     ;;
@@ -23,116 +26,135 @@ case $ELEMENTAL_REPO in
     ;;
 esac
 
+# Format upstream version
+TMP_UPSTREAM_VERSION=${K3S_UPSTREAM_VERSION/+*}
+K8S_UPSTREAM_VERSION=${TMP_UPSTREAM_VERSION/v}
+
 # Create directories
-mkdir -p /opt/rancher/{k3s_$K3S_UPSTREAM_VERSION,helm} /opt/rancher/images/{cert,rancher,registry,elemental}
-cd /opt/rancher/k3s_$K3S_UPSTREAM_VERSION/
+mkdir -p ${OPT_RANCHER}/{k3s_${K8S_UPSTREAM_VERSION},helm} ${OPT_RANCHER}/images/{cert,rancher,registry,elemental}
+cd ${OPT_RANCHER}/k3s_${K8S_UPSTREAM_VERSION}/
 
 # Install packages
-zypper --no-refresh -n in zstd skopeo yq
+sudo zypper --no-refresh -n in skopeo yq
 
 # Add rancher manager in /etc/hosts
-sudo echo "192.168.122.102 rancher-manager.test" >> /etc/hosts
+sudo sh -c 'echo "192.168.122.102 rancher-manager.test" >> /etc/hosts'
 
 # Download k3s and rancher
-curl -#OL https://github.com/k3s-io/k3s/releases/download/v$K3S_UPSTREAM_VERSION%2Bk3s1/k3s-airgap-images-amd64.tar.zst
-curl -#OL https://github.com/k3s-io/k3s/releases/download/v$K3S_UPSTREAM_VERSION%2Bk3s1/k3s
+K3S_URL=https://github.com/k3s-io/k3s/releases/download/${K3S_UPSTREAM_VERSION}
+for i in k3s-airgap-images-amd64.tar.zst k3s; do
+  curl -sOL ${K3S_URL}/${i}
+done
 
 # Get the install script
-curl -sfL https://get.k3s.io/ -o install.sh
+curl -sfL https://get.k3s.io -o install.sh
 
 # Get the airgap deploy script
-cp /home/gh-runner/actions-runner/_work/elemental/elemental/tests/scripts/deploy-airgap . 
+cp ${DEPLOY_AIRGAP_SCRIPT} .
 
 # Get Helm Charts
-cd /opt/rancher/helm/
+cd ${OPT_RANCHER}/helm/
 
 # Add repos
 helm repo add jetstack https://charts.jetstack.io > /dev/null 2>&1
-helm repo add rancher-$RANCHER_CHANNEL https://releases.rancher.com/server-charts/$RANCHER_CHANNEL > /dev/null 2>&1
+helm repo add rancher-${RANCHER_CHANNEL} https://releases.rancher.com/server-charts/${RANCHER_CHANNEL} > /dev/null 2>&1
 helm repo update > /dev/null 2>&1
 
 # Get charts
-helm pull jetstack/cert-manager --version $CERT_MANAGER_VERSION > /dev/null 2>&1
-if [[ "$RANCHER_CHANNEL" == "latest" ]]; then
-  helm pull rancher-$RANCHER_CHANNEL/rancher --devel > /dev/null 2>&1
-else
-  helm pull rancher-$RANCHER_CHANNEL/rancher > /dev/null 2>&1
-fi
+helm pull jetstack/cert-manager --version ${CERT_MANAGER_VERSION} > /dev/null 2>&1
+[[ "${RANCHER_CHANNEL}" == "latest" ]] && DEVEL="--devel"
+helm pull rancher-${RANCHER_CHANNEL}/rancher ${DEVEL} > /dev/null 2>&1
 
 # Get rancher manager version
-RANCHER_MANAGER_VERSION=$(ls rancher*| cut -d '-' -f '2-3')
-helm pull $ELEMENTAL_REPO/elemental-operator-chart > /dev/null 2>&1
-helm pull $ELEMENTAL_REPO/elemental-operator-crds-chart > /dev/null 2>&1
+RANCHER_MANAGER_VERSION=$(ls rancher* 2>/dev/null | cut -d '-' -f '2-3')
+for i in elemental-operator-chart elemental-operator-crds-chart ; do
+  helm pull ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1
+done
 
 # Temporary thing to get latest version of elemental-teal-iso (very ugly...)
-wget https://raw.githubusercontent.com/fgiudici/elemental-operator/airgap-allow-only-channel-creation/scripts/elemental-airgap.sh
-chmod +x elemental-airgap.sh
-./elemental-airgap.sh -r localhost:5000 -sa $ELEMENTAL_VERSION
+ELEMENTAL_AIRGAP_SCRIPT=elemental-airgap.sh
+curl -sOL https://raw.githubusercontent.com/fgiudici/elemental-operator/airgap-allow-only-channel-creation/scripts/${ELEMENTAL_AIRGAP_SCRIPT}
+sh ${ELEMENTAL_AIRGAP_SCRIPT} -r localhost:5000 -sa ${ELEMENTAL_VERSION}
 
 # Get Images - Rancher/Elemental
-cd /opt/rancher/images/
+cd ${OPT_RANCHER}/images/
 
 # Rancher image list
-curl -#L https://github.com/rancher/rancher/releases/download/v${RANCHER_MANAGER_VERSION%.*}/rancher-images.txt -o rancher/orig_rancher-images.txt
+IMAGES_FILE_TMP=/tmp/rancher-images
+IMAGES_FILE_UNSORTED=/tmp/rancher-images_unsorted
+RANCHER_IMAGES_FILE=rancher/rancher-images.txt
+curl -sL https://github.com/rancher/rancher/releases/download/v${RANCHER_MANAGER_VERSION%.*}/rancher-images.txt -o ${IMAGES_FILE_TMP}
 
 # Shorten rancher list with a sort
 # Fix library tags
-sed -i -e '0,/busybox/s/busybox/library\/busybox/' -e 's/registry/library\/registry/g' rancher/orig_rancher-images.txt
+sed -i -e '0,/busybox/s/busybox/library\/busybox/' -e 's/registry/library\/registry/g' ${IMAGES_FILE_TMP}
 
 # We need to keep the following images
 IMAGES_LIST="mirrored-cluster-api-controller mirrored-pause mirrored-coredns-coredns mirrored-library-traefik"
-for i in $IMAGES_LIST; do
-  IMAGES+="$(grep $i rancher/orig_rancher-images.txt)\n"
+for i in ${IMAGES_LIST}; do
+  IMAGES+="$(grep $i ${IMAGES_FILE_TMP})\n"
 done
 
 # Remove things that are not needed and overlapped
-sed -i -E '/neuvector|minio|gke|aks|eks|sriov|harvester|mirrored|longhorn|thanos|tekton|istio|multus|hyper|jenkins|windows/d' rancher/orig_rancher-images.txt
-echo -e $IMAGES >> rancher/orig_rancher-images.txt
+sed -i -E '/neuvector|minio|gke|aks|eks|sriov|harvester|mirrored|longhorn|thanos|tekton|istio|multus|hyper|jenkins|windows/d' ${IMAGES_FILE_TMP}
+echo -e ${IMAGES} >> ${IMAGES_FILE_TMP}
 
 # Get latest version
-for i in $(cat rancher/orig_rancher-images.txt|awk -F: '{print $1}'); do
-  grep -w $i rancher/orig_rancher-images.txt | sort -Vr| head -1 >> rancher/version_unsorted.txt
+for i in $(awk -F: '{print $1}' ${IMAGES_FILE_TMP}); do
+  grep -w $i ${IMAGES_FILE_TMP} | sort -Vr | head -1 >> ${IMAGES_FILE_UNSORTED}
 done
+
 # Except for rancher/kubectl
-grep 'rancher/kubectl' rancher/orig_rancher-images.txt >> rancher/version_unsorted.txt
-grep "rancher/system-agent-installer-k3s:${K3S_DOWNSTREAM_VERSION%+*}" rancher/orig_rancher-images.txt >> rancher/version_unsorted.txt
+grep 'rancher/kubectl' ${IMAGES_FILE_TMP} >> ${IMAGES_FILE_UNSORTED}
+grep "rancher/system-agent-installer-k3s:${K8S_DOWNSTREAM_VERSION}" ${IMAGES_FILE_TMP} >> ${IMAGES_FILE_UNSORTED}
 
 # Final sort
-cat rancher/version_unsorted.txt | sort -u > rancher/rancher-images.txt
+sort -u ${IMAGES_FILE_UNSORTED} > ${RANCHER_IMAGES_FILE}
 
 # Cert-manager image list
-helm template --kube-version=1.22 /opt/rancher/helm/cert-manager-$CERT_MANAGER_VERSION.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g > cert/cert-manager-images.txt
+CERT_IMAGES_FILE=cert/cert-manager-images.txt
+ELEMENTAL_IMAGES_FILE=elemental/elemental-images.txt
+helm template --kube-version=1.22 ${OPT_RANCHER}/helm/cert-manager-${CERT_MANAGER_VERSION}.tgz \
+  | awk '$1 ~ /image:/ {print $2}' \
+  | sed s/\"//g > ${CERT_IMAGES_FILE}
 
 # Elemental image list
-helm template --kube-version=1.22 /opt/rancher/helm/elemental-operator-chart-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g > elemental/elemental-images.txt
-helm template --kube-version=1.22 /opt/rancher/helm/elemental-operator-chart-*.tgz|grep 'seedimage-builder' | awk '{print $2}' >> elemental/elemental-images.txt
+helm template --kube-version=1.22 ${OPT_RANCHER}/helm/elemental-operator-chart-*.tgz \
+  | awk '$1 ~ /image:/ {print $2}' \
+  | sed s/\"//g > ${ELEMENTAL_IMAGES_FILE}
+helm template --kube-version=1.22 ${OPT_RANCHER}/helm/elemental-operator-chart-*.tgz \
+  | grep 'seedimage-builder' \
+  | awk '{print $2}' >> ${ELEMENTAL_IMAGES_FILE}
 
 # Temporary thing to get latest version of elemental-teal-iso (very ugly...)
-grep 'registry.opensuse.*sle-micro-iso' /opt/rancher/helm/elemental-images.txt >> elemental/elemental-images.txt
+grep 'registry.opensuse.*sle-micro-iso' ${OPT_RANCHER}/helm/elemental-images.txt >> ${ELEMENTAL_IMAGES_FILE}
 
 # Get images
 # Skopeo - cert-manager
-for i in $(cat cert/cert-manager-images.txt); do
-  skopeo copy docker://$i docker-archive:cert/$(echo $i| awk -F/ '{print $3}'|sed 's/:/_/g').tar:$(echo $i| awk -F/ '{print $3}') > /dev/null 2>&1
+for i in $(< ${CERT_IMAGES_FILE}); do
+  VAR=$(awk -F/ '{print $3}' <<< ${i})
+  skopeo copy docker://${i} docker-archive:cert/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Elemental
-for i in $(cat elemental/elemental-images.txt); do
-  if grep 'sle-micro-iso' <<< $i; then
-    skopeo copy docker://$i docker-archive:elemental/$(echo $i| awk -F/ '{print $8"-"$9}'|sed 's/:/_/g').tar:$(echo $i| awk -F/ '{print $8"-"$9}') > /dev/null 2>&1
-  else
-    skopeo copy docker://$i docker-archive:elemental/$(echo $i| awk -F/ '{print $8}'|sed 's/:/_/g').tar:$(echo $i| awk -F/ '{print $8}') > /dev/null 2>&1
-  fi
+for i in $(< ${ELEMENTAL_IMAGES_FILE}); do
+  grep -q 'sle-micro-iso' <<< ${i} \
+    && VALUE="\$8\"-\"\$9" \
+    || VALUE=\$8
+
+  VAR=$(awk -F/ "{print ${VALUE}}" <<< ${i})
+  skopeo copy docker://${i} docker-archive:elemental/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Rancher
-for i in $(cat rancher/rancher-images.txt); do
-  skopeo copy docker://$i docker-archive:rancher/$(echo $i| awk -F/ '{print $2}'|sed 's/:/_/g').tar:$(echo $i| awk -F/ '{print $2}') > /dev/null 2>&1
+for i in $(< ${RANCHER_IMAGES_FILE}); do
+  VAR=$(awk -F/ '{print $2}' <<< ${i})
+  skopeo copy docker://${i} docker-archive:rancher/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Registry
 skopeo copy --additional-tag registry:latest docker://registry:latest docker-archive:registry/registry.tar > /dev/null 2>&1
 
 # Compress all the things
-cd /opt/rancher/
-tar -I zstd -vcf /opt/airgap_rancher.zst $(ls) > /dev/null 2>&1
+cd ${OPT_RANCHER}
+tar -I zstd -vcf ${OPT_RANCHER%/*}/airgap_rancher.zst $(ls 2>/dev/null) > /dev/null 2>&1

--- a/tests/scripts/deploy-airgap
+++ b/tests/scripts/deploy-airgap
@@ -2,15 +2,23 @@
 
 set -e -x
 
+# Variable(s)
 K3S_UPSTREAM_VERSION=$1
 CERT_MANAGER_VERSION=$2
+OPT_RANCHER=/opt/rancher
+
+# Format upstream version
+TMP_UPSTREAM_VERSION=${K3S_UPSTREAM_VERSION/+*}
+K8S_UPSTREAM_VERSION=${TMP_UPSTREAM_VERSION/v}
 
 # Install k3s
-cd /opt/rancher/k3s_$K3S_UPSTREAM_VERSION
-sudo mkdir -p /var/lib/rancher/k3s/agent/images/ /etc/rancher/k3s
-sudo cp k3s-airgap-images-amd64.tar.zst /var/lib/rancher/k3s/agent/images/
-sudo chmod +x k3s install.sh
-sudo cp k3s /usr/local/bin/
+cd ${OPT_RANCHER}/k3s_${K8S_UPSTREAM_VERSION}
+sudo sh -c '
+  mkdir -p /var/lib/rancher/k3s/agent/images /etc/rancher/k3s
+  cp k3s-airgap-images-amd64.tar.zst /var/lib/rancher/k3s/agent/images/
+  chmod +x k3s install.sh
+  cp k3s /usr/local/bin/
+'
 
 # Add registry configuration
 cat <<EOF | sudo tee /etc/rancher/k3s/registries.yaml
@@ -25,17 +33,16 @@ configs:
 EOF
 
 # Pre-load registry image
-rsync -avP /opt/rancher/images/registry/registry.tar /var/lib/rancher/k3s/agent/images/
+rsync -avP ${OPT_RANCHER}/images/registry/registry.tar /var/lib/rancher/k3s/agent/images/
 
 # Install k3s
-INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_VERSION=v$K3S_UPSTREAM_VERSION+k3s1 ./install.sh
+INSTALL_K3S_SKIP_DOWNLOAD=true INSTALL_K3S_VERSION=${K3S_UPSTREAM_VERSION} ./install.sh
 systemctl enable --now k3s
 
+# Wait and add link
 sleep 30
-
-# wait and add link
-echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> ~/.bashrc
-source ~/.bashrc
+mkdir -p ${HOME}/.kube
+ln -s /etc/rancher/k3s/k3s.yaml ${HOME}/.kube/config
 
 # Run local registry
 cat <<EOF | kubectl apply -f -
@@ -71,7 +78,7 @@ spec:
       volumes:
       - name: registry
         hostPath:
-          path: /opt/rancher/registry
+          path: ${OPT_RANCHER}/registry
       hostNetwork: true
 EOF
 
@@ -79,17 +86,12 @@ EOF
 sleep 45
 
 # Load images inside the local registry
-# Elemental
-for file in $(ls /opt/rancher/images/elemental/ | grep -v txt ); do
-  skopeo copy docker-archive:/opt/rancher/images/elemental/$file docker://$(echo $file | sed 's/.tar//g' | awk -F_ '{print "rancher-manager.test:5000/elemental/"$1":"$2}') --dest-tls-verify=false
-done
+IMAGES_PATH=${OPT_RANCHER}/images
 
-# Cert-manager
-for file in $(ls /opt/rancher/images/cert/ | grep -v txt ); do
-  skopeo copy docker-archive:/opt/rancher/images/cert/$file docker://$(echo $file | sed 's/.tar//g' | awk -F_ '{print "rancher-manager.test:5000/cert/"$1":"$2}') --dest-tls-verify=false
-done
-
-# Rancher
-for file in $(ls /opt/rancher/images/rancher/ | grep -v txt ); do
-  skopeo copy docker-archive:/opt/rancher/images/rancher/$file docker://$(echo $file | sed 's/.tar//g' | awk -F_ '{print "rancher-manager.test:5000/rancher/"$1":"$2}') --dest-tls-verify=false
+# Elemental + Cert-Manager + Rancher
+for type in elemental cert rancher; do
+  for file in $(ls ${IMAGES_PATH}/${type} 2>/dev/null | grep -v txt); do
+    VAR=$(awk -F_ "{print \"rancher-manager.test:5000/${type}/\"\$1\":\"\$2}" <<< ${file/.tar})
+    skopeo copy docker-archive:${IMAGES_PATH}/${type}/${file} docker://${VAR} --dest-tls-verify=false
+  done
 done


### PR DESCRIPTION
`build-airgap` script is failing in the [CI](https://github.com/rancher/elemental/actions/runs/7985881557/job/21805211453) (see [debug version](https://github.com/rancher/elemental/actions/runs/7990389548/job/21819166756)), this PR tries to fix it.

Verification run:
- [CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/runs/8018451174) :white_check_mark:
- [CLI-K3s-Airgap-RM_latest_devel](https://github.com/rancher/elemental/actions/runs/8018364412) :white_check_mark:

**Note:** the tests failed because of issue https://github.com/rancher/elemental-operator/issues/627, as "expected". The goal of the PR is to fix the build/deploy air-gapped specific issues. They can also failed because of a sync issue in the elemental operator, but again not related to this PR.