### PR TITLE
ci: remove EndBug/add-and-commit action

### DIFF
--- a/.github/workflows/update-tests-description.yaml
+++ b/.github/workflows/update-tests-description.yaml
@@ -21,6 +21,7 @@ jobs:
           # - if the account associated still exists
           # - if the person still has access to the repo
           token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+
       - name: Generate tests description file
         id: readme_generator
         run: |
@@ -35,10 +36,18 @@ jobs:
           NEW_CHK=$(sha512sum ${FILE} 2>/dev/null) || true
 
           # Compare checksum and set generate value if needed
-          [[ "${NEW_CHK}" != "${OLD_CHK}" ]] && echo "generate=needed" >> ${GITHUB_OUTPUT}
-      - uses: EndBug/add-and-commit@v9
+          [[ "${NEW_CHK}" != "${OLD_CHK}" ]] && echo "generate=needed" >> ${GITHUB_OUTPUT} || true
+
+      - name: Push modified file
         if: steps.readme_generator.outputs.generate == 'needed'
-        with:
-          default_author: github_actions
-          message: 'ci: update tests/README.md file'
-          add: 'tests/README.md'
+        env:
+          CI_COMMIT_AUTHOR: "github-actions"
+          CI_COMMIT_EMAIL: "github-actions@users.noreply.github.com"
+          CI_COMMIT_MESSAGE: "ci: update tests/README.md file"
+          CI_COMMIT_FILE: "tests/README.md"
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          git add ${{ env.CI_COMMIT_FILE }}
+          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push


### PR DESCRIPTION
As this one is not validated and we can do it directly with GitHub Actions. Should fix #1468.

Verification runs:
- [With modification](https://github.com/ldevulder/gha-tests/actions/runs/9794266690/job/27043914397)
- [Without modification](https://github.com/ldevulder/gha-tests/actions/runs/9794273302/job/27043933405)
- [Commits list](https://github.com/ldevulder/gha-tests/commits/main/)