### PR TITLE
ci/airgap: mirror both upstream and downstream K3s

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -19,7 +19,10 @@ inputs:
   elemental_ui_version:
     default: "Unknown"
     type: string
-  k8s_version_to_provision:
+  k8s_downstream_version:
+    default: "Unknown"
+    type: string
+  k8s_upstream_version:
     default: "Unknown"
     type: string
   node_number:
@@ -132,7 +135,9 @@ runs:
 
         # Add summary: Rancher Manager
         echo "### Rancher Manager" >> ${GITHUB_STEP_SUMMARY}
-        echo "Rancher Manager URL: https://${{ inputs.public_fqdn }}/dashboard" >> ${GITHUB_STEP_SUMMARY}
+        if ${{ inputs.public_fqdn != 'Unknown' }}; then
+          echo "Rancher Manager URL: https://${{ inputs.public_fqdn }}/dashboard" >> ${GITHUB_STEP_SUMMARY}
+        fi
         echo "Rancher Manager Image: ${{ inputs.rancher_image_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
         if ${{ inputs.ca_type == 'private' }}; then
@@ -152,8 +157,8 @@ runs:
 
         # Add summary: Kubernetes
         echo "### Kubernetes" >> ${GITHUB_STEP_SUMMARY}
-        echo "K3s on Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
-        echo "K8s version deployed on the cluster(s): ${{ inputs.k8s_version_to_provision }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "K3s on Rancher Manager: ${{ inputs.k8s_upstream_version }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "K8s version deployed on the cluster(s): ${{ inputs.k8s_downstream_version }}" >> ${GITHUB_STEP_SUMMARY}
 
         # Add summary: Cluster
         echo "### Cluster nodes" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_latest_dev.yaml
@@ -22,6 +22,5 @@ jobs:
       cert-manager_version: v1.12.2
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel
       test_type: airgap

--- a/.github/workflows/cli-k3s-airgap_rm_stable.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_stable.yaml
@@ -22,5 +22,5 @@ jobs:
       cert-manager_version: v1.12.2
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
+      k8s_version_to_provision: v1.27.8+k3s2
       test_type: airgap

--- a/.github/workflows/cli-k3s-airgap_rm_stable.yaml
+++ b/.github/workflows/cli-k3s-airgap_rm_stable.yaml
@@ -22,5 +22,4 @@ jobs:
       cert-manager_version: v1.12.2
       cluster_name: airgap-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.8+k3s2
       test_type: airgap

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.7.yaml
@@ -24,7 +24,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.8.yaml
@@ -24,7 +24,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_head_2.9.yaml
@@ -24,7 +24,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-rm_stable.yaml
@@ -23,6 +23,5 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 3
       test_type: cli

--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -23,7 +23,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -35,7 +35,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-multi_cluster-rm_stable.yaml
@@ -28,7 +28,6 @@ jobs:
       cluster_number: 20
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -35,7 +35,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -35,7 +35,6 @@ jobs:
       cluster_name: cluster-k3s
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -21,7 +21,6 @@ jobs:
       test_description: "CI - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -47,7 +47,6 @@ jobs:
       test_description: "Manual - CLI - Parallel - OS Upgrade test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.7.yaml
@@ -22,7 +22,6 @@ jobs:
       backup_restore_version: v3.1.2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.7
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.8.yaml
@@ -22,7 +22,6 @@ jobs:
       backup_restore_version: v4.0.0
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.8
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_head_2.9.yaml
@@ -22,7 +22,6 @@ jobs:
       backup_restore_version: v5.0.0-rc2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.9
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-reset-rm_stable.yaml
@@ -21,6 +21,5 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test + reset with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       reset: true
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.7.yaml
@@ -22,6 +22,5 @@ jobs:
       backup_restore_version: v3.1.2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.8.yaml
@@ -22,6 +22,5 @@ jobs:
       backup_restore_version: v4.0.0
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/cli-k3s-rm_head_2.9.yaml
@@ -22,6 +22,5 @@ jobs:
       backup_restore_version: v5.0.0-rc2
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-k3s-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-rm_stable.yaml
@@ -21,5 +21,4 @@ jobs:
       test_description: "CI - CLI - Parallel - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       test_type: cli

--- a/.github/workflows/cli-k3s-scalability-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-scalability-rm_stable.yaml
@@ -26,7 +26,6 @@ jobs:
       test_description: "CI/Manual - CLI - Scalability - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       node_number: 60
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none

--- a/.github/workflows/cli-k3s-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-sequential-rm_stable.yaml
@@ -25,7 +25,6 @@ jobs:
       test_description: "CI/Manual - CLI - Sequential - Deployment test with Standard K3s"
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+k3s2
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none
       test_type: cli

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -60,7 +60,7 @@ jobs:
       cluster_name: my-own-cluster
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: ${{ inputs.k8s_version }}
+      k8s_downstream_version: ${{ inputs.k8s_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -15,9 +15,9 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      k8s_version:
-        description: Version of K3s/RKE2 to use (for both upstream and downstream clusters)
-        default: v1.27.10+k3s2
+      k8s_downstream_version:
+        description: Rancher cluster downstream version (K3s or RKE2)
+        default: v1.27.8+k3s2
         type: string
       node_number:
         description: Number of nodes (>3) to deploy on the provisioned cluster
@@ -60,7 +60,7 @@ jobs:
       cluster_name: my-own-cluster
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_downstream_version: ${{ inputs.k8s_version }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.7

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
@@ -23,8 +23,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.7
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.8

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
@@ -23,8 +23,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.8
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.9

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
@@ -23,8 +23,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.9
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -23,7 +23,8 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -34,4 +35,3 @@ jobs:
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -23,7 +23,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: hardened
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -36,11 +36,11 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -29,7 +29,7 @@ jobs:
       cluster_number: 10
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -29,9 +29,9 @@ jobs:
       cluster_number: 10
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi
-      upstream_cluster_version: v1.26.10+rke2r2
       zone: us-central1-b

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -36,11 +36,11 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       os_to_test: dev

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -36,7 +36,7 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -36,11 +36,11 @@ jobs:
       cluster_name: cluster-rke2
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       os_to_test: staging
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -22,7 +22,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
@@ -32,4 +33,3 @@ jobs:
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -48,7 +48,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -48,7 +48,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       node_number: 5
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/charts/rancher
       operator_repo: ${{ inputs.operator_repo }}
@@ -59,4 +60,3 @@ jobs:
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sle-micro/sle-micro-container-${{ inputs.slem_version }}:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
@@ -22,8 +22,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       reset: true

--- a/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       reset: true

--- a/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
@@ -22,8 +22,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
@@ -22,8 +22,8 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
       reset: true

--- a/.github/workflows/cli-rke2-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       reset: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_stable.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       reset: true
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.7.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.8.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.9.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.9.yaml
@@ -22,7 +22,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-rm_stable.yaml
@@ -22,6 +22,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/cli-rke2-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-rm_stable.yaml
@@ -22,6 +22,6 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       test_type: cli

--- a/.github/workflows/cli-rke2-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_stable.yaml
@@ -26,7 +26,7 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none

--- a/.github/workflows/cli-rke2-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_stable.yaml
@@ -26,9 +26,9 @@ jobs:
       ca_type: private
       cluster_name: cluster-rke2
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none
       sequential: true
       test_type: cli
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -43,7 +43,7 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version (K3s or RKE2)
-        default: v1.27.10+k3s2
+        default: v1.27.8+k3s2
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version (K3s or RKE2)

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -41,9 +41,13 @@ on:
         description: Choose booting from ISO
         default: false
         type: boolean
-      k8s_version_to_provision:
-        description: Name and version of installed K8s distribution
-        required: true
+      k8s_downstream_version:
+        description: Rancher cluster downstream version (K3s or RKE2)
+        default: v1.27.10+k3s2
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version (K3s or RKE2)
+        default: v1.26.10+k3s2
         type: string
       node_number:
         description: Number of nodes to deploy on the provisioned cluster
@@ -104,10 +108,6 @@ on:
         type: string
       upgrade_type:
         description: Type of upgrade to use for the Elemental OS upgrade
-        type: string
-      upstream_cluster_version:
-        description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.26.10+k3s2
         type: string
       zone:
         description: GCP zone to host the runner
@@ -206,7 +206,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: ${{ inputs.iso_boot }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
       operator_upgrade: ${{ inputs.operator_upgrade }}
@@ -227,7 +227,7 @@ jobs:
       upgrade_image: ${{ inputs.upgrade_image }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upgrade_type: ${{ inputs.upgrade_type }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
 
   clean-and-delete-runner:
     if: ${{ always() }}

--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -14,7 +14,10 @@ on:
       cluster_namespace:
         required: true
         type: string
-      k8s_version_to_provision:
+      k8s_downstream_version:
+        required: true
+        type: string
+      k8s_upstream_version:
         required: true
         type: string
       operator_repo:
@@ -41,9 +44,6 @@ on:
       test_type:
         required: true
         type: string
-      upstream_cluster_version:
-        required: true
-        type: string
 
     # Variables to set when calling this reusable workflow
     secrets:
@@ -60,9 +60,9 @@ jobs:
       CLUSTER_NAME: ${{ inputs.cluster_name }}
       CLUSTER_NS: ${{ inputs.cluster_namespace }}
       # Distribution to use to host Rancher Manager (K3s)
-      K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
+      K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
       # For K8s cluster to provision with Rancher Manager
-      K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision}}
+      K8S_DOWNSTREAM_VERSION: ${{ inputs.k8s_downstream_version}}
       # QASE variables
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
       QASE_PROJECT_CODE: ${{ inputs.qase_project_code }}
@@ -127,7 +127,7 @@ jobs:
           # Export values
           echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
           echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
-          echo "rancher_version=${RANCHER_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "rancher_image_version=${RANCHER_VERSION}" >> ${GITHUB_OUTPUT}
 
       - name: Create ISO image for master pool
         id: create_iso_master
@@ -154,7 +154,8 @@ jobs:
         with:
           ca_type: ${{ inputs.ca_type }}
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
-          k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+          k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
+          k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           operator_version: ${{ steps.component.outputs.operator_version }}
           os_to_test: ${{ inputs.os_to_test }}
           os_version: ${{ steps.iso_version.outputs.os_version }}

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -29,7 +29,10 @@ on:
       iso_boot:
         required: true
         type: boolean
-      k8s_version_to_provision:
+      k8s_downstream_version:
+        required: true
+        type: string
+      k8s_upstream_version:
         required: true
         type: string
       node_number:
@@ -86,9 +89,6 @@ on:
       upgrade_type:
         required: true
         type: string
-      upstream_cluster_version:
-        required: true
-        type: string
 
     # Variables to set when calling this reusable workflow
     secrets:
@@ -111,13 +111,13 @@ jobs:
       QASE_RUN_ID: ${{ inputs.qase_run_id }}
       # K3S / RKE2 flags to use for installation
       INSTALL_K3S_SKIP_ENABLE: true
-      INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
-      INSTALL_RKE2_VERSION: ${{ inputs.upstream_cluster_version }}
+      INSTALL_K3S_VERSION: ${{ inputs.k8s_upstream_version }}
+      INSTALL_RKE2_VERSION: ${{ inputs.k8s_upstream_version }}
       K3S_KUBECONFIG_MODE: 0644
       # Distribution to use to host Rancher Manager (K3s or RKE2)
-      K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
+      K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
       # For K8s cluster to provision with Rancher Manager
-      K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
+      K8S_DOWNSTREAM_VERSION: ${{ inputs.k8s_downstream_version }}
       # For Rancher Manager
       RANCHER_VERSION: ${{ inputs.rancher_version }}
       TEST_TYPE: ${{ inputs.test_type }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Install backup-restore components (K3s only for now)
         id: install_backup_restore
-        if: ${{ contains(inputs.upstream_cluster_version, 'k3s') }}
+        if: ${{ contains(inputs.k8s_upstream_version, 'k3s') }}
         env:
           BACKUP_RESTORE_VERSION: ${{ inputs.backup_restore_version }}
         run: cd tests && make e2e-install-backup-restore
@@ -212,7 +212,7 @@ jobs:
         run: |
           # Only use ISO boot if the upstream cluster is RKE2
           # due to issue with pxe, dhcp traffic
-          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'rke') }}; then
             export ISO_BOOT=true
           fi
           cd tests && make e2e-iso-image
@@ -233,7 +233,7 @@ jobs:
           # Only use ISO boot if the upstream cluster is RKE2
           # due to issue with pxe, dhcp traffic
           # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
-          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'rke') }}; then
             export ISO_BOOT=true
             export VM_MEM=10240
             export VM_CPU=6
