### PR TITLE
ci/ui: enable user account back

### DIFF
--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -54,6 +54,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -48,5 +48,4 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -57,6 +57,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user
       zone: us-central1-b

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -44,5 +44,4 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -44,5 +44,4 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -60,7 +60,6 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
-      # Disable user account due to https://github.com/rancher/elemental-ui/issues/175
-      #ui_account: user
+      ui_account: user
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest
       zone: us-central1-b


### PR DESCRIPTION
As https://github.com/rancher/elemental-ui/issues/175 is fixed in latest dev UI, we can enable user account usage in RKE2 tests.

## Verification run
https://github.com/rancher/elemental/actions/runs/9062711370/job/24897191450