### PR TITLE
ci: proxy log is different in rancher prime

### DIFF
--- a/tests/e2e/logs_test.go
+++ b/tests/e2e/logs_test.go
@@ -101,7 +101,7 @@ var _ = Describe("E2E - Getting logs node", Label("logs"), func() {
 				checkRC(err)
 				err = os.WriteFile("squid.log", []byte(out), os.ModePerm)
 				checkRC(err)
-				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT.*docker.io"))
+				Expect(out).Should(MatchRegexp("TCP_TUNNEL/200.*CONNECT.*(docker.io|rancher)"))
 			})
 		}
 	})


### PR DESCRIPTION
Fix #1518 

## Verification runs
[UI-RKE2-rancher_prime](https://github.com/rancher/elemental/actions/runs/10193855584/job/28199345826) ✅ 
[UI-RKE2-rancher_2.8-head](https://github.com/rancher/elemental/actions/runs/10196506713/job/28207474430) ✅ 