### PR TITLE
ci/ui: increase download time for raw image

### DIFF
--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -42,7 +42,10 @@ jobs:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
     with:
-      boot_type: raw
+      # Should be raw for RKE2 but raw image feature is not in stable version.
+      # We will enable it back once the new elemental released
+      # boot_type: raw
+      boot_type: iso
       ca_type: private
       cypress_tags: upgrade
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -87,7 +87,7 @@ Cypress.Commands.add('createMachReg', (
     } else {
       cy.getBySel('select-media-type-build-media')
         .click();
-      if (Cypress.env('boot_type') == 'raw') {
+      if (utils.isBootType('raw')) {
         cy.contains('Raw')
           .click();
       } else {
@@ -129,10 +129,13 @@ Cypress.Commands.add('createMachReg', (
     })
     cy.getBySel(`download-media-btn`)
       .click()
-    if (Cypress.env('boot_type') == 'raw') {
-      cy.verifyDownload('.raw', { contains:true, timeout: 180000, interval: 5000 });
+    // RAW image not available in upgrade scenario because we start from stable
+    // and RAW feature is not already available in stable
+    // upgrade condition will be removed in next elemental stable version
+    if (utils.isBootType('raw') && !utils.isCypressTag('upgrade')) {
+      cy.verifyDownload('.raw', { contains:true, timeout: 300000, interval: 5000 });
     } else {
-      cy.verifyDownload('.iso', { contains:true, timeout: 180000, interval: 5000 });
+      cy.verifyDownload('.iso', { contains:true, timeout: 300000, interval: 5000 });
     }
   }
   

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -1,7 +1,11 @@
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 
+// Check the boot type
+export const isBootType = (bootType: string) => {
+  return (new RegExp(bootType)).test(Cypress.env("boot_type"));
+}
+
 // Check the Cypress tags
-// Implemented but not used yet
 export const isCypressTag = (tag: string) => {
   return (new RegExp(tag)).test(Cypress.env("cypress_tags"));
 }


### PR DESCRIPTION
- Remove boot type raw for RKE2 upgrade because the feature does not exist on Stable
- Create `isBootType` function
- Increase timeout to download the media build

## Verification run
[UI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/8782230157) ✅ 