### PR TITLE
ci/ui: use different cloud-cfg for upgrade tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -215,7 +215,7 @@ describe('Machine registration testing', () => {
         true,
         //checkIsoBuilding
         true,
-        'custom_cloud-config.yaml',
+        'custom_cloud-config_upgrade.yaml',
         //checkDefaultCloudConfig
         false);
         cy.checkMachInvLabel('machine-registration', 'myInvLabel1', 'myInvLabelValue1', false);

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -52,14 +52,6 @@ describe('Elemental operator upgrade tests', () => {
           cy.clickButton('Upgrade');
           cy.contains('.header > .title', 'elemental-operator');
           cy.clickButton('Next');
-          cy.get('[data-testid="string-input-channel.image"]')
-            .clear()
-          cy.get('[data-testid="string-input-channel.image"]')
-            .type('registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel')
-          cy.get('[data-testid="string-input-channel.tag"]')
-            .clear()
-          cy.get('[data-testid="string-input-channel.tag"]')
-            .type(Cypress.env('elemental_dev_version'))
           cy.clickButton('Upgrade');
           cy.contains('SUCCESS: helm', {timeout:120000});
           cy.contains('Installed App: elemental-operator Pending-Upgrade', {timeout:120000});

--- a/tests/cypress/latest/fixtures/custom_cloud-config_upgrade.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_upgrade.yaml
@@ -1,0 +1,11 @@
+config:
+  cloud-config:
+    users:
+    - name: root
+      passwd: r0s@pwd1
+  elemental:
+    install:
+      poweroff: true
+      device: /dev/sda
+      debug: true
+machineName: my-machine

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -105,7 +105,7 @@ Cypress.Commands.add('createMachReg', (
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
     
-    if (utils.isUIVersion('stable')) {
+    if (utils.isCypressTag('upgrade')) {
       cy.getBySel('select-os-version-build-media')
         .click();
     } else {
@@ -129,15 +129,11 @@ Cypress.Commands.add('createMachReg', (
         // In rare case, we might want to test upgrading from staging to dev
         utils.isUpgradeOsChannel('dev') ? cy.contains('(unstable)').click(): null;
       } else {
-        // We cannot use v2.0.2 because the latest stable operator is not in the marketplace yet
-          //cy.contains('ISO x86_64 v2.0.2')
-          cy.contains('ISO x86_64 v1.2.3')
+          cy.contains('ISO x86_64 v2.0.2')
           .click();
       }
     } else if (utils.isOperatorVersion('registry.suse.com')) {
-      // We cannot use v2.0.2 because the latest stable operator is not in the marketplace yet
-      //cy.contains('ISO x86_64 v2.0.2')
-      cy.contains('ISO x86_64 v1.2.3')
+      cy.contains('ISO x86_64 v2.0.2')
         .click();
     } else {
       cy.contains('(unstable)')


### PR DESCRIPTION
To test upgrade, we install elemental-operator `1.4.2`, so we need a specific cloud-config file, because some options of the `1.6.0` version are incompatible.

## Verification run
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8653793843) ✅ 
[UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8658391882) ⏳ 