### PR TITLE
ci: disable qase report for verification runs

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -16,6 +16,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -42,5 +45,6 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: airgap

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -24,6 +24,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -75,6 +78,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
         default: '"latest/devel/2.8"'
@@ -51,6 +54,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -18,7 +18,6 @@ on:
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
-        default: auto
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -24,6 +24,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -75,6 +78,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+rke2r2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
         default: '"latest/devel/2.8"'
@@ -51,6 +54,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true

--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -24,6 +24,9 @@ on:
         description: Rancher cluster upstream version to use
         default: '"v1.26.10+k3s2"'
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"latest/devel/2.9"'
@@ -69,6 +72,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -51,5 +54,6 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -51,6 +54,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -51,6 +54,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       # Disable user account due to https://github.com/rancher/elemental-ui/issues/175

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -20,6 +20,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
@@ -54,6 +57,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       # Disable user account due to https://github.com/rancher/elemental-ui/issues/175

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -24,6 +24,9 @@ on:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
         type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
         default: '"latest/devel/2.9"'
@@ -56,5 +59,6 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
+      qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui


### PR DESCRIPTION
Disable QASE reporting for workflow we use to validate pull request, mainly to avoid noise in our QASE tracking.

## Verification run
- VR without anything in `qase_run_id`
https://github.com/rancher/elemental/actions/runs/8879307454
```
Run if false; then
  if false; then
    # Define and export URL of GH test run in Qase run description
    GH_RUN_URL="https://github.com/rancher/elemental/actions/runs/8879[3](https://github.com/rancher/elemental/actions/runs/8879307454/job/24376829069#step:4:3)07454"
    export QASE_RUN_DESCRIPTION="${GH_RUN_URL}"
```

- VR with `auto`:
 https://github.com/rancher/elemental/actions/runs/8879401433
```
Run if true; then
go: downloading github.com/go-task/slim-sprig v0.0.0-202[30](https://github.com/rancher/elemental/actions/runs/8879401433/job/24377106618#step:4:31)315185526-52ccab3ef572
go: downloading golang.org/x/tools v0.18.0
go: downloading github.com/google/pprof v0.0.0-20240207164012-fb44976bdcd5
go: downloading golang.org/x/mod v0.15.0
go: downloading libvirt.org/libvirt-go-xml v7.4.0+incompatible
go: downloading gopkg.in/check.v1 v1.0.0-2018062817[31](https://github.com/rancher/elemental/actions/runs/8879401433/job/24377106618#step:4:32)08-788fd7840127
go: downloading github.com/stretchr/testify v1.8.1
go: downloading go.uber.org/goleak v1.3.0
go: downloading github.com/kr/pretty v0.1.0
go: downloading google.golang.org/protobuf v1.[33](https://github.com/rancher/elemental/actions/runs/8879401433/job/24377106618#step:4:34).0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading golang.org/x/term v0.17.0
go: downloading github.com/kr/text v0.2.0
go: downloading google.golang.org/appengine v1.6.8
go: downloading github.com/golang/protobuf v1.5.3
Exported values:
QASE_RUN_ID=664
QASE_RUN_DESCRIPTION=https://github.com/rancher/elemental/actions/runs/8879[40](https://github.com/rancher/elemental/actions/runs/8879401433/job/24377106618#step:4:41)1433
QASE_RUN_NAME=UI-K3s-RM_stable/latest-UP_v1.26.10+k3s2-DOWN_v1.27.8+k3s2
```