### PR TITLE
Include btrfsmaintenance package

### DIFF
--- a/.obs/dockerfile/slem-base-os/Dockerfile
+++ b/.obs/dockerfile/slem-base-os/Dockerfile
@@ -35,6 +35,9 @@ RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y grub
 # make SUSE happy
 RUN zypper --installroot /osimage in --no-recommends -y SLE-Micro-Rancher-release systemd-presets-branding-Elemental
 
+# Full support for btrfs
+RUN zypper --installroot /osimage in --no-recommends -y btrfsmaintenance
+
 # make elemental-register happy
 RUN zypper --installroot /osimage in --no-recommends -y dmidecode lvm2
 

--- a/Dockerfile.dev.os
+++ b/Dockerfile.dev.os
@@ -46,6 +46,7 @@ RUN ARCH=$(uname -m); \
       podman \
       sed \
       btrfsprogs \
+      btrfsmaintenance \
       snapper
 
 # elemental-register dependencies


### PR DESCRIPTION
btrfsmaintenance package is a recommended package by btrfsprogs and actually considered a requirement for any OS installed in a btrfs file system.

Fixes #1233