### PR TITLE
Workaround to remove pre-existing elemental initrds

### DIFF
--- a/.obs/dockerfile/micro-rt-os/Dockerfile
+++ b/.obs/dockerfile/micro-rt-os/Dockerfile
@@ -58,5 +58,6 @@ RUN zypper clean --all && \
     >/var/log/lastlog && \
     rm -rf /boot/vmlinux*
 
-# Rebuild initrd to setup dracut with the boot configurations
+# Rebuild initrd to setup dracut with the boot configurations and remove pre-existing initrd from baremetal image
+RUN rm -fv /boot/elemental.initrd*
 RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment


### PR DESCRIPTION
For derived images already including an elemental generated initrd we should remove them specially if the kernel version changes, as the new one would not overwrite the previous one and leave two elemental initrds inside /boot.

Workaround for #1450