### PR TITLE
ci: increase timeout in reset test

### DIFF
--- a/tests/e2e/reset_test.go
+++ b/tests/e2e/reset_test.go
@@ -59,7 +59,7 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out
-			}, tools.SetTimeout(5*time.Minute), 5*time.Second).ShouldNot(ContainSubstring(firstMachineInventory))
+			}, tools.SetTimeout(10*time.Minute), 5*time.Second).ShouldNot(ContainSubstring(firstMachineInventory))
 		})
 
 		By("Checking that MachineInventory is back after the reset", func() {


### PR DESCRIPTION
Increase the timeout when we check that the machine inventory deleted disappears from the machine inventory list.

No need to do a verification run for a timeout increase. Anyway, we will check if the issue still appears in the next few days.