### PR TITLE
ci: fix deployed application test

### DIFF
--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -356,7 +356,11 @@ jobs:
       - name: Test Backup/Restore Elemental resources with Rancher Manager
         id: test_backup_restore
         if: ${{ contains(inputs.k8s_upstream_version, 'k3s') }}
-        run: cd tests && make e2e-backup-restore && make e2e-check-app
+        run: |
+          cd tests && make e2e-backup-restore
+          if ${{ contains(inputs.k8s_downstream_version, 'k3s') }}; then
+            make e2e-check-app
+          fi
 
       - name: Extract ISO version
         id: iso_version


### PR DESCRIPTION
Application is only deployed if the downstream cluster is K3s.

Should fix this [issue](https://github.com/rancher/elemental/actions/runs/9825773431/job/27149698880).

Verification run:
- [CLI-Rancher-Manager-Head-2.9](https://github.com/rancher/elemental/actions/runs/9837005439)