### PR TITLE
ci/ui: add test for dhcp hostname

### DIFF
--- a/tests/assets/machineRegistration-multi.yaml
+++ b/tests/assets/machineRegistration-multi.yaml
@@ -22,4 +22,4 @@ spec:
         poweroff: true
         device: /dev/sda
         debug: true
-  machineName: %VM_NAME%-${System Information/UUID}
+  machineName: ${System Data/Runtime/Hostname}

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -29,6 +29,9 @@ describe('Machine inventory testing', () => {
   const proxy         = "http://172.17.0.1:3128"
   const uiAccount     = Cypress.env('ui_account');
   const uiPassword    = "rancherpassword"
+  let hostname        = ""
+  // Test if machine inventory uses hostname given by DHCP
+  utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('node-001') : hostname=('my-machine');
 
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
@@ -50,7 +53,7 @@ describe('Machine inventory testing', () => {
           .contains('Active')
           .should('exist');
         cy.getBySel('sortable-cell-0-1')
-          .contains('my-machine')
+          .contains(hostname)
           .should('exist');
       })
     );
@@ -58,7 +61,7 @@ describe('Machine inventory testing', () => {
     qase(29,
       it('Check we can see our embedded hardware labels', () => {
         cy.clickNavMenu(["Inventory of Machines"]);
-        cy.contains('my-machine')
+        cy.contains(hostname)
           .click()
         cy.checkMachInvLabel('machine-registration', 'myInvLabel1', 'myInvLabelValue1', true);
         for (const key in hwLabels) {

--- a/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
@@ -15,4 +15,4 @@ config:
       reset-oem: true
       power-off: false
       reboot: true
-machineName: my-machine
+machineName: ${System Data/Runtime/Hostname}


### PR DESCRIPTION
Fix #1204 

Add automated test for https://elemental.docs.rancher.com/next/hostname#keep-the-hostname-assigned-from-dhcp
It will be tested only in the following scenarios:
- UI: `k3s` as kubernetes version and `main` scenario.
- CLI: Multi cluster test

With `machineName: ${System Data/Runtime/Hostname}`:
```
node-001:~ # hostname
node-001
node-001:~ #
```
![image](https://github.com/rancher/elemental/assets/6025636/86bcb094-dbbc-4bcb-8e0e-f488c43a5b54)

## Verification run
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8050974855/job/21987884674) ✅ 
