### PR TITLE
Set transient recovery hostname

### DIFF
--- a/framework/files/system/oem/03_branding.yaml
+++ b/framework/files/system/oem/03_branding.yaml
@@ -3,5 +3,6 @@ stages:
    boot:
     - name: "Recovery"
       if: '[ -f "/run/elemental/recovery_mode" ]'
-      hostname: "recovery"
+      commands:
+        - hostnamectl set-hostname --transient recovery
 


### PR DESCRIPTION
Only setting hostname for recovery using yip overwrites the hostname and uses "recovery" also for active mode.

This commits sets a transient hostname when booting into recovery, hopefully allowing active hostname to not be overwritten.