### PR TITLE
ci: add os downgrade test

### DIFF
--- a/.github/workflows/SCHEDULING.md
+++ b/.github/workflows/SCHEDULING.md
@@ -13,6 +13,7 @@ We try to spread the tests as best as we can to avoid SPOT issue as well as not 
 | CLI Multicluster | Sunday | 5am | us-central1-b |
 | CLI Rancher Manager Devel | Sunday | 8am | us-central1-c |
 | UI Rancher Manager Devel | Sunday | 12pm | us-central1-a |
+| CLI K3s Downgrade | Sunday | 2pm | us-central1-b |
 | UI K3s | Monday to Saturday | 2am | us-central1-a |
 | UI K3s Upgrade | Monday to Saturday | 4am | us-central1-a |
 | UI RKE2 | Monday to Saturday | 2am | us-central1-b |

--- a/.github/workflows/SCHEDULING.md
+++ b/.github/workflows/SCHEDULING.md
@@ -12,7 +12,7 @@ We try to spread the tests as best as we can to avoid SPOT issue as well as not 
 | CLI K3s Scalability | Sunday | 2am | us-central1-f |
 | CLI Multicluster | Sunday | 5am | us-central1-b |
 | CLI Rancher Manager Devel | Sunday | 8am | us-central1-c |
-| UI Rancher Manager Devel | Sunday | 12am | us-central1-a |
+| UI Rancher Manager Devel | Sunday | 12pm | us-central1-a |
 | UI K3s | Monday to Saturday | 2am | us-central1-a |
 | UI K3s Upgrade | Monday to Saturday | 4am | us-central1-a |
 | UI RKE2 | Monday to Saturday | 2am | us-central1-b |

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -1,0 +1,55 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-K3s-Downgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_type:
+        description: Cluster type (empty if normal or hardened)
+        default: '""'
+        type: string
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      k8s_downstream_version:
+        description: Rancher cluster downstream version to use
+        default: '"v1.27.8+k3s2"'
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: '"v1.26.10+k3s2"'
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
+  schedule:
+    # Every Sunday at 2pm UTC (9am in us-central1)
+    - cron: '0 14 * * 0'
+
+jobs:
+  cli:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+    uses: ./.github/workflows/master_e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
+    with:
+      cluster_type: ${{ matrix.cluster_type }}
+      destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
+      force_downgrade: true
+      k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
+      k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      node_number: 3
+      qase_run_id: ${{ inputs.qase_run_id }}
+      rancher_version: stable/latest
+      test_type: cli
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/staging/containers/suse/sl-micro/6.0/baremetal-os-container:latest
+      zone: us-central1-b

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -41,6 +41,10 @@ on:
         description: Version of the elemental ui which will be installed (dev/stable)
         default: dev
         type: string
+      force_downgrade:
+        description: Force OS downgrade
+        default: false
+        type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
         type: string
