### PR TITLE
ci/airgap: fix test with Rancher Manager Stable

### DIFF
--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -107,7 +107,7 @@ RunHelmCmdWithRetry repo add rancher-${RANCHER_CHANNEL} https://releases.rancher
 RunHelmCmdWithRetry repo update > /dev/null 2>&1
 
 # Get CertManager charts
-[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] || VER_OPT="--version ${CERT_MANAGER_VERSION}"
+[[ "${CERT_MANAGER_VERSION}" != "latest" ]] && VER_OPT="--version ${CERT_MANAGER_VERSION}"
 RunHelmCmdWithRetry pull jetstack/cert-manager ${VER_OPT} > /dev/null 2>&1
 
 # Get CertManager version


### PR DESCRIPTION
Fix an error introduced with the last modifications.

Should fix this [issue](https://github.com/rancher/elemental/actions/runs/9823803731/job/27148073365).

Verification run:
- [CLI-K3s-Airgap with RM `latest/stable`](https://github.com/rancher/elemental/actions/runs/9835941885)
- [CLI-K3s-Airgap with RM `alpha`](https://github.com/rancher/elemental/actions/runs/9836971972)