### PR TITLE
ci/cli: fix operator uninstallation test

### DIFF
--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -105,7 +105,7 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 			By("Deleting cluster resource", func() {
 				Eventually(func() error {
-					_, err := kubectl.RunWithoutErr("delete", "cluster",
+					_, err := kubectl.RunWithoutErr("delete", "cluster.v1.provisioning.cattle.io",
 						"--namespace", ns, name)
 					return err
 				}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))


### PR DESCRIPTION
We also have to force the `ApiVersion` for the `delete cluster` action.

Verification run:
- [CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/runs/9175597706)