### PR TITLE
ci/ui: install operator from market if requested

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -172,6 +172,7 @@ jobs:
 
       - name: Install Chartmuseum
         id: install_chartmuseum
+        if: ${{ inputs.operator_repo != 'marketplace' }}
         env: 
           OPERATOR_REPO: ${{ inputs.operator_repo }}
         run: |

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -1,0 +1,62 @@
+# This workflow calls the master E2E workflow with custom variables
+# Run the test using the latest elemental operator chart (pushed to head version first)
+name: UI-Marketplace-Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      boot_type:
+        description: Boot type (iso/raw)
+        default: iso
+        type: string
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      elemental_ui_version:
+        description: Elemental UI version to use
+        default: stable
+        type: string
+      k8s_downstream_version:
+        description: Rancher cluster downstream version to use
+        default: v1.27.8+k3s2
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: v1.26.10+k3s2
+        type: string
+      operator_repo:
+        description: Elemental operator repository to use
+        default: marketplace
+        type: string
+      proxy:
+        description: Deploy a proxy (none/rancher/elemental)
+        default: elemental
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
+      rancher_version:
+        description: Rancher Manager channel/version/head_version to use for installation
+        default: latest/devel/2.9
+        type: string
+
+jobs:
+  ui:
+    uses: ./.github/workflows/master_e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
+    with:
+      boot_type: ${{ inputs.boot_type }}
+      cluster_type: ${{ inputs.cluster_type }}
+      destroy_runner: ${{ inputs.destroy_runner }}
+      elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
+      k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
+      operator_repo: ${{ inputs.operator_repo }}
+      proxy: ${{ inputs.proxy }}
+      qase_run_id: ${{ inputs.qase_run_id }}
+      rancher_version: ${{ inputs.rancher_version }}
+      test_type: ui

--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -16,7 +16,7 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { isCypressTag, isRancherManagerVersion } from '~/support/utils';
+import { isCypressTag, isOperatorVersion, isRancherManagerVersion } from '~/support/utils';
 import { Elemental } from '~/support/elemental';
 import { slowCypressDown } from 'cypress-slow-down'
 
@@ -34,7 +34,7 @@ filterTests(['main', 'upgrade'], () => {
       cypressLib.burgerMenuToggle();
     });
     // Add dev repo for main test or if the test runs on rancher 2.7 (because operator is not in the 2.7 marketplace)
-    if (isCypressTag('main') || isRancherManagerVersion('2.7')) {
+    if (!isOperatorVersion('marketplace') && isCypressTag('main') || isRancherManagerVersion('2.7')) {
       it('Add local chartmuseum repo', () => {
         cypressLib.addRepository('elemental-operator', Cypress.env('chartmuseum_repo')+':8080', 'helm', 'none');
       });
@@ -43,7 +43,7 @@ filterTests(['main', 'upgrade'], () => {
           elemental.installElementalOperator();
         })
       );
-    } else if (isCypressTag('upgrade') && !isRancherManagerVersion('2.7')) {
+    } else if (!isRancherManagerVersion('2.7')) {
       qase(57,
         it('Install latest stable Elemental operator', () => {
           elemental.installElementalOperator();

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -108,7 +108,7 @@ Cypress.Commands.add('createMachReg', (
           cy.contains('ISO x86_64 v2.0.2')
           .click();
       }
-    } else if (utils.isOperatorVersion('registry.suse.com')) {
+    } else if (utils.isOperatorVersion('registry.suse.com') || utils.isOperatorVersion('marketplace')) {
       cy.contains('ISO x86_64 v2.0.2')
         .click();
     } else {

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { isCypressTag } from '~/support/utils';
+import { isCypressTag, isOperatorVersion } from '~/support/utils';
 export class Elemental {
   // Go into the cluster creation menu
   accessClusterMenu() {
@@ -54,7 +54,7 @@ export class Elemental {
     .click();
     cy.get('.nav').contains('Apps')
       .click();
-    if (isCypressTag('main')) {
+    if (isCypressTag('main') && !isOperatorVersion('marketplace')) {
       cy.contains('.item.has-description.color1', 'Elemental', {timeout:30000})
         .click();
     } else {


### PR DESCRIPTION
Partially address #1305 

We can use the [UI-Marketplace-Workflowl](https://github.com/rancher/elemental/actions/workflows/ui-marketplace-workflow.yaml) workflow to run standard tests like this:

Make sure to set:
- operator repo to `marketplace` 
- ui-extension to `stable`
- rancher version to a dev version
<img src="https://github.com/rancher/elemental/assets/6025636/a6fa39fc-9426-455b-b593-7d1b50e76eca" width="400">

## Verification run
[UI-Marketplace-Workflow](https://github.com/rancher/elemental/actions/runs/8817856173/job/24205375550) ❌
The test fails because the elemental operator from the marketplace is quite old (1.4.2), so the cypress code is not compatible anymore (mainly for hostname and recovery partition).
The test will work when the 1.5 operator will be pushed into the marketplace.

[UI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/8817590846) ✅ 
[UI-K3s](https://github.com/rancher/elemental/actions/runs/8818031636) ✅ 

- [x] Documentation