@@ -209,6 +213,7 @@ jobs:
       cypress_tags: ${{ inputs.cypress_tags }}
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
+      force_downgrade: ${{ inputs.force_downgrade }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -29,6 +29,9 @@ on:
       destroy_runner:
         required: true
         type: boolean
+      force_downgrade:
+        required: true
+        type: boolean
       k8s_downstream_version:
         required: true
         type: string
@@ -321,6 +324,7 @@ jobs:
         id: upgrade_node_1
         if: ${{ inputs.upgrade_image != '' }}
         env:
+          FORCE_DOWNGRADE: ${{ inputs.force_downgrade }}
           UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
           UPGRADE_TYPE: osImage
           VM_INDEX: 1
@@ -334,6 +338,7 @@ jobs:
         id: upgrade_other_nodes
         if: ${{ inputs.upgrade_os_channel != '' }}
         env:
+          FORCE_DOWNGRADE: ${{ inputs.force_downgrade }}
           UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
           UPGRADE_TYPE: managedOSVersionName
           VM_INDEX: 2
@@ -381,6 +386,7 @@ jobs:
 
       - name: Create ISO image for worker pool
         id: create_iso_worker
+        if: ${{ inputs.node_number > 3 }}
         env:
           BOOT_TYPE: iso
           OS_TO_TEST: ${{ inputs.os_to_test }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -38,6 +38,9 @@ on:
       elemental_ui_version:
         required: true
         type: string
+      force_downgrade:
+        required: true
+        type: boolean
       k8s_downstream_version:
         required: true
         type: string
@@ -155,6 +158,7 @@ jobs:
       cluster_namespace: ${{ inputs.cluster_namespace }}
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
+      force_downgrade: ${{ inputs.force_downgrade }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -32,8 +32,8 @@ on:
         default: '"latest/devel/2.9"'
         type: string
   schedule:
-    # Every Sunday at 12am UTC (7am in us-central1)
-    - cron: '0 23 * * 1-6'
+    # Every Sunday at 12pm UTC (7am in us-central1)
+    - cron: '0 12 * * 0'
 
 jobs:
   ui:

--- a/tests/assets/upgrade_skel.yaml
+++ b/tests/assets/upgrade_skel.yaml
@@ -9,3 +9,7 @@ spec:
   %UPGRADE_TYPE%
   clusterTargets:
     - clusterName: %CLUSTER_NAME%
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "%FORCE_DOWNGRADE%"

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -35,7 +35,7 @@ func checkClusterAgent(client *tools.Client) {
 	Eventually(func() string {
 		out, _ := client.RunSSH("kubectl get pod -n cattle-system -l app=cattle-cluster-agent")
 		return out
-	}, tools.SetTimeout(3*time.Duration(usedNodes)*time.Minute), 10*time.Second).Should(ContainSubstring("Running"))
+	}, tools.SetTimeout(5*time.Duration(usedNodes)*time.Minute), 10*time.Second).Should(ContainSubstring("Running"))
 }
 
 var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {

--- a/tests/e2e/configure_test.go
+++ b/tests/e2e/configure_test.go
@@ -33,13 +33,8 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 		// Report to Qase
 		testCaseID = 30
 
-		type pattern struct {
-			key   string
-			value string
-		}
-
 		// Patterns to replace
-		basePatterns := []pattern{
+		basePatterns := []YamlPattern{
 			{
 				key:   "%CLUSTER_NAME%",
 				value: clusterName,
@@ -73,7 +68,7 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 
 			for _, pool := range []string{"master", "worker"} {
 				// Patterns to replace
-				addPatterns := []pattern{
+				addPatterns := []YamlPattern{
 					{
 						key:   "%POOL_TYPE%",
 						value: pool,
@@ -108,7 +103,7 @@ var _ = Describe("E2E - Configure test", Label("configure"), func() {
 
 			for _, pool := range []string{"master", "worker"} {
 				// Patterns to replace
-				addPatterns := []pattern{
+				addPatterns := []YamlPattern{
 					{
 						key:   "%PASSWORD%",
 						value: userPassword,

--- a/tests/e2e/multi-cluster_test.go
+++ b/tests/e2e/multi-cluster_test.go
@@ -34,13 +34,8 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 	const seedImageName = "seed-image-multi"
 	const machineRegName = "machine-registration-multi"
 
-	type pattern struct {
-		key   string
-		value string
-	}
-
 	var (
-		basePatterns []pattern
+		basePatterns []YamlPattern
 		globalNodeID int
 		wg           sync.WaitGroup
 	)
@@ -48,7 +43,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 	BeforeEach(func() {
 
 		// Patterns to replace
-		basePatterns = []pattern{
+		basePatterns = []YamlPattern{
 			{
 				key:   "%K8S_VERSION%",
 				value: k8sDownstreamVersion,
@@ -153,7 +148,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 			err = tools.CopyFile(seedImageYaml, seedImageTmp)
 			Expect(err).To(Not(HaveOccurred()))
 
-			seedImagePatterns := []pattern{
+			seedImagePatterns := []YamlPattern{
 				{
 					key:   "%BASE_IMAGE%",
 					value: baseImageURL,
@@ -189,7 +184,7 @@ var _ = Describe("E2E - Bootstrapping nodes", Label("multi-cluster"), func() {
 			createdClusterName := clusterName + "-" + strconv.Itoa(clusterIndex)
 
 			// Patterns to replace
-			addPatterns := []pattern{
+			addPatterns := []YamlPattern{
 				{
 					key:   "%CLUSTER_NAME%",
 					value: createdClusterName,

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -42,11 +42,6 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 		testCaseID = 38
 
 		By("Adding SeedImage", func() {
-			type pattern struct {
-				key   string
-				value string
-			}
-
 			// Wait for list of OS versions to be populated
 			WaitForOSVersion(clusterNS)
 
@@ -92,7 +87,7 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 			})
 
 			// Patterns to replace
-			patterns := []pattern{
+			patterns := []YamlPattern{
 				{
 					key:   "%CLUSTER_NAME%",
 					value: clusterName,

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -64,6 +64,7 @@ var (
 	clusterYaml               string
 	elementalSupport          string
 	emulateTPM                bool
+	forceDowngrade            bool
 	isoBoot                   bool
 	k8sUpstreamVersion        string
 	k8sDownstreamVersion      string
@@ -398,6 +399,12 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "Elemental End-To-End Test Suite")
 }
 
+// Use to modify yaml templates
+type YamlPattern struct {
+	key   string
+	value string
+}
+
 var _ = BeforeSuite(func() {
 	backupRestoreVersion = os.Getenv("BACKUP_RESTORE_VERSION")
 	bootTypeString := os.Getenv("BOOT_TYPE")
@@ -408,6 +415,7 @@ var _ = BeforeSuite(func() {
 	clusterType = os.Getenv("CLUSTER_TYPE")
 	elementalSupport = os.Getenv("ELEMENTAL_SUPPORT")
 	eTPM := os.Getenv("EMULATE_TPM")
+	forceDowngradeString := os.Getenv("FORCE_DOWNGRADE")
 	index := os.Getenv("VM_INDEX")
 	k8sDownstreamVersion = os.Getenv("K8S_DOWNSTREAM_VERSION")
 	k8sUpstreamVersion = os.Getenv("K8S_UPSTREAM_VERSION")
@@ -456,7 +464,7 @@ var _ = BeforeSuite(func() {
 	// NOTE: could be the number added nodes or the number of nodes to use/upgrade
 	usedNodes = (numberOfVMs - vmIndex) + 1
 
-	// Force a correct value for emulateTPM
+	// Force correct value for emulateTPM
 	switch eTPM {
 	case "true":
 		emulateTPM = true
@@ -464,7 +472,7 @@ var _ = BeforeSuite(func() {
 		emulateTPM = false
 	}
 
-	// Same for sequential
+	// Force correct value for sequential
 	switch seqString {
 	case "true":
 		sequential = true
@@ -472,12 +480,20 @@ var _ = BeforeSuite(func() {
 		sequential = false
 	}
 
-	// Same for bootType
+	// Define boot type
 	switch bootTypeString {
 	case "iso":
 		isoBoot = true
 	case "raw":
 		rawBoot = true
+	}
+
+	// Force correct value for forceDowngrade
+	switch forceDowngradeString {
+	case "true":
+		forceDowngrade = true
+	default:
+		forceDowngrade = false
 	}
 
 	// Extract Rancher Manager channel/version to install


### PR DESCRIPTION
Should fix #1316.

Verification run:
- [CLI-K3s-Downgrade](https://github.com/rancher/elemental/actions/runs/9094190641)
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/9095346905)

We can see on the screenshot that the OS was version `2.2.0-66.8` before the downgrade and `2.1.1-8.25` after.
![Screenshot from 2024-05-15 14-48-47](https://github.com/rancher/elemental/assets/25102165/5503136b-afa1-487f-8fa5-7aaec370f437)
