### PR TITLE
ci/ui: bump cypress to 13.7.3

### DIFF
--- a/tests/cypress/latest/cypress.config.ts
+++ b/tests/cypress/latest/cypress.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       return require('./plugins/index.ts')(on, config)
     },
-    experimentalSessionAndOrigin: true,
     supportFile: './support/e2e.ts',
     fixturesFolder: './fixtures',
     screenshotsFolder: './screenshots',

--- a/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
@@ -16,6 +16,10 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import * as utils from '~/support/utils';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -18,6 +18,10 @@ import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import { isCypressTag, isRancherManagerVersion } from '~/support/utils';
 import { Elemental } from '~/support/elemental';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import { isRancherManagerVersion, isUIVersion } from '../../support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 Cypress.config();
 describe('Machine inventory testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 Cypress.config();
 describe('Machine registration testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
@@ -17,6 +17,10 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 filterTests(['main'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -18,6 +18,10 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import * as utils from "~/support/utils";
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 
 Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
@@ -18,6 +18,10 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import * as utils from "~/support/utils";
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 
 Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -17,6 +17,10 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from "~/support/utils";
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { slowCypressDown } from 'cypress-slow-down'
+
+// slow down each command by 500ms
+slowCypressDown(500)
 
 
 Cypress.config();

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -24,10 +24,11 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.0.11",
     "cy-verify-downloads": "^0.1.8",
-    "cypress": "^10.0.0",
+    "cypress": "^13.7.3",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
+    "cypress-slow-down": "^1.3.1",
     "cypress-qase-reporter": "1.4.1",
     "dotenv": "^10.0.0",
     "typescript": "^4.5.2"

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -29,30 +29,6 @@ const hwLabels: hardwareLabels = {
   'TotalMemory': '${System Data/Memory/Total Physical Bytes}'
 };
 
-// Generic commands
-// ////////////////
-
-Cypress.Commands.overwrite('type', (originalFn, subject, text, options = {}) => {
-  options.delay = 100;
-  return originalFn(subject, text, options);
-});
-
-// Add a delay between command without using cy.wait()
-// https://github.com/cypress-io/cypress/issues/249#issuecomment-443021084
-const COMMAND_DELAY = 1000;
-
-for (const command of ['visit', 'click', 'trigger', 'type', 'clear', 'reload', 'contains']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, COMMAND_DELAY);
-    });
-  });
-}; 
-
 // Machine registration commands
 // ///////////////////////////// 
 


### PR DESCRIPTION
Fix #1309 

Migrate Cypress from version 10 to 13
[Migrating to Cypress 13 guide](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-130)
[Migrating to Cypress 12 guide](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-120)
[Migrating to Cypress 11 guide](https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-110)

## Verification runs
[UI-K3s-RM_Stable](https://github.com/rancher/elemental/actions/runs/8689972132) ✅ 
[UI-RKE2-RM_Stable](https://github.com/rancher/elemental/actions/runs/8696146652/job/23848789471) ✅ 
[UI-K3s-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8696148072) ✅ 
[UI-RKE2-OS-Upgrade-RM_Stable](https://github.com/rancher/elemental/actions/runs/8696149512) ✅ 


