### PR TITLE
Use default compression (gzip) for ISOs

### DIFF
--- a/.obs/dockerfile/micro-baremetal-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-baremetal-iso/manifest.yaml
@@ -1,6 +1,3 @@
 iso:
   bootloader-in-rootfs: true
   grub-entry-name: "SL Micro Baremetal Install"
-
-squash-no-compression: true
-

--- a/.obs/dockerfile/micro-base-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-base-iso/manifest.yaml
@@ -1,5 +1,3 @@
 iso:
   bootloader-in-rootfs: true
   grub-entry-name: "SL Micro Base Install"
-
-squash-no-compression: true

--- a/.obs/dockerfile/micro-kvm-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-kvm-iso/manifest.yaml
@@ -1,5 +1,3 @@
 iso:
   bootloader-in-rootfs: true
   grub-entry-name: "SL Micro Virtual Image Install"
-
-squash-no-compression: true

--- a/.obs/dockerfile/micro-rt-iso/manifest.yaml
+++ b/.obs/dockerfile/micro-rt-iso/manifest.yaml
@@ -1,5 +1,3 @@
 iso:
   bootloader-in-rootfs: true
   grub-entry-name: "SL Micro Realtime Install"
-
-squash-no-compression: true


### PR DESCRIPTION
On rancher/elemental-toolkit#2040 we discovered the `squash-no-compression` flag was not really disabling compression. This has been fixed and the non compressed images are way bigger, so let's use the default compression, which was actually the case before fixing mksquashfs flags