### PR TITLE
Include btrfsprogs in dev image

### DIFF
--- a/Dockerfile.dev.os
+++ b/Dockerfile.dev.os
@@ -45,7 +45,8 @@ RUN ARCH=$(uname -m); \
       iproute2 \
       podman \
       sed \
-      btrfsprogs
+      btrfsprogs \
+      snapper
 
 # elemental-register dependencies
 RUN ARCH=$(uname -m); \

--- a/Dockerfile.dev.os
+++ b/Dockerfile.dev.os
@@ -44,7 +44,8 @@ RUN ARCH=$(uname -m); \
       curl \
       iproute2 \
       podman \
-      sed
+      sed \
+      btrfsprogs
 
 # elemental-register dependencies
 RUN ARCH=$(uname -m); \


### PR DESCRIPTION
Without btrfsprogs `mkfs.btrfs` is not found and we can't install. 
This occurs with dev `elemental-toolkit` since it defaults to btrfs.