### PR TITLE
ci/ui: add global slowdown for cypress tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
@@ -16,10 +16,6 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 filterTests(['main'], () => {
   describe('Advanced filtering testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -16,11 +16,7 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
 import { isRancherManagerVersion } from '../../support/utils';
-
-// Slow down each command by 500ms
-slowCypressDown(500)
 
 filterTests(['main'], () => {
   describe('Deploy application in fresh Elemental Cluster', () => {

--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -18,10 +18,6 @@ import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import { isCypressTag, isOperatorVersion, isRancherManagerVersion } from '~/support/utils';
 import { Elemental } from '~/support/elemental';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 filterTests(['main', 'upgrade'], () => {
   describe('Install Elemental Operator', () => {

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -17,10 +17,6 @@ import filterTests from '~/support/filterTests.js';
 import { isRancherManagerVersion, isUIVersion } from '../../support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500)
 
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
@@ -16,7 +16,6 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
-
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();
   describe('First login on Rancher', () => {

--- a/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_inventory.spec.ts
@@ -17,10 +17,6 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from '~/support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 Cypress.config();
 describe('Machine inventory testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_registration.spec.ts
@@ -17,10 +17,6 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from '~/support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 Cypress.config();
 describe('Machine registration testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/machine_selector.spec.ts
@@ -17,10 +17,6 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 filterTests(['main'], () => {
   describe('Machine selector testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/os_version.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/os_version.spec.ts
@@ -15,11 +15,7 @@ limitations under the License.
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import { slowCypressDown } from 'cypress-slow-down';
 import { isRancherManagerVersion } from '~/support/utils';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 filterTests(['main'], () => {
   Cypress.config();

--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -17,10 +17,6 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from '~/support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 filterTests(['main'], () => {
   describe('Reset testing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -19,10 +19,6 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import * as utils from '~/support/utils';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 Cypress.config();
 describe('Elemental operator upgrade tests', () => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
@@ -19,10 +19,6 @@ import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 import * as utils from '~/support/utils';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 describe('UI extension upgrade tests', () => {
   const elemental = new Elemental();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -18,10 +18,6 @@ import filterTests from '~/support/filterTests.js';
 import * as utils from '~/support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { slowCypressDown } from 'cypress-slow-down';
-
-// Slow down each command by 500ms
-slowCypressDown(500);
 
 describe('Upgrade tests', () => {
   const channelName = 'mychannel';

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -13,6 +13,10 @@ limitations under the License.
 */
 
 import './commands';
+import { slowCypressDown } from 'cypress-slow-down';
+
+// Slow down each command by 500ms
+slowCypressDown(500);
 
 declare global {
   // In Cypress functions should be declared with 'namespace'


### PR DESCRIPTION
Configure the slowdown in the support file instead of every test files.

## Verification run
[UI-K3s](https://github.com/rancher/elemental/actions/runs/10735983504/job/29780124852) ✅ 