### PR TITLE
ci/multicluster: reduce number of tested cluster

### DIFF
--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -43,7 +43,7 @@ jobs:
       qase_api_token: ${{ secrets.QASE_API_TOKEN_CLI }}
     with:
       boot_type: iso
-      cluster_number: 20
+      cluster_number: 10
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}


### PR DESCRIPTION
This will reduce pressure on runner as well as the execution time. It will also reduce the risk of failure in RKE2 tests.