### PR TITLE
ci/airgap: fix node deployment

### DIFF
--- a/tests/e2e/helpers/elemental/elemental.go
+++ b/tests/e2e/helpers/elemental/elemental.go
@@ -162,7 +162,7 @@ func GetOperatorVersion() (string, error) {
 	// Extract version
 	operatorVersion := strings.Split(operatorImage, ":")
 
-	return operatorVersion[1], nil
+	return operatorVersion[len(operatorVersion)-1], nil
 }
 
 /*


### PR DESCRIPTION
Elemental operator version is always the last element.

Verification run:
- [CLI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8605884901) :white_check_mark:
- [CLI-K3s-Airgap-RM_stable](https://github.com/rancher/elemental/actions/runs/8605885879) ✅ 