### PR TITLE
ci: use Elemental sle-micro-6.0 based images

### DIFF
--- a/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-hardened-upgrade-reset-rm_stable.yaml
@@ -31,5 +31,5 @@ jobs:
       rancher_version: stable/latest/none
       reset: true
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade-rm_stable.yaml
@@ -28,5 +28,5 @@ jobs:
       rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-k3s-os-upgrade.yaml
+++ b/.github/workflows/cli-k3s-os-upgrade.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       slem_version:
         description: SLE Micro version
-        default: 5.5
+        default: 6.0
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -33,5 +33,5 @@ jobs:
       rancher_version: stable/latest/none
       reset: true
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -31,5 +31,5 @@ jobs:
       rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       slem_version:
         description: SLE Micro version
-        default: 5.5
+        default: 6.0
         type: string
       upgrade_os_channel:
         description: Channel to use for the Elemental OS upgrade

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.7.yaml
@@ -41,4 +41,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.8.yaml
@@ -41,4 +41,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_head_2.9.yaml
@@ -41,4 +41,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest

--- a/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade-rm_stable.yaml
@@ -34,4 +34,4 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -23,7 +23,7 @@ on:
       # Test OS upgrade with OS image in this test ("Use image from registry")
       upgrade_image:
         description: Upgrade image to use
-        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+        default: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
         type: string
 
 jobs:

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.7.yaml
@@ -40,5 +40,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.7' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.8.yaml
@@ -40,5 +40,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_head_2.9.yaml
@@ -40,5 +40,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev

--- a/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade-rm_stable.yaml
@@ -41,5 +41,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: ${{ inputs.rancher_version || 'stable/latest/none' }}
       test_type: ui
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-5.5:latest
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/sle-micro-container-6.0:latest
       upgrade_os_channel: dev


### PR DESCRIPTION
Verification runs:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8268449679) :white_check_mark:
- [UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8268453399) :x:

**NOTE:** the UI test is failing for another reason.