### PR TITLE
ci: fix airgap scheduled tests

### DIFF
--- a/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
@@ -23,7 +23,5 @@ jobs:
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2
-      os_to_test: dev
       rancher_version: latest/devel
       test_type: airgap
-      upstream_cluster_version: v1.26.10+k3s2

--- a/.github/workflows/cli-k3s-airgap_rm_stable.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_stable.yaml
@@ -8,10 +8,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      operator_repo:
-        description: Operator version to use for initial deployment
-        default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
-        type: string
   schedule:
     - cron: '0 8 * * *'
 
@@ -27,8 +23,4 @@ jobs:
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_version_to_provision: v1.27.10+k3s2
-      operator_repo: ${{ inputs.operator_repo }}
-      os_to_test: dev
-      rancher_version: stable/latest
       test_type: airgap
-      upstream_cluster_version: v1.26.10+k3s2

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -71,7 +71,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: stable/latest/none
+        default: stable/latest
         type: string
       reset:
         description: Allow reset test (mainly used on CLI tests)
@@ -107,7 +107,6 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        #default: v1.27.10+k3s2
         default: v1.26.10+k3s2
         type: string
       zone:

--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -14,9 +14,6 @@ on:
       cluster_namespace:
         required: true
         type: string
-      cluster_type:
-        required: true
-        type: string
       k8s_version_to_provision:
         required: true
         type: string
@@ -62,7 +59,6 @@ jobs:
       CERT_MANAGER_VERSION: ${{ inputs.cert-manager_version }}
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: ${{ inputs.cluster_namespace }}
-      CLUSTER_TYPE: ${{ inputs.cluster_type }}
       # Distribution to use to host Rancher Manager (K3s)
       K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
       # For K8s cluster to provision with Rancher Manager
@@ -158,7 +154,6 @@ jobs:
         with:
           ca_type: ${{ inputs.ca_type }}
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
-          cluster_type: ${{ inputs.cluster_type }}
           k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
           operator_version: ${{ steps.component.outputs.operator_version }}
           os_to_test: ${{ inputs.os_to_test }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -119,7 +119,6 @@ jobs:
       cert-manager_version: ${{ inputs.cert-manager_version }}
       cluster_name: ${{ inputs.cluster_name }}
       cluster_namespace: ${{ inputs.cluster_namespace }}
-      cluster_type: ${{ inputs.cluster_type }}
       k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -62,8 +62,8 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 
 			if testType == "airgap" {
 				airgapImagesFile := os.Getenv("HOME") + "/airgap_rancher/images/elemental/elemental-images.txt"
-				isoVersion, _ := exec.Command("bash", "-c", "awk -F/ '/sle-micro-iso/{print $NF}' "+airgapImagesFile).Output()
-				baseImageURL = "localhost:5000/elemental/sle-micro-iso-" + string(isoVersion)
+				isoVersion, _ := exec.Command("bash", "-c", "awk -F/ '/sle-micro-iso/ {print $NF}' "+airgapImagesFile).Output()
+				baseImageURL = "localhost:5000/elemental/sle-micro-" + string(isoVersion)
 			}
 
 			// Set poweroff to false for master pool to have time to check SeedImage cloud-config

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -141,7 +141,7 @@ RunHelmCmdWithRetry template --kube-version=1.22 ${OPT_RANCHER}/helm/elemental-o
   | grep 'seedimage-builder' \
   | awk '{print $2}' >> ${ELEMENTAL_IMAGES_FILE}
 
-# Temporary thing to get latest version of elemental-teal-iso (very ugly...)
+# Temporary thing to get latest version of sle-micro-iso (very ugly...)
 grep 'registry.opensuse.*sle-micro-iso' ${OPT_RANCHER}/helm/elemental-images.txt >> ${ELEMENTAL_IMAGES_FILE}
 
 # Get images

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -2,7 +2,7 @@
 
 # Build Airgap
 
-set -e -x
+set -x
 
 # Retry helm command in case of sporadic issue
 function RunHelmCmdWithRetry() {
@@ -16,7 +16,22 @@ function RunHelmCmdWithRetry() {
   done
 
   # If we are here then an error happened!
-  return 1
+  exit 1
+}
+
+# Retry skopeo command in case of sporadic issue
+function RunSkopeoCmdWithRetry() {
+  # Wait for a maximum of 1 minute
+  for ((i=0; i<60; i++)); do
+    # If skopeo command is OK then we simply return (exit the function)
+    skopeo $* && return
+
+    # Wait a little
+    sleep 5
+  done
+
+  # If we are here then an error happened!
+  exit 1
 }
 
 # Variable(s)
@@ -148,7 +163,7 @@ grep 'registry.opensuse.*sle-micro-iso' ${OPT_RANCHER}/helm/elemental-images.txt
 # Skopeo - cert-manager
 for i in $(< ${CERT_IMAGES_FILE}); do
   VAR=$(awk -F/ '{print $3}' <<< ${i})
-  skopeo copy docker://${i} docker-archive:cert/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
+  RunSkopeoCmdWithRetry copy docker://${i} docker-archive:cert/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Elemental
@@ -158,17 +173,17 @@ for i in $(< ${ELEMENTAL_IMAGES_FILE}); do
     || VALUE=\$8
 
   VAR=$(awk -F/ "{print ${VALUE}}" <<< ${i})
-  skopeo copy docker://${i} docker-archive:elemental/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
+  RunSkopeoCmdWithRetry copy docker://${i} docker-archive:elemental/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Rancher
 for i in $(< ${RANCHER_IMAGES_FILE}); do
   VAR=$(awk -F/ '{print $2}' <<< ${i})
-  skopeo copy docker://${i} docker-archive:rancher/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
+  RunSkopeoCmdWithRetry copy docker://${i} docker-archive:rancher/${VAR//:/_}.tar:${VAR} > /dev/null 2>&1
 done
 
 # Skopeo - Registry
-skopeo copy --additional-tag registry:latest docker://registry:latest docker-archive:registry/registry.tar > /dev/null 2>&1
+RunSkopeoCmdWithRetry copy --additional-tag registry:latest docker://registry:latest docker-archive:registry/registry.tar > /dev/null 2>&1
 
 # Compress all the things
 cd ${OPT_RANCHER}

--- a/tests/scripts/deploy-airgap
+++ b/tests/scripts/deploy-airgap
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e -x
+# Deploy Airgap
+
+set -x
 
 # Retry skopeo command in case of sporadic issue
 function RunSkopeoCmdWithRetry() {
@@ -14,7 +16,7 @@ function RunSkopeoCmdWithRetry() {
   done
 
   # If we are here then an error happened!
-  return 1
+  exit 1
 }
 
 # Variable(s)
@@ -98,7 +100,7 @@ spec:
 EOF
 
 # Wait for registry to be ready
-sleep 45
+sleep 1m
 
 # Load images inside the local registry
 IMAGES_PATH=${OPT_RANCHER}/images


### PR DESCRIPTION
The scheduled tests cannot be defined with inputs left empty.

Verification run:
- [CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/runs/8112775869)

**NOTE:** the real test will be after merging and scheduled, the VR is only for regression test.