### PR TITLE
ci: fix backup-restore-operator tests

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -4,7 +4,7 @@ description: 'Add logs and summary for an Elemental E2E test'
 
 # Variables to set when calling this action
 inputs:
-  backup_restore_version:
+  backup_operator_version:
     default: "Unknown"
     type: string
   ca_type:
@@ -146,7 +146,7 @@ runs:
         echo "Elemental ISO image: ${{ inputs.os_to_test }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental OS version: ${{ inputs.os_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental Operator Image: ${{ inputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
-        echo "Elemental Backup/Restore Operator Image: ${{ inputs.backup_restore_version }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "Elemental Backup/Restore Operator Image: ${{ inputs.backup_operator_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental UI Extension Version: ${{ inputs.elemental_ui_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental UI User: ${{ inputs.ui_account }}" >> ${GITHUB_STEP_SUMMARY}
 

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened K3s"
+      backup_restore_version: v3.1.2
       cert-manager_version: v1.11.1
       cluster_name: cluster-k3s
       cluster_type: hardened

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened K3s"
+      backup_restore_version: v4.0.0
       cert-manager_version: v1.11.1
       cluster_name: cluster-k3s
       cluster_type: hardened

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Hardened K3s"
+      backup_restore_version: v5.0.0-rc2
       cert-manager_version: v1.11.1
       cluster_name: cluster-k3s
       cluster_type: hardened

--- a/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
+      backup_restore_version: v3.1.2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
+      backup_restore_version: v4.0.0
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
+      backup_restore_version: v5.0.0-rc2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/cli-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.7.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
+      backup_restore_version: v3.1.2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/cli-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.8.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
+      backup_restore_version: v4.0.0
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/cli-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.9.yaml
@@ -19,6 +19,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
+      backup_restore_version: v5.0.0-rc2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -162,13 +162,15 @@ jobs:
       - name: Install backup-restore components (K3s only for now)
         id: install_backup_restore
         if: ${{ contains(inputs.upstream_cluster_version, 'k3s') }}
+        env:
+          BACKUP_RESTORE_VERSION: ${{ inputs.backup_restore_version }}
         run: cd tests && make e2e-install-backup-restore
 
       - name: Extract component versions/informations
         id: component
         run: |
           # Extract rancher-backup-operator version
-          BACKUP_RESTORE_VERSION=$(kubectl get pod \
+          BACKUP_OPERATOR_VERSION=$(kubectl get pod \
                                      --namespace cattle-resources-system \
                                      -l app.kubernetes.io/name=rancher-backup \
                                      -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
@@ -192,7 +194,7 @@ jobs:
                               -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
 
           # Export values
-          echo "backup_restore_version=${BACKUP_RESTORE_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "backup_operator_version=${BACKUP_OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
           echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
           echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
           echo "rancher_image_version=${RANCHER_VERSION}" >> ${GITHUB_OUTPUT}
@@ -337,13 +339,7 @@ jobs:
       - name: Test Backup/Restore Elemental resources with Rancher Manager
         id: test_backup_restore
         if: ${{ contains(inputs.upstream_cluster_version, 'k3s') }}
-        env:
-          BACKUP_RESTORE_VERSION: ${{ inputs.backup_restore_version }}
-        run: |
-          cd tests && make e2e-backup-restore
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
-            make e2e-check-app
-          fi
+        run: cd tests && make e2e-backup-restore && make e2e-check-app
 
       - name: Extract ISO version
         id: iso_version
@@ -419,7 +415,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/logs-and-summary
         with:
-          backup_restore_version: ${{ steps.component.outputs.backup_restore_version }}
+          backup_operator_version: ${{ steps.component.outputs.backup_operator_version }}
           ca_type: ${{ inputs.ca_type }}
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
           cluster_type: ${{ inputs.cluster_type }}


### PR DESCRIPTION
Rancher Manager HEAD versions need specific versions of the operator to work well. Should fix #1223.

Verification runs:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8051995347) :white_check_mark:
- [CLI-K3s-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/8051985148) :white_check_mark:
- [CLI-K3s-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/8051987042) :white_check_mark:
- [CLI-K3s-RM_head_2.9](https://github.com/rancher/elemental/actions/runs/8051988151) :x:

All tests now use the correct `backup-restore-operator` version but 2.9-HEAD still fails, looks more a Rancher issue and this will be investigated more in another issue/PR.