### PR TITLE
ci/airgap: add custom OS channel

### DIFF
--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -245,6 +245,8 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 				"--create-namespace",
 				"--set", "image.repository=" + repoServer + rancherPath + "elemental-operator",
 				"--set", "seedImage.repository=" + repoServer + rancherPath + "seedimage-builder",
+				"--set", "channel.name=airgap-os-channel",
+				"--set", "channel.tag=latest",
 				"--set", "channel.image=" + repoServer + rancherPath + "elemental-channel-" + rancherManager,
 				"--set", "registryUrl=",
 				"--wait", "--wait-for-jobs",


### PR DESCRIPTION
With operator version 1.7+ there is no default OS channel anymore, so we have to force the use of one (previously only the URL of the registry was changed). The new code is still compatible with older operator versions, as the default one provided in older versions will simply be changed to the new created one.

PR https://github.com/rancher/elemental-operator/pull/824 in the operator repo needs to be merged first!

Verification run:
- [CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/10475126426)