### PR TITLE
ci/ui: update operator workaround in ui deployment

### DIFF
--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -66,7 +66,7 @@ export class Elemental {
     cy.contains('.outer-container > .header', 'Elemental');
     cy.clickButton('Next');
     // Workaround for https://github.com/rancher/rancher/issues/43379
-    if (isCypressTag('upgrade') && !isRancherManagerVersion('2.7')) {
+    if (isCypressTag('upgrade') && !isRancherManagerVersion('head')) {
       cy.get('[data-testid="string-input-channel.repository"]')
         .type('registry.suse.com/rancher/elemental-teal-channel')
       cy.get('[data-testid="string-input-channel.tag"]')


### PR DESCRIPTION
Workaround not needed for all rancher head versions.

## Verification run
[UI-K3s-OS-Upgrade-RM_head_2.9](https://github.com/rancher/elemental/actions/runs/8170358981/job/22336387858)❌ (not linked to this PR, elemental operator installation is ok)
[UI-K3s-OS-Upgrade-RM_head_2.8](https://github.com/rancher/elemental/actions/runs/8170174488) ✅ 
[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/8170170915) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8170176985) ✅ 