### PR TITLE
Revert "ci/ui: add workaround for dhcp test"

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -31,7 +31,7 @@ describe('Machine inventory testing', () => {
   const uiPassword    = "rancherpassword"
   let hostname        = ""
   // Test if machine inventory uses hostname given by DHCP
-  utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('rancher-') : hostname=('my-machine');
+  utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('node-001') : hostname=('my-machine');
 
   beforeEach(() => {
     (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();


### PR DESCRIPTION
Reverts rancher/elemental#1251

We can revert because of this patch https://github.com/rancher/elemental/pull/1249