### PR TITLE
ci/cli: add support for snapshotter option

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -64,6 +64,9 @@ inputs:
   sequential:
     default: "Unknown"
     type: boolean
+  snap_type:
+    default: "btrfs"
+    type: string
   test_description:
     default: "Unknown"
     type: string
@@ -148,17 +151,18 @@ runs:
 
         # Add summary: Elemental
         echo "### Elemental" >> ${GITHUB_STEP_SUMMARY}
-        echo "Elemental ISO image: ${{ inputs.os_to_test }}" >> ${GITHUB_STEP_SUMMARY}
-        echo "Elemental OS version: ${{ inputs.os_version }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "Elemental ISO Image: ${{ inputs.os_to_test }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "Elemental OS Version: ${{ inputs.os_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental Operator Image: ${{ inputs.operator_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental Backup/Restore Operator Image: ${{ inputs.backup_operator_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental UI Extension Version: ${{ inputs.elemental_ui_version }}" >> ${GITHUB_STEP_SUMMARY}
         echo "Elemental UI User: ${{ inputs.ui_account }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "OS Image Snapshot Type: ${{ inputs.snap_type }}" >> ${GITHUB_STEP_SUMMARY}
 
         # Add summary: Kubernetes
         echo "### Kubernetes" >> ${GITHUB_STEP_SUMMARY}
-        echo "K8s upstream version: ${{ inputs.k8s_upstream_version }}" >> ${GITHUB_STEP_SUMMARY}
-        echo "K8s downstream version: ${{ inputs.k8s_downstream_version }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "K8s Upstream Version: ${{ inputs.k8s_upstream_version }}" >> ${GITHUB_STEP_SUMMARY}
+        echo "K8s Downstream Version: ${{ inputs.k8s_downstream_version }}" >> ${GITHUB_STEP_SUMMARY}
 
         # Add summary: Cluster
         echo "### Cluster nodes" >> ${GITHUB_STEP_SUMMARY}
@@ -173,5 +177,5 @@ runs:
           echo "Rancher Manager Image: ${{ inputs.rancher_image_version_upgrade }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Rancher Manager Version: ${{ inputs.rancher_upgrade }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Channel: ${{ inputs.upgrade_os_channel }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "Upgrade image: ${{ inputs.upgrade_image }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Upgrade Image: ${{ inputs.upgrade_image }}" >> ${GITHUB_STEP_SUMMARY}
         fi

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.7.yaml
@@ -27,4 +27,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.7
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.8.yaml
@@ -27,4 +27,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.8
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_head_2.9.yaml
@@ -27,4 +27,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
       rancher_version: latest/devel/2.9
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-rm_stable.yaml
@@ -26,4 +26,5 @@ jobs:
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       node_number: 3
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-hardened-upgrade-reset-rm_stable.yaml
@@ -32,6 +32,7 @@ jobs:
       rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
       reset: true
+      snap_type: loopdevice
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -43,4 +43,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-multi_cluster-rm_stable.yaml
@@ -34,4 +34,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi
+      snap_type: loopdevice
       zone: us-central1-b

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -43,4 +43,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -43,4 +43,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade-rm_stable.yaml
@@ -30,6 +30,7 @@ jobs:
       os_to_test: stable
       rancher_upgrade: latest/devel/2.8
       rancher_version: stable/latest/none
+      snap_type: loopdevice
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest
       upgrade_os_channel: dev

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -57,6 +57,7 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
+      snap_type: loopdevice
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/${{ inputs.upgrade_os_channel }}/containers/suse/sl-micro/${{ inputs.slem_version }}/baremetal-os-container:latest
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.7.yaml
@@ -26,4 +26,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.8.yaml
@@ -26,4 +26,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_head_2.9.yaml
@@ -26,4 +26,5 @@ jobs:
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-reset-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-reset-rm_stable.yaml
@@ -25,4 +25,5 @@ jobs:
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       reset: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.7.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.7.yaml
@@ -25,4 +25,5 @@ jobs:
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.7
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.8.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.8.yaml
@@ -25,4 +25,5 @@ jobs:
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.8
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_head_2.9.yaml
+++ b/.github/workflows/cli-rke2-rm_head_2.9.yaml
@@ -25,4 +25,5 @@ jobs:
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
       rancher_version: latest/devel/2.9
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-rm_stable.yaml
@@ -24,4 +24,5 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: v1.27.8+rke2r1
       k8s_upstream_version: v1.26.10+rke2r2
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-sequential-rm_stable.yaml
+++ b/.github/workflows/cli-rke2-sequential-rm_stable.yaml
@@ -31,4 +31,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: stable/latest/none
       sequential: true
+      snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -89,6 +89,10 @@ on:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)
         default: false
         type: boolean
+      snap_type:
+        description: Type to use for snapshot partitions (btrfs/loopdevice)
+        default: btrfs
+        type: string
       test_description:
         description: Short description of the test
         default: Unknown
@@ -222,6 +226,7 @@ jobs:
       reset: ${{ inputs.reset }}
       runner_label: ${{ needs.create-runner.outputs.runner_label }}
       sequential: ${{ inputs.sequential }}
+      snap_type: ${{ inputs.snap_type }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
       ui_account: ${{ inputs.ui_account }}

--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -38,6 +38,9 @@ on:
       runner_label:
         required: true
         type: string
+      snap_type:
+        required: true
+        type: string
       test_description:
         required: true
         type: string
@@ -119,6 +122,8 @@ jobs:
 
       - name: Configure Rancher and Libvirt
         id: configure_rancher
+        env:
+          SNAP_TYPE: ${{ inputs.snap_type }}
         run: cd tests && make e2e-configure-rancher
 
       - name: Extract component versions/informations
@@ -201,5 +206,6 @@ jobs:
           os_version: ${{ steps.iso_version.outputs.os_version }}
           rancher_image_version: ${{ steps.component.outputs.rancher_image_version }}
           rancher_version: ${{ inputs.rancher_version }}
+          snap_type: ${{ inputs.snap_type }}
           test_type: cli
           test_description: ${{ inputs.test_description }}

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -74,6 +74,9 @@ on:
       sequential:
         required: true
         type: boolean
+      snap_type:
+        required: true
+        type: string
       test_description:
         required: true
         type: string
@@ -201,6 +204,8 @@ jobs:
 
       - name: Configure Rancher and Libvirt
         id: configure_rancher
+        env:
+          SNAP_TYPE: ${{ inputs.snap_type }}
         run: cd tests && make e2e-configure-rancher
 
       - name: Create ISO image for master pool
@@ -436,6 +441,7 @@ jobs:
           rancher_upgrade: ${{ inputs.rancher_upgrade }}
           rancher_version: ${{ inputs.rancher_version }}
           sequential: ${{ inputs.sequential }}
+          snap_type: ${{ inputs.snap_type }}
           test_type: ${{ inputs.test_type }}
           test_description: ${{ inputs.test_description }}
           upgrade_image: ${{ inputs.upgrade_image }}

--- a/.github/workflows/sub_multi.yaml
+++ b/.github/workflows/sub_multi.yaml
@@ -56,6 +56,9 @@ on:
       runner_label:
         required: true
         type: string
+      snap_type:
+        required: true
+        type: string
       test_description:
         required: true
         type: string
@@ -151,8 +154,9 @@ jobs:
       - name: Deploy multiple clusters (with 3 nodes by cluster)
         id: deploy_multi_clusters
         env:
-          CLUSTER_NUMBER: ${{ inputs.cluster_number }}
           BOOT_TYPE: ${{ inputs.boot_type }}
+          CLUSTER_NUMBER: ${{ inputs.cluster_number }}
+          SNAP_TYPE: ${{ inputs.snap_type }}
           OS_TO_TEST: ${{ inputs.os_to_test }}
         run: |
           # Set RAM to 10GB for RKE2 and vCPU to 6, a bit more than the recommended values
@@ -199,5 +203,6 @@ jobs:
           public_fqdn: ${{ inputs.public_fqdn }}
           rancher_image_version: ${{ steps.component.outputs.rancher_image_version }}
           rancher_version: ${{ inputs.rancher_version }}
+          snap_type: ${{ inputs.snap_type }}
           test_type: ${{ inputs.test_type }}
           test_description: ${{ inputs.test_description }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -86,6 +86,9 @@ on:
       sequential:
         required: true
         type: boolean
+      snap_type:
+        required: true
+        type: string
       test_description:
         required: true
         type: string
@@ -128,6 +131,7 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_label: ${{ inputs.runner_label }}
+      snap_type: ${{ inputs.snap_type }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
@@ -160,6 +164,7 @@ jobs:
       reset: ${{ inputs.reset }}
       runner_label: ${{ inputs.runner_label }}
       sequential: ${{ inputs.sequential }}
+      snap_type: ${{ inputs.snap_type }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
       upgrade_image: ${{ inputs.upgrade_image }}
@@ -189,6 +194,7 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_label: ${{ inputs.runner_label }}
+      snap_type: ${{ inputs.snap_type }}
       test_description: ${{ inputs.test_description }}
       test_type: ${{ inputs.test_type }}
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}

--- a/tests/assets/machineRegistration-multi.yaml
+++ b/tests/assets/machineRegistration-multi.yaml
@@ -22,4 +22,6 @@ spec:
         poweroff: true
         device: /dev/sda
         debug: true
+        snapshotter:
+          type: %SNAP_TYPE%
   machineName: ${System Data/Runtime/Hostname}

--- a/tests/assets/machineRegistration.yaml
+++ b/tests/assets/machineRegistration.yaml
@@ -54,4 +54,6 @@ spec:
           values:
           - 25Gi
         debug: true
+        snapshotter:
+          type: %SNAP_TYPE%
   machineName: %VM_NAME%-${System Information/UUID}

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -116,6 +116,10 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 						value: pool,
 					},
 					{
+						key:   "%SNAP_TYPE%",
+						value: snapType,
+					},
+					{
 						key:   "%USER%",
 						value: userName,
 					},

--- a/tests/e2e/multi-cluster_test.go
+++ b/tests/e2e/multi-cluster_test.go
@@ -54,6 +54,10 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 				value: k8sDownstreamVersion,
 			},
 			{
+				key:   "%SNAP_TYPE%",
+				value: snapType,
+			},
+			{
 				key:   "%PASSWORD%",
 				value: userPassword,
 			},

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -64,7 +64,6 @@ var (
 	clusterYaml               string
 	elementalSupport          string
 	emulateTPM                bool
-	rancherHostname           string
 	isoBoot                   bool
 	k8sUpstreamVersion        string
 	k8sDownstreamVersion      string
@@ -78,6 +77,7 @@ var (
 	proxy                     string
 	rancherChannel            string
 	rancherHeadVersion        string
+	rancherHostname           string
 	rancherLogCollector       string
 	rancherVersion            string
 	rancherUpgrade            string
@@ -89,6 +89,7 @@ var (
 	seedImageYaml             string
 	selectorYaml              string
 	sequential                bool
+	snapType                  string
 	testCaseID                int64
 	testType                  string
 	upgradeImage              string
@@ -407,7 +408,6 @@ var _ = BeforeSuite(func() {
 	clusterType = os.Getenv("CLUSTER_TYPE")
 	elementalSupport = os.Getenv("ELEMENTAL_SUPPORT")
 	eTPM := os.Getenv("EMULATE_TPM")
-	rancherHostname = os.Getenv("PUBLIC_FQDN")
 	index := os.Getenv("VM_INDEX")
 	k8sDownstreamVersion = os.Getenv("K8S_DOWNSTREAM_VERSION")
 	k8sUpstreamVersion = os.Getenv("K8S_UPSTREAM_VERSION")
@@ -418,10 +418,12 @@ var _ = BeforeSuite(func() {
 	os2Test = os.Getenv("OS_TO_TEST")
 	poolType = os.Getenv("POOL")
 	proxy = os.Getenv("PROXY")
+	rancherHostname = os.Getenv("PUBLIC_FQDN")
 	rancherLogCollector = os.Getenv("RANCHER_LOG_COLLECTOR")
 	rancherVersion = os.Getenv("RANCHER_VERSION")
 	rancherUpgrade = os.Getenv("RANCHER_UPGRADE")
 	seqString := os.Getenv("SEQUENTIAL")
+	snapType = os.Getenv("SNAP_TYPE")
 	testType = os.Getenv("TEST_TYPE")
 	upgradeImage = os.Getenv("UPGRADE_IMAGE")
 	upgradeOSChannel = os.Getenv("UPGRADE_OS_CHANNEL")


### PR DESCRIPTION
K3s tests will use `btrfs` and RKE2 ones will use `loopdevice`. The default is set to `btrfs`.

Should fix #1302.

Verification runs:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8466136634) :white_check_mark:
- [CLI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/8467143600) :hourglass_flowing_sand: