### PR TITLE
Disable selinux for recovery

### DIFF
--- a/framework/files/etc/cos/bootargs.cfg
+++ b/framework/files/etc/cos/bootargs.cfg
@@ -15,7 +15,7 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} rd.neednet=0 elemental.oemlabel=${oem_label}"
+  set kernelcmd="console=tty1 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} rd.neednet=0 elemental.oemlabel=${oem_label} selinux=0"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"


### PR DESCRIPTION
Fails to reset system during raw disk boot if selinux is enabled.