### PR TITLE
ci/ui: enable media build select

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -79,16 +79,9 @@ describe('Upgrade tests', () => {
         cy.contains('Target Cluster')
         cy.getBySel('cluster-target')
           .click();
-        // Next if condition will be removed once ui extension 1.3.0 is released
-        if (utils.isUIVersion('stable') || utils.isK8sVersion("rke2")) { 
-          cy.get('#vs5__listbox')
-            .contains(clusterName)
-            .click();
-        } else {
-          cy.get('#vs7__listbox')
-            .contains(clusterName)
-            .click();
-        }
+        cy.get('#vs7__listbox')
+          .contains(clusterName)
+          .click();
         if (utils.isK8sVersion("k3s")) {
           cy.getBySel('upgrade-choice-selector')
             .parent()

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -105,20 +105,17 @@ Cypress.Commands.add('createMachReg', (
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
     
-    // Revert in ui extension, will be needed again soon
-    //if (utils.isUIVersion('stable')) {
-    //  cy.getBySel('select-os-version-build-iso')
-    //    .click();
-    //} else {
-    //  cy.getBySel('select-media-type-build-media')
-    //    .click();
-    //  cy.contains('Iso')
-    //    .click();
-    //  cy.getBySel('select-os-version-build-media')
-    //    .click();
-    //}
-    cy.getBySel('select-os-version-build-media')
-      .click();
+    if (utils.isUIVersion('stable')) {
+      cy.getBySel('select-os-version-build-media')
+        .click();
+    } else {
+      cy.getBySel('select-media-type-build-media')
+        .click();
+      cy.contains('Iso')
+        .click();
+      cy.getBySel('select-os-version-build-media')
+        .click();
+    }
     // Never build from dev ISO in upgrade scenario
     if (utils.isCypressTag('upgrade')) {
       // Stable operator version is hardcoded for now


### PR DESCRIPTION
UI dev team pushed the media build select back so I have to use my older commented code.

https://github.com/rancher/elemental-ui/pull/165

## Verification run
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8020273937/job/21909823462) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8020274654/job/21909823806) ❌ failure not linked to this PR.
UI-K3s-RM_head_2.7 ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/8020277062/job/21909833682) ❌ failure not linked to this PR.