### PR TITLE
Remove recovery hostname change

### DIFF
--- a/framework/files/system/oem/03_branding.yaml
+++ b/framework/files/system/oem/03_branding.yaml
@@ -1,8 +1,0 @@
-name: "Branding"
-stages:
-   boot:
-    - name: "Recovery"
-      if: '[ -f "/run/elemental/recovery_mode" ]'
-      commands:
-        - hostnamectl set-hostname --transient recovery
-


### PR DESCRIPTION
Even the transient hostname is sticky if not overridden by something else.

Fixes #1242 