### PR TITLE
ci/ui: fix chatmuseum script for operator version

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -163,15 +163,17 @@ jobs:
 
       - name: Install Chartmuseum
         id: install_chartmuseum
+        env: 
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
         run: |
           cd tests && make e2e-install-chartmuseum
           # Extract latest dev operator version
-          OPERATOR_DEV_CHART=$(ls elemental-operator-chart*)
-          i=${OPERATOR_DEV_CHART##*-}
-          OPERATOR_DEV_VERSION=${i%.tgz}
+          OPERATOR_CHART=$(ls elemental-operator-chart*)
+          i=${OPERATOR_CHART##*-}
+          OPERATOR_VERSION=${i%.tgz}
 
           # Export value
-          echo "operator_dev_version=${OPERATOR_DEV_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "chartmuseum_operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
 
       # Basics means tests without an extra elemental node needed
       - name: Cypress tests - Basics

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -80,7 +80,7 @@ e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
 
 e2e-install-chartmuseum:
-	sudo ./scripts/deploy-chartmuseum
+	sudo ./scripts/deploy-chartmuseum $(OPERATOR_REPO)
 
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -8,6 +8,9 @@ set -e -x
 # Add missing PATH, removed in recent distributions for security reasons...
 PATH+=:/usr/local/bin
 
+# Variables
+REPO=$1
+
 # Create a systemctl file for chartmuseum
 cat > /etc/systemd/system/chartmuseum.service << EOF
 [Unit]
@@ -42,8 +45,8 @@ helm plugin install https://github.com/chartmuseum/helm-push.git
 helm repo add chartmuseum http://localhost:8080
 
 # Download needed helm charts
-helm pull oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-crds-chart
-helm pull oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart
+helm pull $REPO/elemental-operator-crds-chart
+helm pull $REPO/elemental-operator-chart
 
 # Extract helm charts
 tar -xvzf elemental-operator-crds-*


### PR DESCRIPTION
Chartmuseum has to pull from staging helm repo if we want to test staging operator.

## Verification run
[UI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/8422969793/job/23063557120) ✅ 
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8421504274) ✅ 