### PR TITLE
ci: fix Qase report

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -132,7 +132,7 @@ runs:
           echo "Number of nodes in the cluster: ${{ inputs.node_number }}" >> ${GITHUB_STEP_SUMMARY}
         fi
         echo "Type of certificate for Rancher Manager: ${{ inputs.ca_type }}" >> ${GITHUB_STEP_SUMMARY}
-        if ${{ inputs.cluster_type == 'Unknown' }}; then
+        if ${{ inputs.cluster_type == 'Unknown' || inputs.cluster_type == '' }}; then
           echo "Type of cluster deployed: normal" >> ${GITHUB_STEP_SUMMARY}
         else
           echo "Type of cluster deployed: ${{ inputs.cluster_type }}" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -140,6 +140,7 @@ jobs:
       zone: ${{ inputs.zone }}
 
   pre-qase:
+    needs: create-runner
     runs-on: ubuntu-latest
     env:
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
@@ -228,8 +229,8 @@ jobs:
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
 
   clean-and-delete-runner:
-    if: ${{ always() }}
     needs: [create-runner, e2e]
+    if: ${{ always() }}
     uses: ./.github/workflows/sub_clean-and-delete-runner.yaml
     secrets:
       credentials: ${{ secrets.credentials }}
@@ -238,13 +239,12 @@ jobs:
       create_runner_result: ${{ needs.create-runner.result }}
       destroy_runner: ${{ inputs.destroy_runner }}
       runner_hostname: ${{ needs.create-runner.outputs.runner_hostname }}
-      steps_status: ${{ needs.e2e.outputs.steps_status }}
       runner_label: ${{ needs.create-runner.outputs.runner_label }}
       zone: ${{ inputs.zone }}
 
   post-qase:
-    if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
     needs: [pre-qase, e2e]
+    if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
     runs-on: ubuntu-latest
     env:
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
@@ -263,7 +263,7 @@ jobs:
           go-version-file: tests/go.mod
 
       - name: Finalize Qase Run and publish Results
-        if: ${{ !contains(needs.e2e.outputs.steps_status, 'cancelled') && needs.e2e.result != 'cancelled' && needs.create-runner.result == 'success' }}
+        if: ${{ !contains(needs.e2e.outputs.steps_status, 'cancelled') }}
         run: |
           REPORT=$(cd tests && make publish-qase-run)
           echo "${REPORT}"
@@ -276,13 +276,13 @@ jobs:
           fi
 
       - name: Delete Qase Run if job has been cancelled
-        if: ${{ contains(needs.e2e.outputs.steps_status, 'cancelled') || needs.e2e.result == 'cancelled' || needs.create-runner.result != 'success' }}
+        if: ${{ contains(needs.e2e.outputs.steps_status, 'cancelled') }}
         run: cd tests && make delete-qase-run
 
   # Just to signify that something has been cancelled and it's not useful to check the test
   declare-cancelled:
-    if: ${{ always() && (contains(needs.e2e.outputs.steps_status, 'cancelled') || needs.e2e.result == 'cancelled' || needs.create-runner.result != 'success') }}
-    needs: [create-runner, e2e]
+    needs: e2e
+    if: ${{ always() && contains(needs.e2e.outputs.steps_status, 'cancelled') }}
     runs-on: ubuntu-latest
     steps:
       - name: Specify in summary if something has been cancelled

--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -45,6 +45,12 @@ on:
         required: true
         type: string
 
+    # Job outputs to export for caller workflow
+    outputs:
+      step_status:
+        description: Status of the executed test jobs
+        value: ${{ jobs.airgap.outputs.steps_status }}
+
     # Variables to set when calling this reusable workflow
     secrets:
       credentials:

--- a/.github/workflows/sub_clean-and-delete-runner.yaml
+++ b/.github/workflows/sub_clean-and-delete-runner.yaml
@@ -15,10 +15,6 @@ on:
       runner_hostname:
         required: true
         type: string
-      steps_status:
-        description: Status of all the steps from the previous job
-        required: true
-        type: string
       runner_label:
         required: true
         type: string

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -90,6 +90,12 @@ on:
         required: true
         type: string
 
+    # Job outputs to export for caller workflow
+    outputs:
+      steps_status:
+        description: Status of the executed test jobs
+        value: ${{ jobs.cli.outputs.steps_status }}
+
     # Variables to set when calling this reusable workflow
     secrets:
       qase_api_token:

--- a/.github/workflows/sub_multi.yaml
+++ b/.github/workflows/sub_multi.yaml
@@ -63,6 +63,12 @@ on:
         required: true
         type: string
 
+    # Job outputs to export for caller workflow
+    outputs:
+      steps_status:
+        description: Status of the executed test jobs
+        value: ${{ jobs.multi.outputs.steps_status }}
+
     # Variables to set when calling this reusable workflow
     secrets:
       qase_api_token:

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -105,6 +105,12 @@ on:
         required: true
         type: string
 
+    # Job outputs to export for caller workflow
+    outputs:
+      steps_status:
+        description: Status of the executed test jobs
+        value: ${{ join(jobs.*.outputs.steps_status, ' ') }}
+
     # Secrets to set when calling this reusable workflow
     secrets:
       credentials:

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -69,6 +69,12 @@ on:
         required: true
         type: string
 
+    # Job outputs to export for caller workflow
+    outputs:
+      steps_status:
+        description: Status of the executed test jobs
+        value: ${{ jobs.ui.outputs.steps_status }}
+
     # Variables to set when calling this reusable workflow
     secrets:
       qase_api_token:


### PR DESCRIPTION
Add missing dependencies and serialize some steps to allow full restart of runs with matrix.

Verification runs:
- [CLI-OBS-Manual-Workflow #1](https://github.com/rancher/elemental/actions/runs/8712740338)
- [CLI-OBS-Manual-Workflow #2](https://github.com/rancher/elemental/actions/runs/8712747347)
- [Without QASE RUN_ID](https://github.com/rancher/elemental/actions/runs/8712456268)
- [With QASE RUN_ID](https://github.com/rancher/elemental/actions/runs/8712671023)