### PR TITLE
ci: fix lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,36 +12,42 @@ jobs:
   golang-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
+          cache-dependency-path: tests/go.sum
           go-version-file: tests/go.mod
+
       - name: Analysis
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           args: -v
           working-directory: tests
+
   cypress-lint:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: current
       WORKING_DIR: tests/cypress/latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
       - name: Install npm
         run: |
           cd ${{ env.WORKING_DIR }}
           npm install --save-dev
           npm ls --depth=0
+
       - name: Analysis
-        uses: sibiraj-s/action-eslint@v3
-        with:
-          extensions: 'js,ts'
-          working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          cd ${{ env.WORKING_DIR }}
+          npm run lint

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -7,6 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "lint": "eslint --ext .js,.ts .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -15,7 +16,7 @@
   },
   "keywords": [],
   "author": "Elemental team",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/rancher/elemental/issues"
   },


### PR DESCRIPTION
Fix `Node.js 16 actions are deprecated.` messages in lint workflow.

Verification run:
- [cypress-lint with an error](https://github.com/rancher/elemental/actions/runs/8480536296/job/23236421808?pr=1333)
- [cypress-lint without error](https://github.com/rancher/elemental/actions/runs/8480546188/job/23236450126?pr=1333)