### PR TITLE
ci/ui: report raw/iso installation to Qase

### DIFF
--- a/tests/e2e/ui_test.go
+++ b/tests/e2e/ui_test.go
@@ -96,6 +96,9 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 					Expect(err).To(Not(HaveOccurred()))
 
 					if rawBoot {
+						// Report to Qase that we boot from raw image
+						testCaseID = 75
+
 						// The VM will boot first on the recovery partition to create the normal partition
 						// No need to check the recovery process
 						// Only make sure the VM is up and running on the normal partition
@@ -120,6 +123,9 @@ var _ = Describe("E2E - Bootstrap node for UI", Label("ui"), func() {
 							out, _ := exec.Command("sudo", "virsh", "domstate", h).Output()
 							return strings.Trim(string(out), "\n\n")
 						}, tools.SetTimeout(5*time.Minute), 5*time.Second).Should(Equal("shut off"))
+					} else {
+						// Report to Qase that we boot from ISO
+						testCaseID = 9
 					}
 
 				})


### PR DESCRIPTION
Report to QASE when we boot from raw images.

## Verification run
[UI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/8734969179/job/23975910581) 
![image](https://github.com/rancher/elemental/assets/6025636/738120bb-d6d1-47ee-9203-a919dbecc193)

