### PR TITLE
ci/ui: bump Cypress container to 13.9.0

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -195,7 +195,7 @@ jobs:
           BOOT_TYPE: ${{ inputs.boot_type }}
           BROWSER: chrome
           CHARTMUSEUM_REPO: http://${{ inputs.public_fqdn }}
-          CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          CYPRESS_DOCKER: 'cypress/included:13.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
@@ -267,7 +267,7 @@ jobs:
           BOOT_TYPE: ${{ inputs.boot_type }}
           BROWSER: firefox
           CHARTMUSEUM_REPO: http://${{ inputs.public_fqdn }}
-          CYPRESS_DOCKER: 'cypress/included:10.9.0'
+          CYPRESS_DOCKER: 'cypress/included:13.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_DEV_VERSION: ${{ steps.install_chartmuseum.outputs.operator_dev_version }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}

--- a/tests/cypress/latest/cypress.config.ts
+++ b/tests/cypress/latest/cypress.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     'projectCode': 'ELEMENTAL',
     'logging': true,
   },
+  video: true,
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.


### PR DESCRIPTION
I bumped the Cypress code to version 13 but I forgot to bump the Cypress container image in the CI...

## Verification run
[UI-K3s](https://github.com/rancher/elemental/actions/runs/9095308608/job/24998311366) ✅ 