### PR TITLE
ci/airgap: use alpha channel to test RM 2.9 branch

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","alpha"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -138,8 +138,8 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 
 			err = client.GetFile(localKubeconfig, "/etc/rancher/k3s/k3s.yaml", 0644)
 			Expect(err).To(Not(HaveOccurred()))
-			// NOTE: not sure that this is need because we have the config file in ~/.kube/
 
+			// NOTE: not sure that this is need because we have the config file in ~/.kube/
 			err = os.Setenv("KUBECONFIG", localKubeconfig)
 			Expect(err).To(Not(HaveOccurred()))
 

--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -192,7 +192,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					"--namespace", clusterNS,
 					"-o", "jsonpath={.items[*].metadata.name}")
 				return out
-			}, tools.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring("selector-" + poolType + "-" + clusterName))
+			}, tools.SetTimeout(3*time.Minute), 5*time.Second).Should(ContainSubstring(poolType + "-" + clusterName))
 		})
 
 		By("Waiting for known cluster state before adding the node(s)", func() {

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -107,7 +107,7 @@ RunHelmCmdWithRetry repo add rancher-${RANCHER_CHANNEL} https://releases.rancher
 RunHelmCmdWithRetry repo update > /dev/null 2>&1
 
 # Get CertManager charts
-[[ "${CERT_MANAGER_VERSION}" != "latest" ]] && VER_OPT="--version ${CERT_MANAGER_VERSION}"
+[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] || VER_OPT="--version ${CERT_MANAGER_VERSION}"
 RunHelmCmdWithRetry pull jetstack/cert-manager ${VER_OPT} > /dev/null 2>&1
 
 # Get CertManager version
@@ -116,7 +116,7 @@ CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION#cert-manager-*}
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION%.*}
 
 # Get Rancher charts
-[[ "${RANCHER_CHANNEL}" == "latest" ]] && DEVEL="--devel"
+[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] && DEVEL="--devel"
 RunHelmCmdWithRetry pull rancher-${RANCHER_CHANNEL}/rancher ${DEVEL} > /dev/null 2>&1
 for i in elemental-operator-chart elemental-operator-crds-chart ; do
   RunHelmCmdWithRetry pull ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1


### PR DESCRIPTION
Setting Rancher Manager channel to `latest/devel` points to version `2.9.0-rc1` which doesn't exist yet, so the test fails. If we want to test the latest devel version (so `2.9.0-something`)  we need to use the `alpha` channel for airgap (we cannot use `2.9-head` in air-gapped environment).

Verification run:
- [CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/9780921937)