### PR TITLE
ci: fix OS version extraction

### DIFF
--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -167,14 +167,19 @@ jobs:
           # Extract OS version from ISO
           ISO=$(file -Ls *.iso 2>/dev/null | awk -F':' '/boot sector/ { print $1 }')
           if [[ -n "${ISO}" ]]; then
-            [[ "${{ inputs.os_to_test }}" == "dev" ]] \
-              && INITRD_NAME="elemental.initrd*" \
-              || INITRD_NAME="initrd"
-            INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
-            isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
-              | xz -dc \
-              | cpio -i --to-stdout usr/lib/initrd-release > os-release
-            eval $(grep IMAGE_TAG os-release 2>/dev/null)
+            # NOTE: always keep 'initrd' at the end, as there is always a link with this name
+            for INITRD_NAME in elemental.initrd* initrd; do
+              INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
+              if [[ -n "${INITRD_FILE}" ]]; then
+                isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
+                  | xz -dc \
+                  | cpio -i --to-stdout usr/lib/initrd-release > os-release
+                eval $(grep IMAGE_TAG os-release 2>/dev/null)
+
+                # We found an initrd, stop here
+                break
+              fi
+            done
           fi
 
           # Export value (even if empty!)

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -353,14 +353,19 @@ jobs:
           # Extract OS version from ISO
           ISO=$(file -Ls *.iso 2>/dev/null | awk -F':' '/boot sector/ { print $1 }')
           if [[ -n "${ISO}" ]]; then
-            [[ "${{ inputs.os_to_test }}" == "dev" ]] \
-              && INITRD_NAME="elemental.initrd*" \
-              || INITRD_NAME="initrd"
-            INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
-            isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
-              | xz -dc \
-              | cpio -i --to-stdout usr/lib/initrd-release > os-release
-            eval $(grep IMAGE_TAG os-release 2>/dev/null)
+            # NOTE: always keep 'initrd' at the end, as there is always a link with this name
+            for INITRD_NAME in elemental.initrd* initrd; do
+              INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
+              if [[ -n "${INITRD_FILE}" ]]; then
+                isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
+                  | xz -dc \
+                  | cpio -i --to-stdout usr/lib/initrd-release > os-release
+                eval $(grep IMAGE_TAG os-release 2>/dev/null)
+
+                # We found an initrd, stop here
+                break
+              fi
+            done
           fi
 
           # Export value (even if empty!)

--- a/.github/workflows/sub_multi.yaml
+++ b/.github/workflows/sub_multi.yaml
@@ -173,14 +173,19 @@ jobs:
           # Extract OS version from ISO
           ISO=$(file -Ls *.iso 2>/dev/null | awk -F':' '/boot sector/ { print $1 }')
           if [[ -n "${ISO}" ]]; then
-            [[ "${{ inputs.os_to_test }}" == "dev" ]] \
-              && INITRD_NAME="elemental.initrd*" \
-              || INITRD_NAME="initrd"
-            INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
-            isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
-              | xz -dc \
-              | cpio -i --to-stdout usr/lib/initrd-release > os-release
-            eval $(grep IMAGE_TAG os-release 2>/dev/null)
+            # NOTE: always keep 'initrd' at the end, as there is always a link with this name
+            for INITRD_NAME in elemental.initrd* initrd; do
+              INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
+              if [[ -n "${INITRD_FILE}" ]]; then
+                isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
+                  | xz -dc \
+                  | cpio -i --to-stdout usr/lib/initrd-release > os-release
+                eval $(grep IMAGE_TAG os-release 2>/dev/null)
+
+                # We found an initrd, stop here
+                break
+              fi
+            done
           fi
 
           # Export value (even if empty!)

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -295,14 +295,19 @@ jobs:
           # Extract OS version from ISO
           ISO=$(file -Ls *.iso 2>/dev/null | awk -F':' '/boot sector/ { print $1 }')
           if [[ -n "${ISO}" ]]; then
-            [[ "${{ inputs.os_to_test }}" == "dev" ]] \
-              && INITRD_NAME="elemental.initrd*" \
-              || INITRD_NAME="initrd"
-            INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
-            isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
-              | xz -dc \
-              | cpio -i --to-stdout usr/lib/initrd-release > os-release
-            eval $(grep IMAGE_TAG os-release 2>/dev/null)
+            # NOTE: always keep 'initrd' at the end, as there is always a link with this name
+            for INITRD_NAME in elemental.initrd* initrd; do
+              INITRD_FILE=$(isoinfo -i ${ISO} -R -find -type f -name ${INITRD_NAME} -print 2>/dev/null)
+              if [[ -n "${INITRD_FILE}" ]]; then
+                isoinfo -i ${ISO} -R -x ${INITRD_FILE} 2>/dev/null \
+                  | xz -dc \
+                  | cpio -i --to-stdout usr/lib/initrd-release > os-release
+                eval $(grep IMAGE_TAG os-release 2>/dev/null)
+
+                # We found an initrd, stop here
+                break
+              fi
+            done
           fi
 
           # Export value (even if empty!)


### PR DESCRIPTION
Try until we find a good initrd file, easier rather than having to rely on a variable.

Verification runs:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8555266443) :hourglass_flowing_sand:
- [UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8555277624) :hourglass_flowing_sand: