### PR TITLE
ci: add clearer status in summary

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -67,6 +67,9 @@ inputs:
   snap_type:
     default: "btrfs"
     type: string
+  steps_status:
+    # NOTE: 'steps_status' var cannot be configured with a default value!
+    type: string
   test_type:
     default: "Unknown"
     type: string
@@ -118,6 +121,15 @@ runs:
         # Define some variable(s)
         ${{ inputs.sequential == true }} && BOOTSTRAP_METHOD="Sequential" || BOOTSTRAP_METHOD="Parallel"
 
+        # Define test status
+        if ${{ contains(inputs.steps_status, 'cancelled') }}; then
+          TEST_STATUS="CANCELLED"
+        elif ${{ contains(inputs.steps_status, 'failure') }}; then
+          TEST_STATUS="FAILED"
+        else
+          TEST_STATUS="OK"
+        fi
+
         # Get nodes configuration (use the first one, they are all identical)
         NODE=$(sudo virsh list --name | head -1)
         if [[ -n "${NODE}" ]]; then
@@ -127,7 +139,7 @@ runs:
         fi
 
         # Add summary: General informations
-        echo "## General informations" >> ${GITHUB_STEP_SUMMARY}
+        echo "## General informations - TEST ${TEST_STATUS}" >> ${GITHUB_STEP_SUMMARY}
         echo "Bootstrap method: ${BOOTSTRAP_METHOD}" >> ${GITHUB_STEP_SUMMARY}
         if ${{ inputs.test_type == 'cli' }}; then
           echo "Number of nodes in the cluster: ${{ inputs.node_number }}" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -301,12 +301,3 @@ jobs:
       - name: Delete Qase Run if job has been cancelled
         if: ${{ contains(needs.e2e.outputs.steps_status, 'cancelled') }}
         run: cd tests && make delete-qase-run
-
-  # Just to signify that something has been cancelled and it's not useful to check the test
-  declare-cancelled:
-    needs: e2e
-    if: ${{ always() && contains(needs.e2e.outputs.steps_status, 'cancelled') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Specify in summary if something has been cancelled
-        run: echo "# TEST CANCELLED!" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -47,7 +47,7 @@ on:
 
     # Job outputs to export for caller workflow
     outputs:
-      step_status:
+      steps_status:
         description: Status of the executed test jobs
         value: ${{ jobs.airgap.outputs.steps_status }}
 

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -463,6 +463,7 @@ jobs:
           rancher_version: ${{ inputs.rancher_version }}
           sequential: ${{ inputs.sequential }}
           snap_type: ${{ inputs.snap_type }}
+          steps_status: ${{ join(steps.*.conclusion, ' ') }}
           test_type: ${{ inputs.test_type }}
           upgrade_image: ${{ inputs.upgrade_image }}
           upgrade_os_channel: ${{ inputs.upgrade_os_channel }}


### PR DESCRIPTION
Should fix #1509.

Verification run:
- [CLI-K3s-OBS_Dev in OK state](https://github.com/rancher/elemental/actions/runs/10663120247)
![Screenshot from 2024-09-02 11-09-46](https://github.com/user-attachments/assets/6bef084d-a6b2-42ca-b6fd-870d282cb3e7)
- [CLI-K3s-OBS_Dev in CANCELED state](https://github.com/rancher/elemental/actions/runs/10664160428)
![Screenshot from 2024-09-02 11-10-24](https://github.com/user-attachments/assets/9cbe4633-7e38-4612-b3b5-31b76d87dd7f)
- [CLI-K3s-OBS_Dev in FAILED state](https://github.com/rancher/elemental/actions/runs/10664259922)
![Screenshot from 2024-09-02 11-27-11](https://github.com/user-attachments/assets/9e855f65-b2c7-49f5-8a4d-7615e229a148)