### PR TITLE
ci/ui: add ui-plugin for rancher 2.8 and 2.9

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -36,7 +36,7 @@ filterTests(['main', 'upgrade'], () => {
 
     // Add rancher-ui-plugin-charts repo because its part of Rancher Prime in 2.8 and 2.9-head
     it('Add rancher-ui-plugin-charts repo', () => {
-      isRancherManagerVersion('2.8-head') || isRancherManagerVersion('2.9-head') ? cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main') : null;
+      isRancherManagerVersion('2.8') || isRancherManagerVersion('2.9') ? cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main') : null;
     });
     
     qase(12,


### PR DESCRIPTION
Fix #1342 

Add the `rancher-ui-plugin-charts` for 2.8.3 and 2.9.x because UI extensions are not packaged anymore if you are not a prime user.

## Verification run
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8647805315/job/23710186425) Cypress basics ok ✅ 