### PR TITLE
ci/cli: fix multicluster test

### DIFF
--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -45,6 +45,8 @@ jobs:
       boot_type: iso
       cluster_number: 20
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
+      k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
+      k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5


### PR DESCRIPTION
The version of K8s should be correctly passed in the workflow.

There is no verification run as it will take too much time to run them and the fix will only impact this multicluster test, no regression on others. And we can clearly see in the logs that the wrong version of K8s is used:
```
Release "rancher" does not exist. Installing it now.
Error: chart requires kubeVersion: < 1.29.0-0 which is incompatible with Kubernetes v1.29.4+k3s1
```