### PR TITLE
ci/cli: test recovery mode after OS upgrade

### DIFF
--- a/tests/e2e/bootstrap_test.go
+++ b/tests/e2e/bootstrap_test.go
@@ -369,10 +369,7 @@ var _ = Describe("E2E - Bootstrapping node", Label("bootstrap"), func() {
 					misc.RandomSleep(sequential, i)
 
 					// Execute 'reboot' in background, to avoid SSH locking
-					Eventually(func() error {
-						_, err := cl.RunSSH("setsid -f reboot")
-						return err
-					}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))
+					_ = RunSSHWithRetry(cl, "setsid -f reboot")
 				})
 
 				if p != "worker" {


### PR DESCRIPTION
We should validate that Grub recovery entry is still working. Should fix #1303.

Verification run:
- [CLI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/9910443638)