### PR TITLE
Always ensure a Rancher-vWXYZ transient hostname

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -3,11 +3,7 @@ stages:
   initramfs:
     - if: '[ ! -f /run/elemental/recovery_mode ]'
       commands:
-      - |
-        if [ ! -e /run/elemental/persistent/etc/hostname ]; then
-          sysctl kernel.hostname=rancher-${RANDOM}
-        fi
-        ln -sf /run/elemental/persistent/etc/hostname /etc/hostname
+        - ln -sf /run/elemental/persistent/etc/hostname /etc/hostname
     - if: '[ ! -f "/run/elemental/recovery_mode" ]'
       name: "Persist /etc/machine-id"
       commands:

--- a/framework/files/system/oem/03_hostname.yaml
+++ b/framework/files/system/oem/03_hostname.yaml
@@ -1,0 +1,6 @@
+name: "Fallback hostname"
+stages:
+  initramfs:
+    - if: '[ ! -f /etc/hostname ]'
+      commands:
+        - sysctl kernel.hostname=rancher-${RANDOM}


### PR DESCRIPTION
If a static hostname is not available always set a transient hostname in the form "Rancher-VWXYZ". Do that also when in recovery mode.

Fixes: https://github.com/rancher/elemental-operator/issues/646