### PR TITLE
ci: bump k8s upstream/downstream to latest 1.27.13

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -34,8 +34,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,23 +47,23 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.8+k3s2
-            k8s_upstream_version: v1.26.10+k3s2
+            k8s_downstream_version: v1.27.13+k3s1
+            k8s_upstream_version: v1.27.13+k3s1
             rancher_version: stable/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.8+k3s2
-            k8s_upstream_version: v1.26.10+k3s2
+            k8s_downstream_version: v1.27.13+k3s1
+            k8s_upstream_version: v1.27.13+k3s1
             rancher_version: stable/latest
             reset: true
             sequential: false

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       operator_repo:
         description: Operator version to use for initial deployment

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,11 +17,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+rke2r2
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,23 +47,23 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.8+rke2r1
-            k8s_upstream_version: v1.26.10+rke2r2
+            k8s_downstream_version: v1.27.13+rke2r1
+            k8s_upstream_version: v1.27.13+rke2r1
             rancher_version: stable/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.8+rke2r1
-            k8s_upstream_version: v1.26.10+rke2r2
+            k8s_downstream_version: v1.27.13+rke2r1
+            k8s_upstream_version: v1.27.13+rke2r1
             rancher_version: stable/latest
             reset: true
             sequential: false

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+rke2r2
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+rke2r2
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+rke2r1"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+rke2r2"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+k3s2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       os_version_install:
         description: OS version to install

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -21,11 +21,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+k3s2
+        default: v1.27.13+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+k3s2
+        default: v1.27.13+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.26.10+rke2r2
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+rke2r1"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+rke2r2"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.8+rke2r1
+        default: v1.27.13+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.8+k3s2"'
+        default: '"v1.27.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.26.10+k3s2"'
+        default: '"v1.27.13+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.8+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.26.10+rke2r2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:


### PR DESCRIPTION
Fix #1222 

## Verification runs
[UI-K3s](https://github.com/rancher/elemental/actions/runs/9176167043/job/25230897054) ✅ 
[CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/9176187699/job/25231408646) ✅ 
[CLI-K3s](https://github.com/rancher/elemental/actions/runs/9176189962) ❌ - Failed during operator uninstallation, not related to this PR.
[CLI-RKE2](https://github.com/rancher/elemental/actions/runs/9176192894) ❌ - same reason as above