### PR TITLE
ci/cli: fix Rancher Manager upgrade tests

### DIFF
--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -106,6 +106,15 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 			rancherUpgradeHeadVersion,
 			caType, proxy,
 		)
+
+		// Check if we have the "may still be processing the request" error to workaround it
+		// Manual tests showed that the upgrade is OK after some times, so just ignore the error
+		if err != nil {
+			errMsg := strings.Split(err.Error(), ":")
+			if out := errMsg[len(errMsg)-1]; strings.Contains(out, "but may still be processing the request") {
+				err = nil
+			}
+		}
 		Expect(err).To(Not(HaveOccurred()))
 
 		// Wait for Rancher Manager to be restarted


### PR DESCRIPTION
An issue while upgrading with Helm can sometimes happens, but after checking the upgrade is fine, so better to workaround it.

Verification runs:
- [CLI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8613985220) :white_check_mark:
- [CLI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8615051830) :white_check_mark: