### PR TITLE
Adding the btrfs default at elemental-operator level

### DIFF
--- a/.obs/specfile/elemental.spec
+++ b/.obs/specfile/elemental.spec
@@ -142,9 +142,6 @@ rm -rf %{buildroot}/usr/libexec/.placeholder
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE
-%dir %{_sysconfdir}/elemental
-%dir %{_sysconfdir}/elemental/config.d
-%config %{_sysconfdir}/elemental/config.d/snapshotter.yaml 
 %dir %{_sysconfdir}/cos
 %config %{_sysconfdir}/cos/bootargs.cfg
 %dir %{_sysconfdir}/dracut.conf.d

--- a/framework/files/etc/elemental/config.d/snapshotter.yaml
+++ b/framework/files/etc/elemental/config.d/snapshotter.yaml
@@ -1,3 +1,0 @@
-snapshotter:
-  type: btrfs
-  max-snaps: 4


### PR DESCRIPTION
Removes the snapshotter default value from the image itself as this default is moved to elemental-operator code in rancher/elemental-operator#651

Part of rancher/elemental#1241