### PR TITLE
Only apply upgrade config on OS upgrades

### DIFF
--- a/framework/files/usr/sbin/suc-upgrade
+++ b/framework/files/usr/sbin/suc-upgrade
@@ -72,7 +72,6 @@ function isEqualVersion() {
         echo "Upgrade already done with release:"
         cat ${HOST_DIR}${RELEASE_FILE}
 
-        config
         exit 0
     fi
 

--- a/tests/manifests/elemental-dev-upgrade-example.yaml
+++ b/tests/manifests/elemental-dev-upgrade-example.yaml
@@ -4,6 +4,13 @@ metadata:
   name: dev-upgrade
   namespace: fleet-default
 spec:
+  # The cloudConfig will be applied after node reboot
+  cloudConfig:
+    write_files:
+    - path: /etc/foo/bar.yaml
+      content: |
+        foo:
+          bar
   # Set to the new Elemental version you would like to upgrade to or track the latest tag
   osImage: "172.18.0.2:30000/elemental-os:dev-next"
   clusterTargets:


### PR DESCRIPTION
Part of rancher/elemental-operator#670

Note that this is not strictly necessary. 
Removing this line only serves to not create false expectations on the user, regarding the application of the cloud-init config when the system is not actually upgraded.  

Note that this still applies to the UPGRADE_RECOVERY_ONLY scenario, but in that case the config is already "effective" even if the system will not reboot, since it only applies to recovery boots.