### PR TITLE
Set layout with yaml format

### DIFF
--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -49,7 +49,7 @@ stages:
               - /var/lib/kubelet
               - /var/lib/NetworkManager
               - /var/lib/cni
-              - /var/calico
+              - /var/lib/calico
     - if: '[ -f "/run/elemental/recovery_mode" ]'
       name: "Layout configuration for recovery"
       files: 

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -21,32 +21,42 @@ stages:
   rootfs:
     - if: '[ ! -f "/run/elemental/recovery_mode" ]'
       name: "Layout configuration"
-      environment_file: /run/elemental/mount-layout.env
-      environment:
-        OVERLAY: "tmpfs:25%"
-        RW_PATHS: "/var /etc /srv"
-        PERSISTENT_STATE_PATHS: >-
-          /etc/systemd
-          /etc/rancher
-          /etc/ssh
-          /etc/iscsi
-          /etc/cni
-          /home
-          /opt
-          /root
-          /usr/libexec
-          /usr/local
-          /var/log
-          /var/lib/elemental
-          /var/lib/rancher
-          /var/lib/kubelet
-          /var/lib/NetworkManager
-          /var/lib/cni
-          /var/lib/calico
-        PERSISTENT_STATE_BIND: "true"
+      files: 
+      - path: /etc/elemental/config.d/layout.yaml
+        content: |
+          mount:
+            write-fstab: true
+            ephemeral:
+              type: tmpfs
+              size: 25%
+              paths: ['/etc', '/var', '/srv']
+            persistent:
+              mode: bind
+              paths:
+              - /etc/systemd
+              - /etc/rancher
+              - /etc/ssh
+              - /etc/iscsi
+              - /etc/cni
+              - /home
+              - /opt
+              - /root
+              - /usr/libexec
+              - /usr/local
+              - /var/log
+              - /var/lib/elemental
+              - /var/lib/rancher
+              - /var/lib/kubelet
+              - /var/lib/NetworkManager
+              - /var/lib/cni
+              - /var/calico
     - if: '[ -f "/run/elemental/recovery_mode" ]'
-      # omit the persistent partition on recovery mode
       name: "Layout configuration for recovery"
-      environment_file: /run/elemental/mount-layout.env
-      environment:
-        OVERLAY: "tmpfs:25%"
+      files: 
+      - path: /etc/elemental/config.d/layout.yaml
+        content: |
+          mount:
+            write-fstab: true
+            ephemeral:
+              type: tmpfs
+              size: 25%


### PR DESCRIPTION
I prefer having the explicit configuration on yaml and it provides additional configuration possibilities and it is also way more explicit.

This makes it easier to experiment with other setups like having persistent mounted on /var by default, which I think it could be interesting from the SELinux perspective.

Related with #1362