### PR TITLE
ci/cli: fix upgrade tests

### DIFF
--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	"github.com/rancher/elemental/tests/e2e/helpers/elemental"
+	"golang.org/x/mod/semver"
 )
 
 var _ = Describe("E2E - Configure test", Label("configure"), func() {
@@ -137,6 +139,15 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 				// Create Yaml file
 				for _, p := range patterns {
 					err := tools.Sed(p.key, p.value, registrationTmp)
+					Expect(err).To(Not(HaveOccurred()))
+				}
+
+				// Stable version of Elemental Operator does not support snapshotter option
+				// NOTE: a bit dirty, but this is a workaround until Dev become the new Stable
+				operatorVersion, err := elemental.GetOperatorVersion()
+				if semver.Compare("v"+operatorVersion, "v1.6.0") == -1 {
+					GinkgoWriter.Printf("Found operator Stable version, apply workaround for pool %s.\n", pool)
+					err = exec.Command("sed", "-i", "/snapshotter:/,/type:/d", registrationTmp).Run()
 					Expect(err).To(Not(HaveOccurred()))
 				}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240328132501-e38cbb7563a8
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/mod v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -201,6 +201,8 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
+golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Stable version of Elemental Operator does not support the `snapshotter` option.
Should fix this [issue](https://github.com/rancher/elemental/actions/runs/8548027821).

Verification run:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8554180020) :x:

**NOTE:** the test fails for an issue not related to this PR, this will be investigated later.