### PR TITLE
ci: fix github badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 ## Weekly CI
 
-[![CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml)
-[![CLI-K3s-Scalability](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml)
-[![CLI-Multicluster](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml)
-[![CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix.yaml)
-[![UI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix.yaml)
+[![CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml)
+[![CLI-K3s-Scalability](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml)
+[![CLI-Multicluster](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml)
+[![CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.9-matrix.yaml)
+[![UI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.9-matrix.yaml)
 
 ## Goal
 


### PR DESCRIPTION
Fix bad links for Github badges

## Currently:
![image](https://github.com/rancher/elemental/assets/6025636/36a87369-0ded-4774-b138-b555ac76e0a9)

## With my branch:
![image](https://github.com/rancher/elemental/assets/6025636/3b3e34e2-7549-4336-8a7f-b190bddaeb46)
