### PR TITLE
Ci modify scheduling

### DIFF
--- a/.github/workflows/SCHEDULING.md
+++ b/.github/workflows/SCHEDULING.md
@@ -4,17 +4,19 @@ We try to spread the tests as best as we can to avoid SPOT issue as well as not 
 
 | Test type | Day(s) | Hour |
 |:---:|:---:|:---:|
-| CLI K3s | Monday to Saturday | 6am |
-| CLI K3s Upgrade | Monday to Saturday | 8am |
-| CLI RKE2 | Monday to Saturday | 7am |
-| CLI RKE2 Upgrade | Monday to Saturday | 9am |
-| CLI K3s Airgap | Sunday | 2am |
-| CLI K3s Scalability | Sunday | 4am |
+| CLI K3s | Monday to Saturday | 3am |
+| CLI K3s Upgrade | Monday to Saturday | 7am |
+| CLI RKE2 | Monday to Saturday | 5am |
+| CLI RKE2 Upgrade | Monday to Saturday | 8am |
+| CLI K3s Airgap | Sunday | 1am |
+| CLI K3s Scalability | Sunday | 2am |
 | CLI Multicluster | Sunday | 5am |
-| UI K3s | Monday to Saturday | 2am |
-| UI K3s Upgrade | Monday to Saturday | 4am |
-| UI RKE2 | Monday to Saturday | 3am |
-| UI RKE2 Upgrade | Monday to Saturday | 5am |
+| CLI Rancher Manager Devel | Sunday | 8am |
+| UI Rancher Manager Devel | Sunday | 12am |
+| UI K3s | Monday to Saturday | 11pm |
+| UI K3s Upgrade | Monday to Saturday | 1am |
+| UI RKE2 | Monday to Saturday | 0am |
+| UI RKE2 Upgrade | Monday to Saturday | 2am |
 | Update tests description | All days | 11pm |
 
 **NOTE:** please note that the GitHub scheduler uses UTC and our GCP runners are deployed in `us-central1`, so UTC-5.

--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -21,8 +21,8 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # Every Sunday at 2am UTC (9pm in us-central1)
-    - cron: '0 2 * * 0'
+    # Every Sunday at 1am UTC (8pm in us-central1)
+    - cron: '0 1 * * 0'
 
 jobs:
   cli:

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -33,8 +33,8 @@ on:
         default: false
         type: boolean
   schedule:
-    # From Monday to Saturday at 6am UTC (1am in us-central1)
-    - cron: '0 6 * * 1-6'
+    # From Monday to Saturday at 3am UTC (10pm in us-central1)
+    - cron: '0 3 * * 1-6'
 
 jobs:
   cli:

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -46,7 +46,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -21,8 +21,8 @@ on:
         default: auto
         type: string
   schedule:
-    # Every Sunday at 4am UTC (11pm in us-central1)
-    - cron: '0 4 * * 0'
+    # Every Sunday at 2am UTC (9pm in us-central1)
+    - cron: '0 2 * * 0'
 
 jobs:
   cli:

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"latest/devel/2.8"'
         type: string
   schedule:
-    # From Monday to Saturday at 8am UTC (3am in us-central1)
-    - cron: '0 8 * * 1-6'
+    # From Monday to Saturday at 7am UTC (2am in us-central1)
+    - cron: '0 7 * * 1-6'
 
 jobs:
   cli:

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -25,7 +25,7 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # Every Sunday at 8am UTC (3am in us-central1)
+    # Every Sunday at 5am UTC (0am in us-central1)
     - cron: '0 5 * * 0'
 
 jobs:

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -52,15 +52,15 @@ jobs:
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.8+k3s2
-            k8s_upstream_version: v1.26.10+k3s2
+            k8s_downstream_version: v1.27.8+rke2r1
+            k8s_upstream_version: v1.26.10+rke2r2
             rancher_version: stable/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.8+k3s2
-            k8s_upstream_version: v1.26.10+k3s2
+            k8s_downstream_version: v1.27.8+rke2r1
+            k8s_upstream_version: v1.26.10+rke2r2
             rancher_version: stable/latest
             reset: true
             sequential: false

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -33,8 +33,8 @@ on:
         default: false
         type: boolean
   schedule:
-    # From Monday to Saturday at 7am UTC (2am in us-central1)
-    - cron: '0 7 * * 1-6'
+    # From Monday to Saturday at 5am UTC (0am in us-central1)
+    - cron: '0 5 * * 1-6'
 
 jobs:
   cli:

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -46,7 +46,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"latest/devel/2.8"'
         type: string
   schedule:
