### PR TITLE
Finalize Micro rename

### DIFF
--- a/.obs/dockerfile/micro-baremetal-iso/Dockerfile
+++ b/.obs/dockerfile/micro-baremetal-iso/Dockerfile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildName: build-iso-image
-#!BuildTag: suse/sl-micro/sl-micro-iso-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-iso-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-iso-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildName: build-baremetal-iso-image
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-iso-image:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-iso-image:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-iso-image:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-container-$SLMICRO_VERSION:latest AS os
-FROM suse/sl-micro/sl-micro-container-$SLMICRO_VERSION:latest AS builder
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS os
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS builder
 
 WORKDIR /iso
 
@@ -22,7 +22,7 @@ RUN zypper --installroot /busybox in --no-recommends -y busybox
 
 # Version value is taken form the elemental repository tags
 # Release value of this image and os image are unrelated
-RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
+RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-%%SLMICRO_VERSION%%-baremetal-$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
 
 # Only keep the ISO as a result and busybox
 FROM scratch
@@ -31,13 +31,13 @@ COPY --from=builder /output /elemental-iso
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-iso-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-iso-image
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sl.micro
-LABEL org.opencontainers.image.title="SUSE Linux Micro ISO"
-LABEL org.opencontainers.image.description="Includes the SUSE Linux Micro ISO"
+LABEL org.opencontainers.image.title="SUSE Linux Micro baremetal ISO"
+LABEL org.opencontainers.image.description="Includes the SUSE Linux Micro baremetal ISO"
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"
 LABEL org.opencontainers.image.created="%BUILDTIME%"

--- a/.obs/dockerfile/micro-baremetal-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-baremetal-iso/manifest.yaml
@@ -1,6 +1,6 @@
 iso:
   bootloader-in-rootfs: true
-  grub-entry-name: "SLE Micro Install"
+  grub-entry-name: "SL Micro Baremetal Install"
 
 squash-no-compression: true
 

--- a/.obs/dockerfile/micro-baremetal-os/Dockerfile
+++ b/.obs/dockerfile/micro-baremetal-os/Dockerfile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
 #!BuildName: SL-Micro-container
-#!BuildTag: suse/sl-micro/sl-micro-container-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-container-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-container-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-os-container:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-os-container:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-os-container:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 #
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-base-container-${SLMICRO_VERSION}:latest
+FROM suse/sl-micro/${SLMICRO_VERSION}/base-os-container:latest
 
 # dummy zypper call to get elemental into the build context and extract %VERSION% from it via _service
 RUN zypper in --no-recommends -y systemd-presets-branding-Elemental elemental
@@ -29,7 +29,7 @@ RUN zypper in --no-recommends -y procps openssh openssh-server \
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-container-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/baremetal-os-container
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
@@ -45,8 +45,8 @@ RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sl.micro
-LABEL org.opencontainers.image.title="SUSE Linux Micro Container"
-LABEL org.opencontainers.image.description="Container image SUSE Linux Micro - a containerized OS layer for Kubernetes."
+LABEL org.opencontainers.image.title="SUSE Linux Micro Baremetal OS Container"
+LABEL org.opencontainers.image.description="SUSE Linux Micro Baremetal OS - a containerized OS layer for Kubernetes."
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"
 LABEL org.opencontainers.image.created="%BUILDTIME%"

--- a/.obs/dockerfile/micro-base-iso/Dockerfile
+++ b/.obs/dockerfile/micro-base-iso/Dockerfile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildName: build-iso-base-image
-#!BuildTag: suse/sl-micro/sl-micro-base-iso-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-base-iso-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-base-iso-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildName: build-base-iso-image
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-iso-image:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-iso-image:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-iso-image:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-base-container-${SLMICRO_VERSION}:latest AS os
-FROM suse/sl-micro/sl-micro-container-${SLMICRO_VERSION}:latest AS builder
+FROM suse/sl-micro/${SLMICRO_VERSION}/base-os-container:latest AS os
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS builder
 
 WORKDIR /iso
 
@@ -22,7 +22,7 @@ RUN zypper --installroot /busybox in --no-recommends -y busybox
 
 # Version value is taken form the elemental repository tags
 # Release value of this image and os image are unrelated
-RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-base.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
+RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-%%SLMICRO_VERSION%%-base-$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
 
 # Only keep the ISO as a result and busybox
 FROM scratch
@@ -31,7 +31,7 @@ COPY --from=builder /output /elemental-iso
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-base-iso-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/base-iso-image
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers

--- a/.obs/dockerfile/micro-base-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-base-iso/manifest.yaml
@@ -1,5 +1,5 @@
 iso:
   bootloader-in-rootfs: true
-  grub-entry-name: "SLE Micro base Install"
+  grub-entry-name: "SL Micro Base Install"
 
 squash-no-compression: true

--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
 #!BuildName: SL-Micro-base-container
-#!BuildTag: suse/sl-micro/sl-micro-base-container-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-base-container-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-base-container-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-os-container:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-os-container:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/base-os-container:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 #
 
@@ -53,7 +53,7 @@ COPY --from=host /osimage /
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-base-container-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/base-os-container
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
@@ -67,7 +67,7 @@ RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sl.micro
-LABEL org.opencontainers.image.title="SUSE Linux Micro Base Container"
+LABEL org.opencontainers.image.title="SUSE Linux Micro Base OS Container"
 LABEL org.opencontainers.image.description="Container image for SUSE Linux Micro Base - a containerized OS layer for Kubernetes."
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 LABEL org.opencontainers.image.url="https://www.suse.com/products/micro/"

--- a/.obs/dockerfile/micro-kvm-iso/Dockerfile
+++ b/.obs/dockerfile/micro-kvm-iso/Dockerfile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildName: build-iso-kvm-image
-#!BuildTag: suse/sl-micro/sl-micro-kvm-iso-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-kvm-iso-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-kvm-iso-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildName: build-kvm-iso-image
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-iso-image:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-iso-image:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-iso-image:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-kvm-container-${SLMICRO_VERSION}:latest AS os
-FROM suse/sl-micro/sl-micro-container-${SLMICRO_VERSION}:latest AS builder
+FROM suse/sl-micro/${SLMICRO_VERSION}/kvm-os-container:latest AS os
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS builder
 
 WORKDIR /iso
 
@@ -22,7 +22,7 @@ RUN zypper --installroot /busybox in --no-recommends -y busybox
 
 # Version value is taken form the elemental repository tags
 # Release value of this image and os image are unrelated
-RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-kvm.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
+RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-%%SLMICRO_VERSION%%-kvm-$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
 
 # Only keep the ISO as a result and busybox
 FROM scratch
@@ -31,7 +31,7 @@ COPY --from=builder /output /elemental-iso
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-kvm-iso-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/kvm-iso-image
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers

--- a/.obs/dockerfile/micro-kvm-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-kvm-iso/manifest.yaml
@@ -1,5 +1,5 @@
 iso:
   bootloader-in-rootfs: true
-  grub-entry-name: "SLE Micro virtual image Install"
+  grub-entry-name: "SL Micro Virtual Image Install"
 
 squash-no-compression: true

--- a/.obs/dockerfile/micro-kvm-os/Dockerfile
+++ b/.obs/dockerfile/micro-kvm-os/Dockerfile
@@ -1,16 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#
 #!BuildName: SL-Micro-kvm-container
-#!BuildTag: suse/sl-micro/sl-micro-kvm-container-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-kvm-container-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-kvm-container-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-os-container:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-os-container:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/kvm-os-container:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 #
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-base-container-${SLMICRO_VERSION}:latest
+FROM suse/sl-micro/${SLMICRO_VERSION}/base-os-container:latest
 
 # dummy zypper call to get elemental into the build context and extract %VERSION% from it via _service
 RUN zypper in --no-recommends -y systemd-presets-branding-Elemental elemental
