### PR TITLE
ci/ui: remove hardcoded version due to new ui rc

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -66,15 +66,6 @@ filterTests(['main', 'upgrade'], () => {
         cy.get('.plugin')
           .contains('Install')
           .click();
-        // Latest UI version is only compatible with 2.8
-        // Waiting on annotations inmplementation for 2.9
-        // We have to force the version to 1.3.1-rc7
-        if (isRancherManagerVersion('2.9')) {
-          cy.getBySel('install-ext-modal-select-version')
-            .click();
-          cy.contains('1.3.1-rc7')
-            .click();
-        }
         cy.clickButton('Install');
         cy.contains('Installing');
         cy.contains('Extensions changed - reload required', {timeout: 40000});


### PR DESCRIPTION
Rancher `2.9` has its proper version number (2.x) and rancher `2.8` will not see it, so we can remove the harcoded version `1.3.1-rc7` which was only made for `2.9`.

## Verification run
[UI-K3S-rancher2.9-head](https://github.com/rancher/elemental/actions/runs/10268476976) ✅  we can see ui `2.0.0-rc1` installed
[UI-K3S-rancher2.8.5](https://github.com/rancher/elemental/actions/runs/10268507208) ✅  we can see ui `1.3.1-rc9`  installed