### PR TITLE
ci/ui: fix cypress test for stable UI

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -105,7 +105,7 @@ Cypress.Commands.add('createMachReg', (
     // Most of the time, it uses the latest dev version but sometimes
     // before releasing, we want to test staging/stable artifacts 
     
-    if (utils.isCypressTag('upgrade')) {
+    if (utils.isCypressTag('upgrade') || utils.isUIVersion('stable')) {
       cy.getBySel('select-os-version-build-media')
         .click();
     } else {


### PR DESCRIPTION
Fix html selector when using stable elemental UI version (1.3.0).

## Verification run
[UI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/8726770808) ✅ 