### PR TITLE
ci/ui: Do not install rc ui version in 2.9 upgrade

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -69,7 +69,7 @@ filterTests(['main', 'upgrade'], () => {
         // Latest UI version is only compatible with 2.8
         // Waiting on annotations inmplementation for 2.9
         // We have to force the version to 1.3.1-rc7
-        if (isRancherManagerVersion('2.9') && isUIVersion('dev')) {
+        if (isRancherManagerVersion('2.9')) {
           cy.getBySel('install-ext-modal-select-version')
             .click();
           cy.contains('1.3.1-rc7')


### PR DESCRIPTION
Upgrade tests targeting rancher 2.9 must use `1.3.1-rc7` because this is the only compatible version.

## Verification runs
[UI-K3S-Upgrade-2.9](https://github.com/rancher/elemental/actions/runs/10141421551) ✅ 
[UI-RKE2-Upgrade-2.9](https://github.com/rancher/elemental/actions/runs/10141466483) ✅ 
[UI-K3S-Upgrade-2.8.5](https://github.com/rancher/elemental/actions/runs/10144497269) ✅ 