@@ -22,7 +21,7 @@ MAINTAINER SUSE LLC (https://www.suse.com/)
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-kvm-container-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/kvm-os-container
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers

--- a/.obs/dockerfile/micro-rt-iso/Dockerfile
+++ b/.obs/dockerfile/micro-rt-iso/Dockerfile
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildName: build-iso-rt-image
-#!BuildTag: suse/sl-micro/sl-micro-rt-iso-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-rt-iso-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-rt-iso-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildName: build-rt-iso-image
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-iso-image:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-iso-image:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-iso-image:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 10
 #!BuildConstraint: hardware:memory:size unit=G 16
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-rt-container-${SLMICRO_VERSION}:latest AS os
-FROM suse/sl-micro/sl-micro-container-${SLMICRO_VERSION}:latest AS builder
+FROM suse/sl-micro/${SLMICRO_VERSION}/rt-os-container:latest AS os
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS builder
 
 WORKDIR /iso
 
@@ -22,7 +22,7 @@ RUN zypper --installroot /busybox in --no-recommends -y busybox
 
 # Version value is taken form the elemental repository tags
 # Release value of this image and os image are unrelated
-RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-rt.$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
+RUN elemental --debug --config-dir . build-iso -o /output -n "sl-micro-%%SLEMICRO_VERSION%%-rt-$(uname -m)-%VERSION%-Build%RELEASE%" dir:rootfs
 
 # Only keep the ISO as a result and busybox
 FROM scratch
@@ -31,12 +31,12 @@ COPY --from=builder /output /elemental-iso
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-rt-iso-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/rt-iso-image
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sl.micro
-LABEL org.opencontainers.image.title="SUSE Linux Micro rt-ISO"
+LABEL org.opencontainers.image.title="SUSE Linux Micro rt ISO"
 LABEL org.opencontainers.image.description="Includes the SUSE Linux Micro realtime ISO"
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 LABEL org.opencontainers.image.url="https://github.com/rancher/elemental"

--- a/.obs/dockerfile/micro-rt-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-rt-iso/manifest.yaml
@@ -1,5 +1,5 @@
 iso:
   bootloader-in-rootfs: true
-  grub-entry-name: "SLE Micro real-time Install"
+  grub-entry-name: "SL Micro Realtime Install"
 
 squash-no-compression: true

--- a/.obs/dockerfile/micro-rt-os/Dockerfile
+++ b/.obs/dockerfile/micro-rt-os/Dockerfile
@@ -2,15 +2,15 @@
 # Define the names/tags of the container
 #!ExclusiveArch: x86_64
 #!BuildName: SL-Micro-rt-container
-#!BuildTag: suse/sl-micro/sl-micro-rt-container-%%SLMICRO_VERSION%%:latest
-#!BuildTag: suse/sl-micro/sl-micro-rt-container-%%SLMICRO_VERSION%%:%VERSION%
-#!BuildTag: suse/sl-micro/sl-micro-rt-container-%%SLMICRO_VERSION%%:%VERSION%-%RELEASE%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-container-image:latest
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-container-image:%VERSION%
+#!BuildTag: suse/sl-micro/%%SLMICRO_VERSION%%/rt-container-image:%VERSION%-%RELEASE%
 #!BuildConstraint: hardware:disk:size unit=G 8
 #
 
 ARG SLMICRO_VERSION
 
-FROM suse/sl-micro/sl-micro-container-$SLMICRO_VERSION:latest AS os
+FROM suse/sl-micro/${SLMICRO_VERSION}/baremetal-os-container:latest AS os
 
 # dummy zypper call to get elemental into the build context and extract %VERSION% from it via _service
 RUN zypper in --no-recommends -y systemd-presets-branding-Elemental elemental
@@ -22,13 +22,13 @@ MAINTAINER SUSE LLC (https://www.suse.com/)
 
 ARG SLMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/sl-micro-rt-container-$SLMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sl-micro/%%SLMICRO_VERSION%%/rt-os-container
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sl.micro
-LABEL org.opencontainers.image.title="SUSE Linux Micro for Rancher RT"
-LABEL org.opencontainers.image.description="Image containing SUSE Linux Micro for Rancher RT - a containerized OS layer for Kubernetes."
+LABEL org.opencontainers.image.title="SUSE Linux Micro Realtime OS Container"
+LABEL org.opencontainers.image.description="Image containing SUSE Linux Micro Realtime - a containerized OS layer for Kubernetes."
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.source="%SOURCEURL%"


### PR DESCRIPTION
- change tags to suse/sl-micro/<micro-version>/<flavor>-os-container resp. suse/sl-micro/<micro-version>/<flavor>-iso-image

- change ISO image filenames to include SL Micro version

- drop the "non flavored" flavor, call it "baremetal"

- adapt grub boot entry names (in manifest.yaml) accordingly

- iron out any inconsistencies