### PR TITLE
Move install openssh and openssh-server

### DIFF
--- a/.obs/dockerfile/micro-baremetal-os/Dockerfile
+++ b/.obs/dockerfile/micro-baremetal-os/Dockerfile
@@ -15,7 +15,7 @@ FROM suse/sl-micro/${SLMICRO_VERSION}/base-os-container:latest
 RUN zypper in --no-recommends -y systemd-presets-branding-Elemental elemental
 
 # extend -base with baremetal and usability packages
-RUN zypper in --no-recommends -y procps openssh openssh-server \
+RUN zypper in --no-recommends -y procps \
     vim-small less kernel-firmware-all NetworkManager-wwan cryptsetup \
     \
     avahi bash-completion catatonit cni cni-plugins conmon conntrack-tools \

--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -49,7 +49,7 @@ RUN zypper --installroot /osimage in --no-recommends -y elemental
 # end of mandatory package installs for SUSE Linux Micro
 
 # make derived containers possible
-RUN zypper --installroot /osimage in --no-recommends -y zypper
+RUN zypper --installroot /osimage in --no-recommends -y zypper openssh openssh-server
 
 FROM scratch as osimage
 


### PR DESCRIPTION
Move the installation of openssh and openssh-server to micro-base-os
Dockerfile.

This should include openssh and openssh-server in all derivatives which
is needed for CI.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
