### PR TITLE
ci/cli: upgrade Rancher Manager only to 2.8.x

### DIFF
--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7","latest/devel/2.8"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
As only Stable version is installed (2.8.x), so upgrading to an older version is neither very useful nor allowed.

Verification runs:
- [CLI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/9074699836)
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/9069549421)