### PR TITLE
ci: fix SeedImage root password

### DIFF
--- a/tests/assets/seedImage-multi.yaml
+++ b/tests/assets/seedImage-multi.yaml
@@ -10,10 +10,16 @@ spec:
       - name: root
         passwd: r0s@pwd1
     write_files:
-      - append: true
+      - path: /etc/elemental-test
+        append: true
         content: |
           SeedImage cloud-config-test
-        path: /etc/elemental-test
+      - path: /etc/ssh/sshd_config
+        append: true
+        content: |
+          PermitRootLogin yes
+        owner: root:root
+        permissions: 644
   registrationRef:
     apiVersion: elemental.cattle.io/v1beta1
     kind: MachineRegistration

--- a/tests/assets/seedImage.yaml
+++ b/tests/assets/seedImage.yaml
@@ -10,10 +10,16 @@ spec:
       - name: root
         passwd: r0s@pwd1
     write_files:
-      - append: true
+      - path: /etc/elemental-test
+        append: true
         content: |
           SeedImage cloud-config-test
-        path: /etc/elemental-test
+      - path: /etc/ssh/sshd_config
+        append: true
+        content: |
+          PermitRootLogin yes
+        owner: root:root
+        permissions: 644
   registrationRef:
     apiVersion: elemental.cattle.io/v1beta1
     kind: MachineRegistration


### PR DESCRIPTION
SLEM6 doesn't allow root ssh login by default.

It fails in CLI tests with [RKE2](https://github.com/rancher/elemental/actions/runs/8274468446) as these ones are checking the `cloud-config` section defined in `SeedImage` and so need a ssh connection.

Verification runs:
- [CLI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/8277901176) :hourglass_flowing_sand: