### PR TITLE
ci/scalability: remove test on Rancher Manager Devel

### DIFF
--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
It's not very useful to keep this test, as scalability is not our main focus and moreover the Devel version of RM is already tested in regular CI. Better to focus on RM Stable version for this test.