### PR TITLE
ci/ui: fix upgrade check

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -131,9 +131,7 @@ describe('Upgrade tests', () => {
           .contains(clusterName)
           .click();
         cy.get('.primaryheader')
-          .contains('Active');
-        cy.get('.primaryheader')
-          .contains('Active', {timeout: 420000}).should('not.exist');
+          .contains('Updating', {timeout: 420000});
         cy.get('.primaryheader')
           .contains('Active', {timeout: 720000});
       })


### PR DESCRIPTION
Sometimes, upgrade is triggered very quickly so Cypress does not have time to see the cluster in Active state.
![image](https://github.com/rancher/elemental/assets/6025636/e7866201-7ad1-4032-ab5a-448da831bee9)

This PR will check that the cluster is in `Updating` stage.

## Verification run
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8685366474) ✅ 
[UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8685367824) ✅ 

[UI-K3s-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/8685380787) ✅ 
[UI-RKE2-OS-Upgrade-RM_head_2.7](https://github.com/rancher/elemental/actions/runs/8686007809) ✅ 