### PR TITLE
ci: fix impersonator account error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Airgap tests
 
-[![CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml) (Tested ith Rancher stable)
+[![CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_stable.yaml) (Tested with Rancher stable)
 
 [![CLI-K3s-Airgap-RM_latest_devel](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml/badge.svg?branch=main)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap_rm_latest_dev.yaml) (Tested with Rancher latest RC)
 

--- a/tests/e2e/app_test.go
+++ b/tests/e2e/app_test.go
@@ -57,9 +57,11 @@ var _ = Describe("E2E - Checking a simple application", Label("check-app"), func
 		Expect(err).To(Not(HaveOccurred()))
 
 		By("Scaling the deployment to the number of nodes", func() {
-			nodeList, err := kubectl.RunWithoutErr("get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(nodeList).To(Not(BeEmpty()))
+			var nodeList string
+			Eventually(func() string {
+				nodeList, _ = kubectl.RunWithoutErr("get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+				return nodeList
+			}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(Not(BeEmpty()))
 
 			nodeNumber := len(strings.Fields(nodeList))
 			Expect(nodeNumber).To(Not(BeNil()))


### PR DESCRIPTION
Should "fix" this sporadic [issue](https://github.com/rancher/elemental/actions/runs/8322889311), could be related to timing issue after the restore test.

Verification run:
- [CLI-K3s-Scalability-RM_Stable](https://github.com/rancher/elemental/actions/runs/8323738257)

**NOTE:** as the issue is sporadic the VR is mainly here to validate that at least the PR doesn't break anything. We will see in the daily CI if the initial issue is really fixed or not.