### PR TITLE
Do not start elemental-register timer manually

### DIFF
--- a/framework/files/system/oem/99_elemental-register-timer.yaml
+++ b/framework/files/system/oem/99_elemental-register-timer.yaml
@@ -1,6 +1,0 @@
-name: "Elemental Register start"
-stages:
-  network.after:
-    - if: '[ ! -f /run/elemental/live_mode ] && [ ! -f /run/elemental/recovery_mode ]'
-      commands:
-        - systemctl start elemental-register.timer

--- a/framework/files/usr/lib/systemd/system/elemental-register.timer
+++ b/framework/files/usr/lib/systemd/system/elemental-register.timer
@@ -1,6 +1,9 @@
 [Unit]
 Description=Run elemental-register every 30 minutes
 Documentation=https://elemental.docs.rancher.com
+# Do not run the timer for installation media or recovery system
+ConditionPathExists=!/run/elemental/live_mode
+ConditionPathExists=!/run/elemental/recovery_mode
 
 [Timer]
 OnStartupSec=5


### PR DESCRIPTION
Starting the service manually prevent proper ordering and tracking of related services. Having a manual start makes it difficult form other services to check its status as there is no obvious way order the related executions.

Follow up for #1263 