### PR TITLE
ci: enable qase for all tests

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -37,6 +37,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -68,6 +68,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       ca_type: ${{ matrix.ca_type }}
       cluster_type: ${{ matrix.cluster_type }}

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       cluster_type: ${{ matrix.cluster_type }}
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -68,6 +68,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       ca_type: ${{ matrix.ca_type }}
       cluster_type: ${{ matrix.cluster_type }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -42,6 +42,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       cluster_type: ${{ matrix.cluster_type }}
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}

--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -62,6 +62,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       ca_type: ${{ matrix.ca_type }}
       cluster_type: ${{ matrix.cluster_type }}

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -67,6 +67,7 @@ on:
         type: string
       qase_run_id:
         description: Case run ID where the results will be reported
+        default: auto
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
@@ -170,7 +171,7 @@ jobs:
             # Define and export the Qase run name, as it cannot be done
             # in 'env:' because GITHUB_WORKFLOW is a shell variable
             # Export them also to be used locally
-            export QASE_RUN_NAME="${GITHUB_WORKFLOW}"
+            export QASE_RUN_NAME="${GITHUB_WORKFLOW}-RM_${{inputs.rancher_version}}-UP_${{inputs.k8s_upstream_version}}-DOWN_${{inputs.k8s_downstream_version}}"
 
             # Create a Qase run, get its ID
             ID=$(cd tests && make create-qase-run)

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       boot_type: iso
       ca_type: selfsigned

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       boot_type: iso
       ca_type: selfsigned

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       boot_type: raw
       ca_type: private

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -41,6 +41,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       # Should be raw for RKE2 but raw image feature is not in stable version.
       # We will enable it back once the new elemental released

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -46,6 +46,7 @@ jobs:
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
       boot_type: ${{ matrix.boot_type }}
       ca_type: selfsigned


### PR DESCRIPTION
Fix #1379 

In the following screenshot, we can see that UI-K3S and Airgap (daily tests) are reported to QASE:

![image](https://github.com/rancher/elemental/assets/6025636/8d8b88fb-f0dd-41b0-a172-1a78510b3ad3)


I also added variables into the QASE run name to easily identify jobs.