### PR TITLE
Revert "Run services after time-sync.target"

### DIFF
--- a/framework/files/system/oem/15_timesync.yaml
+++ b/framework/files/system/oem/15_timesync.yaml
@@ -1,9 +1,0 @@
-name: "Enable systemd-time-wait-sync"
-stages:
-   initramfs:
-     - name: "Default systemd config"
-       if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
-       systemctl:
-        enable:
-        - systemd-time-wait-sync
-

--- a/framework/files/usr/lib/systemd/system/elemental-register-install.service
+++ b/framework/files/usr/lib/systemd/system/elemental-register-install.service
@@ -3,8 +3,6 @@ Description=Elemental Register Install
 Documentation=https://elemental.docs.rancher.com
 Wants=network-online.target
 After=network-online.target
-Wants=time-sync.target
-After=time-sync.target
 
 [Service]
 EnvironmentFile=-/etc/default/elemental

--- a/framework/files/usr/lib/systemd/system/elemental-register-reset.service
+++ b/framework/files/usr/lib/systemd/system/elemental-register-reset.service
@@ -3,8 +3,6 @@ Description=Elemental Register Reset
 Documentation=https://elemental.docs.rancher.com
 Wants=network-online.target
 After=network-online.target
-Wants=time-sync.target
-After=time-sync.target
 ConditionPathExists=/run/elemental/recovery_mode
 
 [Service]


### PR DESCRIPTION
This reverts commit d6c0b1cd3bdb0a3f96abe1ff3701aff7d4240f34.

Fixes rancher/elemental-operator#627