-    # From Monday to Saturday at 9am UTC (4am in us-central1)
-    - cron: '0 9 * * 1-6'
+    # From Monday to Saturday at 8am UTC (3am in us-central1)
+    - cron: '0 8 * * 1-6'
 
 jobs:
   cli:

--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -1,0 +1,74 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-Rancher-Manager-Head-2.9
+
+on:
+  workflow_dispatch:
+    inputs:
+      ca_type:
+        description: CA type to use (selfsigned or private)
+        default: '"selfsigned"'
+        type: string
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        default: '""'
+        type: string
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      k8s_downstream_version:
+        description: Rancher cluster downstream version to use
+        default: '"v1.27.8+k3s2"'
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: '"v1.26.10+k3s2"'
+        type: string
+      rancher_version:
+        description: Rancher Manager channel/version/head_version to use
+        default: '"latest/devel/2.9"'
+        type: string
+      reset:
+        description: Allow reset test (mainly used on CLI tests)
+        default: false
+        type: boolean
+  schedule:
+    # Every Sunday at 8am UTC (3am in us-central1)
+    - cron: '0 8 * * 0'
+
+jobs:
+  cli:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
+        cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2","v1.27.8+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2","v1.27.10+rke2r2"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
+        reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
+        sequential: [ false ]
+        include:
+          - ca_type: selfsigned
+            cluster_type: ""
+            reset: true
+            sequential: true
+          - ca_type: private
+            cluster_type: hardened
+            reset: true
+            sequential: false
+    uses: ./.github/workflows/master_e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+    with:
+      ca_type: ${{ matrix.ca_type }}
+      cluster_type: ${{ matrix.cluster_type }}
+      destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
+      k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
+      k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      rancher_version: ${{ matrix.rancher_version }}
+      reset: ${{ matrix.reset }}
+      sequential: ${{ matrix.sequential }}
+      test_type: cli

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # From Monday to Saturday at 2am UTC (9pm in us-central1)
-    - cron: '0 2 * * 1-6'
+    # From Monday to Saturday at 11pm UTC (6pm in us-central1)
+    - cron: '0 23 * * 1-6'
 
 jobs:
   ui:

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # From Monday to Saturday at 4am UTC (11pm in us-central1)
-    - cron: '0 4 * * 1-6'
+    # From Monday to Saturday at 1am UTC (8pm in us-central1)
+    - cron: '0 1 * * 1-6'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # From Monday to Saturday at 3am UTC (10pm in us-central1)
-    - cron: '0 3 * * 1-6'
+    # From Monday to Saturday at 0am UTC (7pm in us-central1)
+    - cron: '0 0 * * 1-6'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -25,8 +25,8 @@ on:
         default: '"stable/latest"'
         type: string
   schedule:
-    # From Monday to Saturday at 5am UTC (0am in us-central1)
-    - cron: '0 5 * * 1-6'
+    # From Monday to Saturday at 2am UTC (9pm in us-central1)
+    - cron: '0 2 * * 1-6'
 
 jobs:
   ui:

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -1,0 +1,59 @@
+# This workflow calls the master E2E workflow with custom variables
+name: UI-Rancher-Manager-Head-2.9
+
+on:
+  workflow_dispatch:
+    inputs:
+      boot_type:
+        description: Type of image used for bootstrapping the nodes
+        default: '"iso"'
+        type: string
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      k8s_downstream_version:
+        description: Rancher cluster downstream version to use
+        default: '"v1.27.8+k3s2"'
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: '"v1.26.10+k3s2"'
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      rancher_version:
+        description: Rancher Manager channel/version/head_version to use
+        default: '"latest/devel/2.9"'
+        type: string
+  schedule:
+    # Every Sunday at 12am UTC (7am in us-central1)
+    - cron: '0 23 * * 1-6'
+
+jobs:
+  ui:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        boot_type: ${{ fromJSON(format('[{0}]', inputs.boot_type || '"iso","raw"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2","v1.27.8+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2","v1.27.19+rke2r2"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
+    uses: ./.github/workflows/master_e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+    with:
+      boot_type: ${{ matrix.boot_type }}
+      ca_type: selfsigned
+      cypress_tags: main
+      destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
+      elemental_ui_version: dev
+      k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
+      k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      proxy: ${{ inputs.proxy || 'elemental' }}
+      rancher_version: ${{ matrix.rancher_version }}
+      test_type: ui

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 [![CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml)
 [![CLI-K3s-Scalability](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml)
 [![CLI-Multicluster](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml)
+[![CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix.yaml)
+[![UI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix.yaml)
 
 ## Goal
 


### PR DESCRIPTION
- ci: remove nightly tests for Rancher devel/2.9
- ci: move Rancher Head-2.9 tests on Sunday
- ci: reschedule the workflows
- ci/cli: fix RKE2 workflow

