### PR TITLE
ci/cli: reduce execution time on multicluster test

### DIFF
--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:


### PR DESCRIPTION
Due to HW constraints and time consuming the multicluster test sporadically fail. So better to only run it one time instead of 4.

Use K3s for upstream cluster and RKE2 for the downstream ones.