### PR TITLE
ci: fix proxy tests for rancher 2.9

### DIFF
--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -101,7 +101,7 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 				checkRC(err)
 				err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
 				checkRC(err)
-				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT.*rancher.io"))
+				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT.*docker.io"))
 			})
 		}
 	})


### PR DESCRIPTION
In upgrade tests using Rancher `2.9` we do not see this kind of entries:
`TCP_TUNNEL/200.*CONNECT.*rancher.io`
Moreover, we can see it in basic rancher 2.9 tests.

## Verification run
[UI-K3S-Upgrade](https://github.com/rancher/elemental/actions/runs/10161220848) ✅ 