@@ -252,7 +252,7 @@ jobs:
 
       - name: Install a simple application
         id: install_simple_app
-        if: ${{ contains(inputs.upstream_cluster_version, 'k3s') }}
+        if: ${{ contains(inputs.k8s_upstream_version, 'k3s') }}
         run: cd tests && make e2e-install-app && make e2e-check-app
 
       - name: Reset a node in the cluster
@@ -262,7 +262,7 @@ jobs:
 
       - name: Check app after reset
         id: check_app
-        if: ${{ inputs.reset == true && contains(inputs.upstream_cluster_version, 'k3s') }}
+        if: ${{ inputs.reset == true && contains(inputs.k8s_upstream_version, 'k3s') }}
         run: cd tests && make e2e-check-app
 
       - name: Upgrade Elemental Operator
@@ -272,7 +272,7 @@ jobs:
           OPERATOR_UPGRADE: ${{ inputs.operator_upgrade }}
         run: |
           cd tests && make e2e-upgrade-operator
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'k3s') }}; then
             make e2e-check-app
           fi
 
@@ -296,7 +296,7 @@ jobs:
           RANCHER_UPGRADE: ${{ inputs.rancher_upgrade }}
         run: |
           cd tests && make e2e-upgrade-rancher-manager
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'k3s') }}; then
             make e2e-check-app
           fi
 
