### PR TITLE
ci/ui: fix elemental operator upgrade

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -163,7 +163,15 @@ jobs:
 
       - name: Install Chartmuseum
         id: install_chartmuseum
-        run: cd tests && make e2e-install-chartmuseum
+        run: |
+          cd tests && make e2e-install-chartmuseum
+          # Extract latest dev operator version
+          OPERATOR_DEV_CHART=$(ls elemental-operator-chart*)
+          i=${OPERATOR_DEV_CHART##*-}
+          OPERATOR_DEV_VERSION=${i%.tgz}
+
+          # Export value
+          echo "operator_dev_version=${OPERATOR_DEV_VERSION}" >> ${GITHUB_OUTPUT}
 
       # Basics means tests without an extra elemental node needed
       - name: Cypress tests - Basics
@@ -237,6 +245,7 @@ jobs:
           CHARTMUSEUM_REPO: http://${{ inputs.public_fqdn }}
           CYPRESS_DOCKER: 'cypress/included:10.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
+          ELEMENTAL_DEV_VERSION: ${{ steps.install_chartmuseum.outputs.operator_dev_version }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           PROXY: ${{ inputs.proxy }}

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -52,14 +52,14 @@ describe('Elemental operator upgrade tests', () => {
           cy.clickButton('Upgrade');
           cy.contains('.header > .title', 'elemental-operator');
           cy.clickButton('Next');
-          cy.get('[data-testid="string-input-channel.repository"]')
+          cy.get('[data-testid="string-input-channel.image"]')
             .clear()
-          cy.get('[data-testid="string-input-channel.repository"]')
-            .type('rancher/elemental-channel')
+          cy.get('[data-testid="string-input-channel.image"]')
+            .type('registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel')
           cy.get('[data-testid="string-input-channel.tag"]')
             .clear()
           cy.get('[data-testid="string-input-channel.tag"]')
-            .type('1.5.0')
+            .type(Cypress.env('elemental_dev_version'))
           cy.clickButton('Upgrade');
           cy.contains('SUCCESS: helm', {timeout:120000});
           cy.contains('Installed App: elemental-operator Pending-Upgrade', {timeout:120000});

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -34,6 +34,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.chartmuseum_repo       = process.env.CHARTMUSEUM_REPO;
   config.env.cluster                = process.env.CLUSTER_NAME;
   config.env.cypress_tags           = process.env.CYPRESS_TAGS;
+  config.env.elemental_dev_version  = process.env.ELEMENTAL_DEV_VERSION;
   config.env.elemental_ui_version   = process.env.ELEMENTAL_UI_VERSION;
   config.env.k8s_downstream_version = process.env.K8S_DOWNSTREAM_VERSION;
   config.env.operator_repo          = process.env.OPERATOR_REPO;

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -19,6 +19,7 @@ npm install
 docker run -v $PWD:/workdir -w /workdir               \
     -e BOOT_TYPE=$BOOT_TYPE                           \
     -e CYPRESS_TAGS=$CYPRESS_TAGS                     \
+    -e ELEMENTAL_DEV_VERSION=$ELEMENTAL_DEV_VERSION   \
     -e ELEMENTAL_UI_VERSION=$ELEMENTAL_UI_VERSION     \
     -e CHARTMUSEUM_REPO=$CHARTMUSEUM_REPO             \
     -e K8S_UPSTREAM_VERSION=$K8S_UPSTREAM_VERSION     \


### PR DESCRIPTION
- Fix this failing test https://github.com/rancher/elemental/actions/workflows/ui-k3s-os-upgrade-rm_stable.yaml
It looks like one HTML selector has changed.

- Improves the code to get the latest elemental dev version instead of using a hardcoded version

[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8328310769) ✅ 