### PR TITLE
ci: bump ele-testhelpers library

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240227152220-1b9250417c8d
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -146,8 +146,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849 h1:RNHdLRAv57ZylRBl8XKsGpxgue1PAV7JvShYTXqQjJw=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240220161358-9267740af849/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240227152220-1b9250417c8d h1:uWhUciLoSxKDYdW87Ir4BeQQdv7OzeZ74GO+R3gSSDM=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240227152220-1b9250417c8d/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
This is to use the new version of `DeployRancherManager` function.

Verification runs:
- [UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/8067467345) :white_check_mark:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8067468425) :white_check_mark:
- [CLI-K3s-RM_head_2.9](https://github.com/rancher/elemental/actions/runs/8067469565) :x:

**NOTE:** the test on Rancher 2.9-HEAD still fail but seems to be related to Rancher or the backup operator and not Elemental.