### PR TITLE
ci/ui: add workaround for dhcp test

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -31,7 +31,7 @@ describe('Machine inventory testing', () => {
   const uiPassword    = "rancherpassword"
   let hostname        = ""
   // Test if machine inventory uses hostname given by DHCP
-  utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('node-001') : hostname=('my-machine');
+  utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('rancher-') : hostname=('my-machine');
 
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();


### PR DESCRIPTION
In our CI environment, keeping the DHCP hostname means to get a hostname like `rancher-`
We will see later if we have a better test.

[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8063196366/job/22024551737) ✅ 