### PR TITLE
ci/cli: use Rancher Manager Prime on RKE2 tests

### DIFF
--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: stable/latest
+        default: prime/latest
         type: string
 
 jobs:

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -29,7 +29,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
-        default: '"stable/latest"'
+        default: '"prime/latest"'
         type: string
       reset:
         description: Allow reset test (mainly used on CLI tests)
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.7","latest/devel/2.8"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.7","latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
@@ -57,14 +57,14 @@ jobs:
             cluster_type: ""
             k8s_downstream_version: v1.27.13+rke2r1
             k8s_upstream_version: v1.27.13+rke2r1
-            rancher_version: stable/latest
+            rancher_version: prime/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
             k8s_downstream_version: v1.27.13+rke2r1
             k8s_upstream_version: v1.27.13+rke2r1
-            rancher_version: stable/latest
+            rancher_version: prime/latest
             reset: true
             sequential: false
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: stable/latest
+        default: prime/latest
         type: string
 
 jobs:

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: stable/latest
+        default: prime/latest
         type: string
 
 jobs:

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -56,7 +56,7 @@ jobs:
       os_to_test: stable
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
-      rancher_version: stable/latest
+      rancher_version: prime/latest
       reset: true
       test_type: cli
       upgrade_image: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sl-micro/6.0/baremetal-os-container:latest


### PR DESCRIPTION
Should fix #1208.

Verification runs:
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/9857461377/job/27216712317)
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/9858538829), failed but for something not related to this PR.