### PR TITLE
Fix grub2-x86_64-efi installation

### DIFF
--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -24,7 +24,7 @@ RUN zypper --installroot /osimage in --no-recommends -y filesystem
 RUN zypper --installroot /osimage in --no-recommends -y grub2 shim dracut iputils kernel-default systemd bash
 
 #!ArchExclusiveLine: x86_64
-RUN if [ `uname -m` = "x86-64" ]; then zypper --installroot /osimage in --no-recommends -y syslinux grub2-i386-pc grub2-x86_64-efi; fi
+RUN if [ `uname -m` = "x86_64" ]; then zypper --installroot /osimage in --no-recommends -y syslinux grub2-i386-pc grub2-x86_64-efi; fi
 
 # make dracut happy
 RUN zypper --installroot /osimage in --no-recommends -y squashfs NetworkManager-branding-SLE NetworkManager device-mapper iproute2 tar curl ca-certificates ca-certificates-mozilla


### PR DESCRIPTION
Suprisingly enough this has not popped up until late April, when 5.5 images started to fail due to missing grub2-x86_64-efi package.

Apparently this package is usually already installed as part of the previous steps and the explicit installation is usually unneeded in OBS, however for some reason under the stack 5.5 the explicit installation is needed since late April.