### PR TITLE
Ensure uninstall test is backward compatible

### DIFF
--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -136,9 +136,15 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 				}
 			}
 
+			// On older versions managedOSVersions CRD might be already gone at this stage
+			// ignore error if the managedOSVersion type is unknown
 			mOSList, err := kubectl.RunWithoutErr("get", "ManagedOSVersion",
 				"--namespace", clusterNS, "-o", "jsonpath={.items[*].metadata.name}")
-			Expect(err).To(Not(HaveOccurred()))
+			if err != nil && strings.Contains(err.Error(), "doesn't have a resource type") {
+				mOSList = ""
+			} else {
+				Expect(err).ToNot((HaveOccurred()))
+			}
 
 			for _, mOS := range strings.Fields(mOSList) {
 				// Delete blocking Finalizers


### PR DESCRIPTION
For versions <= v1.5 uninstalling CRDs chart already removes the ManagedOSVersion CRD, hence listing ManagedOSVersions resources results to an error as this is an unknown type

Tested with v1.5 [here](https://github.com/rancher/elemental/actions/runs/9698741592)