### PR TITLE
ci: fix Qase support in manual workflows

### DIFF
--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -21,6 +21,7 @@ on:
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -4,9 +4,6 @@ name: CLI-K3s-OBS_Dev
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -21,6 +18,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+k3s2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -4,9 +4,6 @@ name: CLI-K3s-OBS_Staging
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -21,6 +18,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+k3s2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -4,9 +4,6 @@ name: CLI-K3s-Scalability
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -18,6 +15,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
   schedule:
     # Every Sunday at 4am UTC (11pm in us-central1)
@@ -40,9 +41,9 @@ jobs:
     with:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       node_number: 60
-      qase_run_id: ${{ inputs.qase_run_id }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: cli

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -4,9 +4,6 @@ name: CLI-Multicluster
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -18,6 +15,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -8,9 +8,6 @@ on:
         description: CA type to use (selfsigned or private)
         default: selfsigned
         type: string
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -26,6 +23,9 @@ on:
       operator_repo:
         description: Operator version to use for initial deployment
         default: oci://registry.suse.com/rancher
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -31,6 +31,9 @@ on:
         description: OS repository to test (dev/staging/stable)
         type: string
         default: dev
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
@@ -54,6 +57,7 @@ jobs:
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
       sequential: ${{ inputs.sequential }}

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -4,9 +4,6 @@ name: CLI-RKE2-IBS_Stable
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -21,6 +18,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+rke2r2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -4,9 +4,6 @@ name: CLI-RKE2-OBS_Dev
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -21,6 +18,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+rke2r2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -4,9 +4,6 @@ name: CLI-RKE2-OBS_Staging
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       cluster_type:
         description: Cluster type (empty if normal or hardened)
         type: string
@@ -21,6 +18,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+rke2r2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-rke2-os-upgrade.yaml
+++ b/.github/workflows/cli-rke2-os-upgrade.yaml
@@ -4,9 +4,6 @@ name: CLI-RKE2-Manual-Upgrade-Workflow
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -22,6 +19,10 @@ on:
       operator_repo:
         description: Operator version to use for initial deployment
         default: oci://registry.suse.com/rancher
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -4,10 +4,6 @@ name: UI-K3s-IBS_Stable
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -27,6 +23,10 @@ on:
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -4,10 +4,6 @@ name: UI-K3s-OBS_Dev
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -23,6 +19,10 @@ on:
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -4,10 +4,6 @@ name: UI-K3s-OBS_Staging
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -23,6 +19,10 @@ on:
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-k3s-os-upgrade.yaml
+++ b/.github/workflows/ui-k3s-os-upgrade.yaml
@@ -4,10 +4,6 @@ name: UI-K3s-Manual-Upgrade-Workflow
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -27,6 +23,10 @@ on:
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -35,13 +35,12 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
-        type: string
-      runner_template:
-        description: Runner template to use
-        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
         type: string
 
 jobs:
@@ -59,6 +58,6 @@ jobs:
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
       test_type: ui

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -4,10 +4,6 @@ name: UI-RKE2-IBS_Stable
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -23,6 +19,10 @@ on:
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
         default: v1.26.10+rke2r2
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -4,10 +4,6 @@ name: UI-RKE2-OBS_Dev
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -19,6 +15,10 @@ on:
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
         default: v1.27.8+rke2r1
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -4,10 +4,6 @@ name: UI-RKE2-OBS_Staging
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -19,6 +15,10 @@ on:
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
         default: v1.27.8+rke2r1
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/ui-rke2-os-upgrade.yaml
+++ b/.github/workflows/ui-rke2-os-upgrade.yaml
@@ -4,10 +4,6 @@ name: UI-RKE2-Manual-Upgrade-Workflow
 on:
   workflow_dispatch:
     inputs:
-      qase_run_id:
-        description: Qase run ID where the results will be reported
-        default: auto
-        type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -27,6 +23,10 @@ on:
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation


### PR DESCRIPTION
Some manual workflows didn't had the Qase support. Also set `auto` value for all manual workflows but the ones used by developers.