### PR TITLE
Install openssl in micro-base-os

### DIFF
--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -37,7 +37,7 @@ RUN if [ `uname -m` = "aarch64" ]; then zypper --installroot /osimage in -y grub
 RUN zypper --installroot /osimage in --no-recommends -y SL-Micro-release systemd-presets-branding-Elemental btrfsmaintenance audit
 
 # make elemental-register happy
-RUN zypper --installroot /osimage in --no-recommends -y dmidecode lvm2
+RUN zypper --installroot /osimage in --no-recommends -y dmidecode lvm2 openssl
 
 # add elemental
 RUN zypper --installroot /osimage in --no-recommends -y elemental

--- a/.obs/dockerfile/micro-os/Dockerfile
+++ b/.obs/dockerfile/micro-os/Dockerfile
@@ -15,7 +15,7 @@ FROM suse/sl-micro/sl-micro-base-container-${SLMICRO_VERSION}:latest
 RUN zypper in --no-recommends -y systemd-presets-branding-Elemental elemental
 
 # extend -base with baremetal and usability packages
-RUN zypper in --no-recommends -y procps openssl openssh openssh-server \
+RUN zypper in --no-recommends -y procps openssh openssh-server \
     vim-small less kernel-firmware-all NetworkManager-wwan cryptsetup \
     \
     avahi bash-completion catatonit cni cni-plugins conmon conntrack-tools \


### PR DESCRIPTION
Moves installation of openssl from micro-os to micro-base-os.

This makes the kvm flavor have openssl which is needed for machine registration.