### PR TITLE
V2.0.x

### DIFF
--- a/.obs/dockerfile/slem-kvm-os/Dockerfile
+++ b/.obs/dockerfile/slem-kvm-os/Dockerfile
@@ -18,7 +18,7 @@ RUN zypper in --no-recommends -y kernel-default-base -kernel-default qemu-guest-
 
 ARG SLEMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
-ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/$SLEMICRO_VERSION
+ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/kvm-$SLEMICRO_VERSION
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The

--- a/.obs/dockerfile/slem-kvm-os/Dockerfile
+++ b/.obs/dockerfile/slem-kvm-os/Dockerfile
@@ -24,7 +24,7 @@ ARG IMAGE_TAG=%VERSION%-%RELEASE%
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
 # values here should reflect the tag of the image being built
 # Also used by elemental-populate-labels
-RUN grep -v IMAGE_REPO /etc/os-release | grep -v "IMAGE_TAG|IMAGE=|TIMESTAMP|GRUB_ENTRY_NAME" > /tmp/os-release
+RUN grep -v "IMAGE_REPO\|IMAGE_TAG\|IMAGE=\|TIMESTAMP\|GRUB_ENTRY_NAME" /etc/os-release > /tmp/os-release
 RUN mv /tmp/os-release /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"                >> /etc/os-release && \

--- a/.obs/dockerfile/slem-os/Dockerfile
+++ b/.obs/dockerfile/slem-os/Dockerfile
@@ -34,7 +34,7 @@ ARG IMAGE_TAG=%VERSION%-%RELEASE%
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
 # values here should reflect the tag of the image being built
 # Also used by elemental-populate-labels
-RUN grep -v IMAGE_REPO /etc/os-release | grep -v "IMAGE_TAG|IMAGE=|TIMESTAMP|GRUB_ENTRY_NAME" > /tmp/os-release
+RUN grep -v "IMAGE_REPO\|IMAGE_TAG\|IMAGE=\|TIMESTAMP\|GRUB_ENTRY_NAME" /etc/os-release > /tmp/os-release
 RUN mv /tmp/os-release /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"              >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"                >> /etc/os-release && \

--- a/.obs/dockerfile/slem-rt-os/Dockerfile
+++ b/.obs/dockerfile/slem-rt-os/Dockerfile
@@ -37,6 +37,8 @@ RUN zypper in --no-recommends -y -- \
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
 # values here should reflect the tag of the image being built
 # Also used by elemental-populate-labels
+RUN grep -v "IMAGE_REPO\|IMAGE_TAG\|IMAGE=\|TIMESTAMP\|GRUB_ENTRY_NAME" /etc/os-release > /tmp/os-release
+RUN mv /tmp/os-release /etc/os-release
 RUN echo IMAGE_REPO=\"${IMAGE_REPO}\"         >> /etc/os-release && \
     echo IMAGE_TAG=\"${IMAGE_TAG}\"           >> /etc/os-release && \
     echo IMAGE=\"${IMAGE_REPO}:${IMAGE_TAG}\" >> /etc/os-release && \

--- a/.obs/dockerfile/slem-rt-os/Dockerfile
+++ b/.obs/dockerfile/slem-rt-os/Dockerfile
@@ -7,16 +7,23 @@
 #
 
 ARG SLEMICRO_VERSION
+
+FROM suse/sle-micro/$SLEMICRO_VERSION:latest AS os
+
+MAINTAINER SUSE LLC (https://www.suse.com/)
+
+ARG SLEMICRO_VERSION
 ARG BUILD_REPO=%%IMG_REPO%%
 ARG IMAGE_REPO=$BUILD_REPO/suse/sle-micro/rt-$SLEMICRO_VERSION
 ARG IMAGE_TAG=%VERSION%-%RELEASE%
 
-FROM suse/sle-micro/$SLEMICRO_VERSION:latest AS os
-
 # dummy zypper call to get elemental into the build context and extract %VERSION% from it via _service
 RUN zypper in --no-recommends -y systemd-presets-branding-SLE-Micro-for-Rancher elemental
 
-MAINTAINER SUSE LLC (https://www.suse.com/)
+# turn base image into a rt image
+RUN zypper in --no-recommends -y -- \
+  -kernel-default \
+  kernel-rt
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.sle.micro.rancher
@@ -28,11 +35,6 @@ LABEL org.opencontainers.image.source="%SOURCEURL%"
 LABEL org.opensuse.reference="${IMAGE_REPO}:${IMAGE_TAG}"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 # endlabelprefix
-
-# turn base image into a rt image
-RUN zypper in --no-recommends -y -- \
-  -kernel-default \
-  kernel-rt
 
 # IMPORTANT: Setup elemental-release used for versioning/upgrade. The
 # values here should reflect the tag of the image being built


### PR DESCRIPTION
This fixes `/etc/os-release` for v2.0.x series. As a consequence also elemental-rt-channel gets the expected values.