### PR TITLE
ci/cli: fix IPv6 deactivation

### DIFF
--- a/tests/assets/machineRegistration-multi.yaml
+++ b/tests/assets/machineRegistration-multi.yaml
@@ -16,6 +16,17 @@ spec:
       users:
         - name: %USER%
           passwd: %PASSWORD%
+      write_files:
+        - path: /oem/99_disable_ipv6.yaml
+          owner: root:root
+          permissions: 644
+          content: |
+            name: Reboot to apply network config
+            stages:
+              network:
+                - if: '! grep -q ipv6.disable /oem/grubenv'
+                  commands:
+                    - grub2-editenv /oem/grubenv set extra_cmdline=ipv6.disable=1 && shutdown -r now
     elemental:
       install:
         reboot: false

--- a/tests/assets/machineRegistration.yaml
+++ b/tests/assets/machineRegistration.yaml
@@ -26,7 +26,7 @@ spec:
             name: Reboot to apply network config
             stages:
               network:
-                - if: '[ ! -f /oem/grubenv ]'
+                - if: '! grep -q ipv6.disable /oem/grubenv'
                   commands:
                     - grub2-editenv /oem/grubenv set extra_cmdline=ipv6.disable=1 && shutdown -r now
         - path: /etc/ssh/sshd_config


### PR DESCRIPTION
On recent version of OS image /oem/grubenv can already exist, so it's better to check if `ipv6.disable` is set or not.

The logic has also been validated manually on my test lab.

Verification run:
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/9198182193)