@@ -318,7 +318,7 @@ jobs:
           VM_INDEX: 1
         run: |
           cd tests && make e2e-upgrade-node
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'k3s') }}; then
             make e2e-check-app
           fi
 
@@ -332,13 +332,13 @@ jobs:
           VM_NUMBERS: 3
         run: |
           cd tests && make e2e-upgrade-node
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'k3s') }}; then
             make e2e-check-app
           fi
 
       - name: Test Backup/Restore Elemental resources with Rancher Manager
         id: test_backup_restore
-        if: ${{ contains(inputs.upstream_cluster_version, 'k3s') }}
+        if: ${{ contains(inputs.k8s_upstream_version, 'k3s') }}
         run: cd tests && make e2e-backup-restore && make e2e-check-app
 
       - name: Extract ISO version
@@ -381,7 +381,7 @@ jobs:
           VM_END: ${{ inputs.node_number }}
         run: |
           # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
-          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'rke') }}; then
             export VM_MEM=10240
             export VM_CPU=6
           fi
@@ -397,7 +397,7 @@ jobs:
           fi
 
           # Check the installed application
-          if ${{ contains(inputs.upstream_cluster_version, 'k3s') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'k3s') }}; then
             make e2e-check-app
           fi
 
@@ -419,7 +419,8 @@ jobs:
           ca_type: ${{ inputs.ca_type }}
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
           cluster_type: ${{ inputs.cluster_type }}
-          k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+          k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
+          k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           node_number: ${{ inputs.node_number }}
           operator_upgrade: ${{ steps.operator_upgrade.outputs.operator_upgrade }}
           operator_version: ${{ steps.component.outputs.operator_version }}

--- a/.github/workflows/sub_multi.yaml
+++ b/.github/workflows/sub_multi.yaml
@@ -26,7 +26,10 @@ on:
       iso_boot:
         required: true
         type: boolean
-      k8s_version_to_provision:
+      k8s_downstream_version:
+        required: true
+        type: string
+      k8s_upstream_version:
         required: true
         type: string
       operator_repo:
@@ -56,9 +59,6 @@ on:
       test_type:
         required: true
         type: string
-      upstream_cluster_version:
-        required: true
-        type: string
 
     # Variables to set when calling this reusable workflow
     secrets:
@@ -81,13 +81,13 @@ jobs:
       QASE_RUN_ID: ${{ inputs.qase_run_id }}
       # K3S / RKE2 flags to use for installation
       INSTALL_K3S_SKIP_ENABLE: true
-      INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
-      INSTALL_RKE2_VERSION: ${{ inputs.upstream_cluster_version }}
+      INSTALL_K3S_VERSION: ${{ inputs.k8s_upstream_version }}
+      INSTALL_RKE2_VERSION: ${{ inputs.k8s_upstream_version }}
       K3S_KUBECONFIG_MODE: 0644
       # Distribution to use to host Rancher Manager (K3s or RKE2)
-      K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
+      K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
       # For K8s cluster to provision with Rancher Manager
-      K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
+      K8S_DOWNSTREAM_VERSION: ${{ inputs.k8s_downstream_version }}
       # For Rancher Manager
       RANCHER_VERSION: ${{ inputs.rancher_version }}
       TEST_TYPE: ${{ inputs.test_type }}
@@ -152,7 +152,7 @@ jobs:
           ISO_BOOT: ${{ inputs.iso_boot }}
         run: |
           # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
