### PR TITLE
ci/cli: fix Rancher Manager 2.9 tests

### DIFF
--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -73,6 +73,7 @@ jobs:
       pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
       qase_api_token: ${{ secrets.QASE_API_TOKEN }}
     with:
+      backup_restore_version: v5.0.0-rc.6
       ca_type: ${{ matrix.ca_type }}
       cluster_type: ${{ matrix.cluster_type }}
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}

--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.28.9+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.28.9+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,18 +47,24 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2","v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2","v1.27.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.9+k3s1","v1.28.9+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.9+k3s1","v1.28.9+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
+            k8s_downstream_version: v1.28.9+k3s1
+            k8s_upstream_version: v1.28.9+k3s1
+            rancher_version: stable/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
+            k8s_downstream_version: v1.28.9+k3s1
+            k8s_upstream_version: v1.28.9+k3s1
+            rancher_version: stable/latest
             reset: true
             sequential: false
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.28.9+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.28.9+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -42,8 +42,8 @@ jobs:
       max-parallel: 4
       matrix:
         boot_type: ${{ fromJSON(format('[{0}]', inputs.boot_type || '"iso","raw"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2","v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2","v1.27.19+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.9+k3s1","v1.28.9+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.9+k3s1","v1.28.9+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -181,9 +181,8 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 
 		By("Incrementing number of nodes in "+poolType+" pool", func() {
 			// Increase 'quantity' field
-			value, err := rancher.SetNodeQuantity(clusterNS,
-				clusterName,
-				"pool-"+poolType+"-"+clusterName, usedNodes)
+			poolName := "pool-" + poolType + "-" + clusterName
+			value, err := rancher.SetNodeQuantity(clusterNS, clusterName, poolName, usedNodes)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(value).To(BeNumerically(">=", 1))
 

--- a/tests/e2e/helpers/elemental/elemental.go
+++ b/tests/e2e/helpers/elemental/elemental.go
@@ -58,7 +58,7 @@ Get state of the cluster
   - @returns The YAML structure or an error
 */
 func GetClusterState(ns, cluster, condition string) (string, error) {
-	out, err := kubectl.RunWithoutErr("get", "cluster", "--namespace", ns, cluster, "-o", "jsonpath="+condition)
+	out, err := kubectl.RunWithoutErr("get", "cluster.v1.provisioning.cattle.io", "--namespace", ns, cluster, "-o", "jsonpath="+condition)
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -155,7 +155,7 @@ func WaitCluster(ns, cn string) {
 
 	// Check that the cluster is in Ready state (this means that it has been created)
 	Eventually(func() string {
-		status, _ := kubectl.RunWithoutErr("get", "cluster",
+		status, _ := kubectl.RunWithoutErr("get", "cluster.v1.provisioning.cattle.io",
 			"--namespace", ns, cn,
 			"-o", "jsonpath={.status.ready}")
 		return status
@@ -166,7 +166,7 @@ func WaitCluster(ns, cn string) {
 		counter := 0
 
 		Eventually(func() string {
-			status, _ := kubectl.RunWithoutErr("get", "cluster",
+			status, _ := kubectl.RunWithoutErr("get", "cluster.v1.provisioning.cattle.io",
 				"--namespace", ns, cn,
 				"-o", "jsonpath={.status.conditions[?(@.type==\""+s.conditionType+"\")].status}")
 
@@ -228,7 +228,7 @@ Check that Cluster resource has been correctly created
 func CheckCreatedCluster(ns, cn string) {
 	// Check that the cluster is correctly created
 	Eventually(func() string {
-		out, _ := kubectl.RunWithoutErr("get", "cluster",
+		out, _ := kubectl.RunWithoutErr("get", "cluster.v1.provisioning.cattle.io",
 			"--namespace", ns,
 			cn, "-o", "jsonpath={.metadata.name}")
 		return out

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -37,7 +37,7 @@ func deleteFinalizers(ns, object, value string) {
 
 func testClusterAvailability(ns, cluster string) {
 	Eventually(func() string {
-		out, _ := kubectl.RunWithoutErr("get", "cluster",
+		out, _ := kubectl.RunWithoutErr("get", "cluster.v1.provisioning.cattle.io",
 			"--namespace", ns, cluster,
 			"-o", "jsonpath={.metadata.name}")
 		return out
@@ -141,7 +141,7 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 		wg.Wait()
 
 		By("Testing cluster resource unavailability", func() {
-			out, err := kubectl.Run("get", "cluster",
+			out, err := kubectl.Run("get", "cluster.v1.provisioning.cattle.io",
 				"--namespace", clusterNS, clusterName,
 				"-o", "jsonpath={.metadata.name}")
 			Expect(err).To(HaveOccurred(), out)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240412110134-536443696b01
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/mod v0.15.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -132,10 +132,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240328132501-e38cbb7563a8 h1:kcioyUdM+ahT0fbm1n1mfLUM+lWtDst2S1mcxbxC/mU=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240328132501-e38cbb7563a8/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240412110134-536443696b01 h1:aF8X89bdjBDnMc+K+VYZu0k0sGW6we/WHp9fZn+/iA4=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240412110134-536443696b01/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4 h1:EanghO516nddvE1Bz5ViO7VJA42+sIZKcE1IejE/44c=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Backup/Restore plugin should be updated to the recently released 5.0.0-rc6 version. This PR also bump K8s version to use the latest supported ones. It also fixes the cluster check, as with newer versions of K8s `apiVersion cluster.x-k8s.io/v1beta1` is used by default instead of `provisioning.cattle.io/v1` when calling `kubectl get cluster`.

Verification run:
- [CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/runs/9124696615)
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/9125301353)