### PR TITLE
ci: Bump checkout version in update-tests-description

### DIFF
--- a/.github/workflows/update-tests-description.yaml
+++ b/.github/workflows/update-tests-description.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # A token is needed to be able to push on main, maybe this can be changed later
           # with another GHA or with some webhook?
@@ -35,9 +35,7 @@ jobs:
           NEW_CHK=$(sha512sum ${FILE} 2>/dev/null) || true
 
           # Compare checksum and set generate value if needed
-          if [[ "${NEW_CHK}" != "${OLD_CHK}" ]]; then
-            echo "generate=needed" >> ${GITHUB_OUTPUT}
-          fi
+          [[ "${NEW_CHK}" != "${OLD_CHK}" ]] && echo "generate=needed" >> ${GITHUB_OUTPUT}
       - uses: EndBug/add-and-commit@v9
         if: steps.readme_generator.outputs.generate == 'needed'
         with:


### PR DESCRIPTION
`actions/checkout` needs to be bumped to v4.