### PR TITLE
ci/multi: fix the OS image used

### DIFF
--- a/.github/workflows/sub_multi.yaml
+++ b/.github/workflows/sub_multi.yaml
@@ -35,6 +35,9 @@ on:
       operator_repo:
         required: true
         type: string
+      os_to_test:
+        required: true
+        type: string
       public_domain:
         required: true
         type: string
@@ -150,6 +153,7 @@ jobs:
         env:
           CLUSTER_NUMBER: ${{ inputs.cluster_number }}
           BOOT_TYPE: ${{ inputs.boot_type }}
+          OS_TO_TEST: ${{ inputs.os_to_test }}
         run: |
           # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
           if ${{ contains(inputs.k8s_upstream_version, 'rke') }}; then
@@ -187,6 +191,7 @@ jobs:
           k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
           k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           operator_version: ${{ steps.component.outputs.operator_version }}
+          os_to_test: ${{ inputs.os_to_test }}
           os_version: ${{ steps.iso_version.outputs.os_version }}
           public_fqdn: ${{ inputs.public_fqdn }}
           rancher_image_version: ${{ steps.component.outputs.rancher_image_version }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -182,6 +182,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: ${{ inputs.os_to_test }}
       public_domain: ${{ inputs.public_domain }}
       public_fqdn: ${{ inputs.public_fqdn }}
       qase_project_code: ${{ inputs.qase_project_code }}


### PR DESCRIPTION
Dev one should be used and tested, not Stable.

Verification run:
- [CLI-K3s-Multi_Cluster-RM_Stable](https://github.com/rancher/elemental/actions/runs/8417997841)

**NOTE:** the VR can fail, as there is an issue with Dev ISO, which helped to identify the issue fixed by this PR.