### PR TITLE
ci/ui: fix default snapshotter in UI tests

### DIFF
--- a/tests/cypress/latest/fixtures/custom_cloud-config.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config.yaml
@@ -11,7 +11,19 @@ config:
         permissions: 644
   elemental:
     install:
+      device-selector:
+      - key: Name
+        operator: In
+        values:
+          - /dev/sda
+          - /dev/vda
+          - /dev/nvme0n1
+      - key: Size
+        operator: Gt
+        values:
+          - 25Gi
+      snapshotter:
+        type: btrfs
       poweroff: true
-      device: /dev/sda
       debug: true
 machineName: my-machine

--- a/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
@@ -12,8 +12,20 @@ config:
   elemental:
     install:
       poweroff: true
-      device: /dev/sda
       debug: true
+      device-selector:
+      - key: Name
+        operator: In
+        values:
+          - /dev/sda
+          - /dev/vda
+          - /dev/nvme0n1
+      - key: Size
+        operator: Gt
+        values:
+          - 25Gi
+      snapshotter:
+        type: btrfs
     reset:
       debug: true
       enabled: true


### PR DESCRIPTION
## Description

BTRFS snapshotter is the default when you create machine registration with the UI.

But if you import a cloud-config YAML file and snapshotter is not defined, it will default to loopdevice and we want BTRFS in all UI tests.

This PR adds BTRFS snapshotter in the YAML file imported by the tests.

## Verification run
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8551026054/job/23429202419) ✅ 