### PR TITLE
Removing syslinux from base image

### DIFF
--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -24,7 +24,7 @@ RUN zypper --installroot /osimage in --no-recommends -y filesystem
 RUN zypper --installroot /osimage in --no-recommends -y grub2 shim dracut iputils kernel-default systemd bash
 
 #!ArchExclusiveLine: x86_64
-RUN if [ `uname -m` = "x86_64" ]; then zypper --installroot /osimage in --no-recommends -y syslinux grub2-i386-pc grub2-x86_64-efi; fi
+RUN if [ `uname -m` = "x86_64" ]; then zypper --installroot /osimage in --no-recommends -y grub2-i386-pc grub2-x86_64-efi; fi
 
 # make dracut happy
 RUN zypper --installroot /osimage in --no-recommends -y squashfs NetworkManager-branding-SLE NetworkManager device-mapper iproute2 tar curl ca-certificates ca-certificates-mozilla


### PR DESCRIPTION
Syslinux is no longer needed as there is no support for legacy firmware anymore.