-          if ${{ contains(inputs.upstream_cluster_version, 'rke') }}; then
+          if ${{ contains(inputs.k8s_upstream_version, 'rke') }}; then
             export VM_MEM=10240
             export VM_CPU=6
           fi
@@ -184,7 +184,8 @@ jobs:
           ca_type: ${{ inputs.ca_type }}
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
           cluster_type: ${{ inputs.cluster_type }}
-          k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+          k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
+          k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           operator_version: ${{ steps.component.outputs.operator_version }}
           os_version: ${{ steps.iso_version.outputs.os_version }}
           public_fqdn: ${{ inputs.public_fqdn }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -38,7 +38,10 @@ on:
       iso_boot:
         required: true
         type: boolean
-      k8s_version_to_provision:
+      k8s_downstream_version:
+        required: true
+        type: string
+      k8s_upstream_version:
         required: true
         type: string
       node_number:
@@ -101,9 +104,6 @@ on:
       upgrade_type:
         required: true
         type: string
-      upstream_cluster_version:
-        required: true
-        type: string
 
     # Secrets to set when calling this reusable workflow
     secrets:
@@ -119,7 +119,7 @@ jobs:
       cert-manager_version: ${{ inputs.cert-manager_version }}
       cluster_name: ${{ inputs.cluster_name }}
       cluster_namespace: ${{ inputs.cluster_namespace }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}
       qase_project_code: ${{ inputs.qase_project_code }}
@@ -128,7 +128,7 @@ jobs:
       runner_label: ${{ inputs.runner_label }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
 
   cli:
     if: ${{ inputs.test_type == 'cli' }}
@@ -144,7 +144,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       iso_boot: ${{ inputs.iso_boot }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}
       operator_upgrade: ${{ inputs.operator_upgrade }}
@@ -163,7 +163,7 @@ jobs:
       upgrade_image: ${{ inputs.upgrade_image }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
       upgrade_type: ${{ inputs.upgrade_type }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
 
   multi:
     if: ${{ inputs.test_type == 'multi' }}
@@ -178,7 +178,7 @@ jobs:
       cluster_number: ${{ inputs.cluster_number }}
       cluster_type: ${{ inputs.cluster_type }}
       iso_boot: ${{ inputs.iso_boot }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       public_domain: ${{ inputs.public_domain }}
       public_fqdn: ${{ inputs.public_fqdn }}
@@ -188,7 +188,7 @@ jobs:
       runner_label: ${{ inputs.runner_label }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
 
   ui:
     if: ${{ inputs.test_type == 'ui' }}
@@ -204,7 +204,7 @@ jobs:
       cypress_tags: ${{ inputs.cypress_tags }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: ${{ inputs.iso_boot }}
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       public_domain: ${{ inputs.public_domain }}
@@ -217,4 +217,4 @@ jobs:
       ui_account: ${{ inputs.ui_account }}
       upgrade_image: ${{ inputs.upgrade_image }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-      upstream_cluster_version: ${{ inputs.upstream_cluster_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -29,7 +29,10 @@ on:
       iso_boot:
         required: true
         type: boolean
-      k8s_version_to_provision:
+      k8s_downstream_version:
+        required: true
+        type: string
+      k8s_upstream_version:
         required: true
         type: string
       operator_repo:
@@ -68,9 +71,6 @@ on:
       upgrade_os_channel:
         required: true
         type: string
-      upstream_cluster_version:
-        required: true
-        type: string
 
     # Variables to set when calling this reusable workflow
     secrets:
@@ -93,13 +93,13 @@ jobs:
       QASE_REPORT: 1
       # K3S / RKE2 flags to use for installation
       INSTALL_K3S_SKIP_ENABLE: true
-      INSTALL_K3S_VERSION: ${{ inputs.upstream_cluster_version }}
-      INSTALL_RKE2_VERSION: ${{ inputs.upstream_cluster_version }}
+      INSTALL_K3S_VERSION: ${{ inputs.k8s_upstream_version }}
+      INSTALL_RKE2_VERSION: ${{ inputs.k8s_upstream_version }}
       K3S_KUBECONFIG_MODE: 0644
       # Distribution to use to host Rancher Manager (K3s or RKE2)
-      K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
+      K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
       # For K8s cluster to provision with Rancher Manager
-      K8S_VERSION_TO_PROVISION: ${{ inputs.k8s_version_to_provision }}
+      K8S_DOWNSTREAM_VERSION: ${{ inputs.k8s_downstream_version }}
     steps:
       - name: Checkout
         id: checkout
@@ -175,7 +175,7 @@ jobs:
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           ISO_BOOT: ${{ inputs.iso_boot }}
-          K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
+          K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           RANCHER_VERSION: ${{ steps.component.outputs.rancher_image_version }}
           RANCHER_PASSWORD: rancherpassword
@@ -303,7 +303,8 @@ jobs:
           cert_manager_version: ${{ steps.component.outputs.cert_manager_version }}
           cluster_type: ${{ inputs.cluster_type }}
           elemental_ui_version: ${{ inputs.elemental_ui_version }}
-          k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+          k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
+          k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           node_number: ${{ inputs.node_number }}
           operator_version: ${{ steps.component.outputs.operator_version }}
           os_version: ${{ steps.iso_version.outputs.os_version }}

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -39,7 +39,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.suse.com/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -35,7 +35,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -35,7 +35,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -38,7 +38,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -38,7 +38,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
@@ -38,7 +38,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -31,7 +31,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -39,7 +39,6 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: stable
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-k3s-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.7.yaml
@@ -32,7 +32,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.8.yaml
@@ -32,7 +32,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-rm_head_2.9.yaml
@@ -32,7 +32,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-k3s-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-rm_stable.yaml
@@ -32,7 +32,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+k3s2
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -15,7 +15,7 @@ on:
         description: Elemental UI version to use
         default: dev
         type: string
-      k8s_version_to_provision:
+      k8s_downstream_version:
         description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
         default: v1.27.10+k3s2
         type: string
@@ -49,7 +49,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: ${{ inputs.k8s_version_to_provision }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -16,8 +16,8 @@ on:
         default: dev
         type: string
       k8s_downstream_version:
-        description: Version of K8s to deploy on the cluster (only K3s or RKE2 are supported)
-        default: v1.27.10+k3s2
+        description: Rancher cluster downstream version (K3s or RKE2)
+        default: v1.27.8+k3s2
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -36,10 +36,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       ui_account: user
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.suse.com/rancher
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -32,10 +32,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       ui_account: user
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -32,10 +32,10 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       ui_account: user
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -32,7 +32,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -36,9 +36,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -36,9 +36,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
@@ -36,9 +36,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
@@ -36,7 +36,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -37,9 +37,9 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
       upgrade_os_channel: dev
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -37,7 +37,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -39,7 +39,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -39,11 +39,11 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
       ui_account: user
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.7.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.7.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.8.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.8.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.9.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui

--- a/.github/workflows/ui-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-rm_head_2.9.yaml
@@ -30,7 +30,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-rm_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_version_to_provision: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upstream_cluster_version: v1.26.10+rke2r2

--- a/.github/workflows/ui-rke2-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-rm_stable.yaml
@@ -33,7 +33,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       elemental_ui_version: dev
       iso_boot: true
-      k8s_downstream_version: v1.27.10+rke2r1
+      k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Elemental
 
-[![Code style](https://github.com/rancher/elemental/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/lint.yaml)
+[![Lint](https://github.com/rancher/elemental/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/lint.yaml)
+
+## Regular tests
 
 | Rancher stable (night) | Rancher head 2.7 (8am) | Rancher head 2.8 (9am) | Rancher head 2.9 (10am) |
 | - | - | - | - |
@@ -24,8 +26,13 @@
 | [![UI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_stable.yaml) | [![UI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml) | [![UI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml) | [![UI-K3s-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml)
 | [![UI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_stable.yaml) | [![UI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml) | [![UI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml) | [![UI-RKE2-OS-Upgrade](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml)
 
-## Airgap test
-[![CLI-K3s-Airgap-RM_latest](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml) [![CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml)
+## Airgap tests
+
+[![CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml) (Tested ith Rancher stable)
+
+[![CLI-K3s-Airgap-RM_latest_devel](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml) (Tested with Rancher latest RC)
+
+## Goal
 
 Elemental is a software stack enabling a centralized, full cloud-native OS management solution with Kubernetes.
 
@@ -34,3 +41,19 @@ Cluster Node OSes are built and maintained via container images through the [Ele
 The [Elemental Operator](https://github.com/rancher/elemental-operator) and the [Rancher System Agent](https://github.com/rancher/system-agent) enable Rancher Manager to fully control Elemental clusters, from the installation and management of the OS on the Nodes to the provisioning of new K3s or RKE2 clusters in a centralized way.
 
 Follow our [Quickstart](https://rancher.github.io/elemental/quickstart/) or see the [full docs](https://rancher.github.io/elemental/) for more info.
+
+## License
+
+Copyright (c) 2020-2024 [SUSE, LLC](http://suse.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -20,16 +20,16 @@ import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 Cypress.config();
 describe('Machine inventory testing', () => {
-  const elementalUser = "elemental-user"
-  const hwLabels      = ["TotalCPUThread", "TotalMemory", "CPUModel",
-                        "CPUVendor", "NumberBlockDevices", "NumberNetInterface",
-                        "CPUVendorTotalCPUCores"]
-  const k8sVersion    = Cypress.env('k8s_version');
-  const clusterName   = "mycluster"
-  const proxy         = "http://172.17.0.1:3128"
-  const uiAccount     = Cypress.env('ui_account');
-  const uiPassword    = "rancherpassword"
-  let hostname        = ""
+  const elementalUser        = "elemental-user"
+  const hwLabels             = ["TotalCPUThread", "TotalMemory", "CPUModel",
+                               "CPUVendor", "NumberBlockDevices", "NumberNetInterface",
+                               "CPUVendorTotalCPUCores"]
+  const k8sDownstreamVersion = Cypress.env('k8s_downstream_version');
+  const clusterName          = "mycluster"
+  const proxy                = "http://172.17.0.1:3128"
+  const uiAccount            = Cypress.env('ui_account');
+  const uiPassword           = "rancherpassword"
+  let hostname               = ""
   // Test if machine inventory uses hostname given by DHCP
   utils.isK8sVersion("k3s") && utils.isCypressTag("main") ? hostname=('node-001') : hostname=('my-machine');
 
@@ -84,7 +84,7 @@ describe('Machine inventory testing', () => {
   filterTests(['main', 'upgrade'], () => {
     qase(30,
       it('Create Elemental cluster', () => {
-        utils.createCluster(clusterName, k8sVersion, proxy);
+        utils.createCluster(clusterName, k8sDownstreamVersion, proxy);
       })
     );
   });

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -21,12 +21,12 @@ import { qase } from 'cypress-qase-reporter/dist/mocha';
 filterTests(['main'], () => {
   Cypress.config();
   describe('Reset testing', () => {
-    const clusterName   = "mycluster"
-    const elementalUser = "elemental-user"
-    const k8sVersion    = Cypress.env('k8s_version');
-    const proxy         = "http://172.17.0.1:3128" 
-    const uiAccount     = Cypress.env('ui_account');
-    const uiPassword    = "rancherpassword"
+    const clusterName          = "mycluster"
+    const elementalUser        = "elemental-user"
+    const k8sDownstreamVersion = Cypress.env('k8s_downstream_version');
+    const proxy                = "http://172.17.0.1:3128" 
+    const uiAccount            = Cypress.env('ui_account');
+    const uiPassword           = "rancherpassword"
   
     beforeEach(() => {
       (uiAccount == "user") ? cy.login(elementalUser, uiPassword) : cy.login();
@@ -69,7 +69,7 @@ filterTests(['main'], () => {
 
     qase(30,
       it('Create Elemental cluster', () => {
-        utils.createCluster(clusterName, k8sVersion, proxy);
+        utils.createCluster(clusterName, k8sDownstreamVersion, proxy);
       }));
   });
 });

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -28,22 +28,22 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   const { isFileExist, findFiles } = require('cy-verify-downloads');
   on('task', { isFileExist, findFiles })
 
-  config.baseUrl                  = url.replace(/\/$/, );
-  config.env.cache_session        = process.env.CACHE_SESSION || false;
-  config.env.chartmuseum_repo     = process.env.CHARTMUSEUM_REPO;
-  config.env.cluster              = process.env.CLUSTER_NAME;
-  config.env.cypress_tags         = process.env.CYPRESS_TAGS;
-  config.env.elemental_ui_version = process.env.ELEMENTAL_UI_VERSION;
-  config.env.k8s_version          = process.env.K8S_VERSION_TO_PROVISION;
-  config.env.operator_repo        = process.env.OPERATOR_REPO;
-  config.env.password             = process.env.RANCHER_PASSWORD;
-  config.env.proxy_ip             = process.env.PROXY_IP;
-  config.env.proxy                = process.env.PROXY;
-  config.env.rancher_version      = process.env.RANCHER_VERSION;
-  config.env.ui_account           = process.env.UI_ACCOUNT;
-  config.env.upgrade_image        = process.env.UPGRADE_IMAGE;
-  config.env.upgrade_os_channel   = process.env.UPGRADE_OS_CHANNEL;
-  config.env.username             = process.env.RANCHER_USER;
+  config.baseUrl                    = url.replace(/\/$/, );
+  config.env.cache_session          = process.env.CACHE_SESSION || false;
+  config.env.chartmuseum_repo       = process.env.CHARTMUSEUM_REPO;
+  config.env.cluster                = process.env.CLUSTER_NAME;
+  config.env.cypress_tags           = process.env.CYPRESS_TAGS;
+  config.env.elemental_ui_version   = process.env.ELEMENTAL_UI_VERSION;
+  config.env.k8s_downstream_version = process.env.K8S_DOWNSTREAM_VERSION;
+  config.env.operator_repo          = process.env.OPERATOR_REPO;
+  config.env.password               = process.env.RANCHER_PASSWORD;
+  config.env.proxy_ip               = process.env.PROXY_IP;
+  config.env.proxy                  = process.env.PROXY;
+  config.env.rancher_version        = process.env.RANCHER_VERSION;
+  config.env.ui_account             = process.env.UI_ACCOUNT;
+  config.env.upgrade_image          = process.env.UPGRADE_IMAGE;
+  config.env.upgrade_os_channel     = process.env.UPGRADE_OS_CHANNEL;
+  config.env.username               = process.env.RANCHER_USER;
 
   return config;
 };

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -9,7 +9,7 @@ export const isCypressTag = (tag: string) => {
 // Check the K8s version
 export const isK8sVersion = (version: string) => {
   version = version.toLowerCase();
-  return (new RegExp(version)).test(Cypress.env("k8s_version"));
+  return (new RegExp(version)).test(Cypress.env("k8s_downstream_version"));
 }
 
 // Check the Elemental operator version
@@ -47,7 +47,7 @@ export const createCluster = (clusterName: string, k8sVersion: string, proxy: st
   cy.contains(k8sVersion)
     .click();
   // Configure proxy if proxy is set to elemental
-  if ( Cypress.env('proxy') == "elemental") {
+  if (Cypress.env('proxy') == "elemental") {
     cy.contains('Agent Environment Vars')
       .click();
     cy.get('#agentEnv > .key-value')

--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -30,8 +30,8 @@ import (
 var _ = Describe("E2E - Build the airgap archive", Label("prepare-archive"), func() {
 	It("Execute the script to build the archive", func() {
 		// Could be useful for manual debugging!
-		GinkgoWriter.Printf("Executed command: %s %s %s %s %s %s\n", airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sVersion, operatorRepo)
-		out, err := exec.Command(airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sVersion, operatorRepo).CombinedOutput()
+		GinkgoWriter.Printf("Executed command: %s %s %s %s %s %s\n", airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sDownstreamVersion, operatorRepo)
+		out, err := exec.Command(airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sDownstreamVersion, operatorRepo).CombinedOutput()
 		Expect(err).To(Not(HaveOccurred()), string(out))
 	})
 })

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -280,7 +280,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					defer wg.Done()
 					defer GinkgoRecover()
 
-					if strings.Contains(k8sVersion, "rke2") {
+					if strings.Contains(k8sDownstreamVersion, "rke2") {
 						By("Configuring kubectl command on node "+h, func() {
 							dir := "/var/lib/rancher/rke2/bin"
 							kubeCfg := "export KUBECONFIG=/etc/rancher/rke2/rke2.yaml"
@@ -299,7 +299,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 						Eventually(func() string {
 							out, _ := cl.RunSSH("kubectl version 2>/dev/null | grep 'Server Version:'")
 							return out
-						}, tools.SetTimeout(5*time.Minute), 5*time.Second).Should(ContainSubstring(k8sVersion))
+						}, tools.SetTimeout(5*time.Minute), 5*time.Second).Should(ContainSubstring(k8sDownstreamVersion))
 					})
 
 					By("Checking cluster agent on "+h, func() {

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -44,7 +44,7 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 			},
 			{
 				key:   "%K8S_VERSION%",
-				value: k8sVersion,
+				value: k8sDownstreamVersion,
 			},
 		}
 

--- a/tests/e2e/multi-cluster_test.go
+++ b/tests/e2e/multi-cluster_test.go
@@ -51,7 +51,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 		basePatterns = []pattern{
 			{
 				key:   "%K8S_VERSION%",
-				value: k8sVersion,
+				value: k8sDownstreamVersion,
 			},
 			{
 				key:   "%PASSWORD%",

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -69,7 +69,7 @@ var (
 	rancherHostname           string
 	isoBoot                   bool
 	k8sUpstreamVersion        string
-	k8sVersion                string
+	k8sDownstreamVersion      string
 	numberOfClusters          int
 	numberOfVMs               int
 	operatorUpgrade           string
@@ -409,8 +409,8 @@ var _ = BeforeSuite(func() {
 	rancherHostname = os.Getenv("PUBLIC_FQDN")
 	index := os.Getenv("VM_INDEX")
 	isoBootString := os.Getenv("ISO_BOOT")
+	k8sDownstreamVersion = os.Getenv("K8S_DOWNSTREAM_VERSION")
 	k8sUpstreamVersion = os.Getenv("K8S_UPSTREAM_VERSION")
-	k8sVersion = os.Getenv("K8S_VERSION_TO_PROVISION")
 	number := os.Getenv("VM_NUMBERS")
 	clusterNumber := os.Getenv("CLUSTER_NUMBER")
 	operatorUpgrade = os.Getenv("OPERATOR_UPGRADE")

--- a/tests/manifests/elemental-dev-example.yaml
+++ b/tests/manifests/elemental-dev-example.yaml
@@ -44,7 +44,7 @@ spec:
       configs:
         "172.18.0.2:30000":
           insecureSkipVerify: true    
-  kubernetesVersion: v1.27.10+k3s1
+  kubernetesVersion: v1.27.8+k3s2
 ---
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineRegistration

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -45,10 +45,10 @@ OPT_RANCHER=${HOME}/airgap_rancher
 
 # Set Elemental version
 case ${ELEMENTAL_REPO} in
-  *dev*)
+  */dev/*)
     ELEMENTAL_VERSION=dev
     ;;
-  *staging*)
+  */staging/*)
     ELEMENTAL_VERSION=staging
     ;;
   *)
@@ -56,13 +56,14 @@ case ${ELEMENTAL_REPO} in
     ;;
 esac
 
-# Format upstream version
-TMP_UPSTREAM_VERSION=${K3S_UPSTREAM_VERSION/+*}
-K8S_UPSTREAM_VERSION=${TMP_UPSTREAM_VERSION/v}
+# Format K8s version
+TMP_VER=${K3S_UPSTREAM_VERSION/+*}
+K8S_UPSTREAM_VERSION=${TMP_VER/v}
+TMP_VER=${K3S_DOWNSTREAM_VERSION/+*}
+K8S_DOWNSTREAM_VERSION=${TMP_VER/v}
 
 # Create directories
-mkdir -p ${OPT_RANCHER}/{k3s_${K8S_UPSTREAM_VERSION},helm} ${OPT_RANCHER}/images/{cert,rancher,registry,elemental}
-cd ${OPT_RANCHER}/k3s_${K8S_UPSTREAM_VERSION}/
+mkdir -p ${OPT_RANCHER}/{k3s_${K8S_UPSTREAM_VERSION},k3s_${K8S_DOWNSTREAM_VERSION},helm} ${OPT_RANCHER}/images/{cert,rancher,registry,elemental}
 
 # Install packages
 sudo zypper --no-refresh -n in skopeo yq
@@ -71,16 +72,18 @@ sudo zypper --no-refresh -n in skopeo yq
 sudo sh -c 'echo "192.168.122.102 rancher-manager.test" >> /etc/hosts'
 
 # Download k3s and rancher
-K3S_URL=https://github.com/k3s-io/k3s/releases/download/${K3S_UPSTREAM_VERSION}
-for i in k3s-airgap-images-amd64.tar.zst k3s; do
-  curl -sOL ${K3S_URL}/${i}
+for k8s_ver in ${K3S_UPSTREAM_VERSION}:${K8S_UPSTREAM_VERSION} ${K3S_DOWNSTREAM_VERSION}:${K8S_DOWNSTREAM_VERSION}; do
+  K3S_URL=https://github.com/k3s-io/k3s/releases/download/${k8s_ver%:*}
+  for i in k3s-airgap-images-amd64.tar.zst k3s; do
+    curl -sL ${K3S_URL}/${i} -o ${OPT_RANCHER}/k3s_${k8s_ver#*:}/${i}
+
+    # Get the install script
+    curl -sfL https://get.k3s.io -o ${OPT_RANCHER}/k3s_${k8s_ver#*:}/install.sh
+
+    # Get the airgap deploy script
+    cp ${DEPLOY_AIRGAP_SCRIPT} ${OPT_RANCHER}/k3s_${k8s_ver#*:}
+  done
 done
-
-# Get the install script
-curl -sfL https://get.k3s.io -o install.sh
-
-# Get the airgap deploy script
-cp ${DEPLOY_AIRGAP_SCRIPT} .
 
 # Get Helm Charts
 cd ${OPT_RANCHER}/helm/
@@ -94,17 +97,18 @@ RunHelmCmdWithRetry repo update > /dev/null 2>&1
 RunHelmCmdWithRetry pull jetstack/cert-manager --version ${CERT_MANAGER_VERSION} > /dev/null 2>&1
 [[ "${RANCHER_CHANNEL}" == "latest" ]] && DEVEL="--devel"
 RunHelmCmdWithRetry pull rancher-${RANCHER_CHANNEL}/rancher ${DEVEL} > /dev/null 2>&1
-
-# Get rancher manager version
-RANCHER_MANAGER_VERSION=$(ls rancher* 2>/dev/null | cut -d '-' -f '2-3')
 for i in elemental-operator-chart elemental-operator-crds-chart ; do
   RunHelmCmdWithRetry pull ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1
 done
 
-# Temporary thing to get latest version of elemental-teal-iso (very ugly...)
+# Get rancher manager version
+RANCHER_MANAGER_VERSION=$(ls rancher* 2>/dev/null | cut -d '-' -f '2-3')
+
+# Temporary thing to get latest version of sle-micro-iso (very ugly...)
+ELEMENTAL_AIRGAP_REPO=https://raw.githubusercontent.com/rancher/elemental-operator/main/scripts
 ELEMENTAL_AIRGAP_SCRIPT=elemental-airgap.sh
-curl -sOL https://raw.githubusercontent.com/fgiudici/elemental-operator/airgap-allow-only-channel-creation/scripts/${ELEMENTAL_AIRGAP_SCRIPT}
-sh ${ELEMENTAL_AIRGAP_SCRIPT} -r localhost:5000 -sa ${ELEMENTAL_VERSION}
+curl -sOL ${ELEMENTAL_AIRGAP_REPO}/${ELEMENTAL_AIRGAP_SCRIPT}
+bash ${ELEMENTAL_AIRGAP_SCRIPT} -d -r localhost:5000 -sa ${ELEMENTAL_VERSION}
 
 # Get Images - Rancher/Elemental
 cd ${OPT_RANCHER}/images/
@@ -136,7 +140,9 @@ done
 
 # Except for rancher/kubectl
 grep 'rancher/kubectl' ${IMAGES_FILE_TMP} >> ${IMAGES_FILE_UNSORTED}
-grep "rancher/system-agent-installer-k3s:${K8S_DOWNSTREAM_VERSION}" ${IMAGES_FILE_TMP} >> ${IMAGES_FILE_UNSORTED}
+for k8s_ver in ${K8S_UPSTREAM_VERSION} ${K8S_DOWNSTREAM_VERSION}; do
+  grep "rancher/system-agent-installer-k3s:v${k8s_ver}" ${IMAGES_FILE_TMP} >> ${IMAGES_FILE_UNSORTED}
+done
 
 # Final sort
 sort -u ${IMAGES_FILE_UNSORTED} > ${RANCHER_IMAGES_FILE}

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -16,27 +16,27 @@ pushd cypress/latest
 npm install
 
 # Start Cypress tests with docker
-docker run -v $PWD:/workdir -w /workdir                     \
-    -e CYPRESS_TAGS=$CYPRESS_TAGS                           \
-    -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION           \
-    -e CHARTMUSEUM_REPO=$CHARTMUSEUM_REPO                   \
-    -e K8S_UPSTREAM_VERSION=$K8S_UPSTREAM_VERSION           \
-    -e K8S_VERSION_TO_PROVISION=$K8S_VERSION_TO_PROVISION   \
-    -e OPERATOR_REPO=$OPERATOR_REPO                         \
-    -e PROXY=$PROXY                                         \
-    -e QASE_API_TOKEN=$QASE_API_TOKEN                       \
-    -e QASE_REPORT=$QASE_REPORT                             \
-    -e QASE_RUN_ID=$QASE_RUN_ID                             \
-    -e RANCHER_VERSION=$RANCHER_VERSION                     \
-    -e RANCHER_PASSWORD=$RANCHER_PASSWORD                   \
-    -e RANCHER_URL=$RANCHER_URL                             \
-    -e RANCHER_USER=$RANCHER_USER                           \
-    -e UI_ACCOUNT=$UI_ACCOUNT                               \
-    -e UPGRADE_IMAGE=$UPGRADE_IMAGE                         \
-    -e UPGRADE_OS_CHANNEL=$UPGRADE_OS_CHANNEL               \
-    --add-host host.docker.internal:host-gateway            \
-    --ipc=host                                              \
-    $CYPRESS_DOCKER                                         \
+docker run -v $PWD:/workdir -w /workdir               \
+    -e CYPRESS_TAGS=$CYPRESS_TAGS                     \
+    -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION     \
+    -e CHARTMUSEUM_REPO=$CHARTMUSEUM_REPO             \
+    -e K8S_UPSTREAM_VERSION=$K8S_UPSTREAM_VERSION     \
+    -e K8S_DOWNSTREAM_VERSION=$K8S_DOWNSTREAM_VERSION \
+    -e OPERATOR_REPO=$OPERATOR_REPO                   \
+    -e PROXY=$PROXY                                   \
+    -e QASE_API_TOKEN=$QASE_API_TOKEN                 \
+    -e QASE_REPORT=$QASE_REPORT                       \
+    -e QASE_RUN_ID=$QASE_RUN_ID                       \
+    -e RANCHER_VERSION=$RANCHER_VERSION               \
+    -e RANCHER_PASSWORD=$RANCHER_PASSWORD             \
+    -e RANCHER_URL=$RANCHER_URL                       \
+    -e RANCHER_USER=$RANCHER_USER                     \
+    -e UI_ACCOUNT=$UI_ACCOUNT                         \
+    -e UPGRADE_IMAGE=$UPGRADE_IMAGE                   \
+    -e UPGRADE_OS_CHANNEL=$UPGRADE_OS_CHANNEL         \
+    --add-host host.docker.internal:host-gateway      \
+    --ipc=host                                        \
+    $CYPRESS_DOCKER                                   \
     -s $SPEC
 
 [[ -d downloads ]] && sudo chown -R gh-runner:users downloads videos


### PR DESCRIPTION
Upstream and downstream cluster versions' of K3s need both to be mirrored. Also the `rancher/system-agent-installer-k3s` latest version is `v1.27.8-k3s2`, not `v1.27.10-k3s2`.

Verification runs:
- [CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/runs/8156941753)
- [CLI-K3s-Airgap-RM_latest_devel](https://github.com/rancher/elemental/actions/runs/8155609068)

Regression runs:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8145759468)
- [UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8155546082)
- [UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/8155548172)