### PR TITLE
ci: use latest version of DeployRancherManager func

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240712093819-83407d764415
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/mod v0.15.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -132,8 +132,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4 h1:EanghO516nddvE1Bz5ViO7VJA42+sIZKcE1IejE/44c=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240516141025-55f6001299d4/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240712093819-83407d764415 h1:KZkS4xA3yNz8pZdJBfeGBSz/XOE9geT6KBSl8eKrItI=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240712093819-83407d764415/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
To support the deployment of alpha versions of Rancher Manager.

Verification run:
- [UI Marketplace with rancher 2.9.0-alpha7](https://github.com/rancher/elemental/actions/runs/9905994866/job/27366720626) ✅ => rancher installation ok