### PR TITLE
ci: define default value for qase reporting

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -45,7 +45,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: airgap
       zone: us-central1-c

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -48,7 +48,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       node_number: 3
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: stable/latest
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/staging/containers/suse/sl-micro/6.0/baremetal-os-container:latest

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -78,7 +78,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -43,7 +43,7 @@ jobs:
       node_number: 60
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: cli

--- a/.github/workflows/cli-k3s-selinux-matrix.yaml
+++ b/.github/workflows/cli-k3s-selinux-matrix.yaml
@@ -63,7 +63,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       os_to_test: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/k3s-selinux-iso-image:latest
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       selinux: true

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -54,7 +54,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -47,7 +47,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       runner_template: elemental-e2e-ci-runner-spot-x86-64-template-n2-highmem-80-v5
       test_type: multi

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -78,7 +78,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -54,7 +54,7 @@ jobs:
       operator_upgrade: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       operator_repo: oci://registry.suse.com/rancher
       os_to_test: stable
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true

--- a/.github/workflows/cli-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.9-matrix.yaml
@@ -79,7 +79,7 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
       sequential: ${{ matrix.sequential }}

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -102,8 +102,6 @@ jobs:
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
       QASE_PROJECT_CODE: ${{ inputs.qase_project_code }}
       QASE_RUN_ID: ${{ inputs.qase_run_id }}
-      # NOTE: this REPORT var is needed for Cypress!
-      QASE_REPORT: 1
       # K3S / RKE2 flags to use for installation
       INSTALL_K3S_SKIP_ENABLE: true
       INSTALL_K3S_VERSION: ${{ inputs.k8s_upstream_version }}

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -54,7 +54,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       zone: us-central1-a

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -45,6 +45,6 @@ jobs:
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
       operator_repo: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
       proxy: ${{ inputs.proxy }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -54,7 +54,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -54,7 +54,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       ui_account: user

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -57,7 +57,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       ui_account: user

--- a/.github/workflows/ui-rm-head-2.9-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.9-matrix.yaml
@@ -59,7 +59,7 @@ jobs:
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       proxy: ${{ inputs.proxy || 'elemental' }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       test_type: ui
       zone: us-central1-a

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -15,6 +15,9 @@ pushd cypress/latest
 # Needed to install Cypress plugins
 npm install
 
+# Check if we have to report to QASE
+[[ -n $QASE_RUN_ID ]] && QASE_REPORT=1
+
 # Start Cypress tests with docker
 docker run -v $PWD:/workdir -w /workdir               \
     -e BOOT_TYPE=$BOOT_TYPE                           \


### PR DESCRIPTION
This PR addresses 2 fixes:

1. CI tests are not reported into QASE anymore:
<img src="https://github.com/rancher/elemental/assets/6025636/12e304af-4e7e-42ca-b9f8-711399d05950" width="400">

instead of:
<img src="https://github.com/rancher/elemental/assets/6025636/dad53ba6-5712-435b-8362-bc622ae2aa18" width="400">

2. UI tests always report to QASE due to hardcoded `QASE_REPORT=1`
## Verification runs
[UI-K3s with empty `QASE_RUN_ID`](https://github.com/rancher/elemental/actions/runs/9364885320) ✅ 
[UI-K3s with `QASE_RUN_ID=auto`](https://github.com/rancher/elemental/actions/runs/9364891504) => [Qase report](https://app.qase.io/run/ELEMENTAL/dashboard/1482) ✅ 
![image](https://github.com/rancher/elemental/assets/6025636/c6b76ce2-728b-4343-91d4-da45bf5d3fe4)
