### PR TITLE
Ci/ui: report elemental version in summary for UI

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -160,12 +160,6 @@ jobs:
                                    -l app=cert-manager \
                                    -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
 
-          # Extract elemental-operator version
-          OPERATOR_VERSION=$(kubectl get pod \
-                               --namespace cattle-elemental-system \
-                               -l app=elemental-operator \
-                               -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
-
           # Extract Rancher Manager version
           RANCHER_VERSION=$(kubectl get pod \
                               --namespace cattle-system \
@@ -174,7 +168,6 @@ jobs:
 
           # Export values
           echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
-          echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
           echo "rancher_image_version=${RANCHER_VERSION}" >> ${GITHUB_OUTPUT}
 
       - name: Install Chartmuseum
@@ -245,6 +238,17 @@ jobs:
           name: cypress-videos-basics-${{ inputs.public_fqdn }}-${{ steps.date.outputs.epoch }}
           path: tests/cypress/latest/videos
           retention-days: 7
+
+      - name: Extract Elemental version
+        id: elemental_version
+        run: |
+          # Extract elemental-operator version
+          OPERATOR_VERSION=$(kubectl get pod \
+                               --namespace cattle-elemental-system \
+                               -l app=elemental-operator \
+                               -o jsonpath={.items[*].status.containerStatuses[*].image} 2> /dev/null || true)
+          # Export value
+          echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
 
       - name: Deploy nodes to join Rancher manager
         id: deploy_node_ui
@@ -358,7 +362,7 @@ jobs:
           k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
           k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
           node_number: ${{ inputs.node_number }}
-          operator_version: ${{ steps.component.outputs.operator_version }}
+          operator_version: ${{ steps.elemental_version.outputs.operator_version }}
           os_version: ${{ steps.iso_version.outputs.os_version }}
           proxy: ${{ inputs.proxy }}
           public_fqdn: ${{ inputs.public_fqdn }}

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -39,6 +39,18 @@ export class Elemental {
     });
   }
 
+  // Get elemental operator version
+  getOperatorVersion(): void {
+    cy.contains('local').click();
+    cy.contains('Workloads').click();
+    cy.contains('Deployments').click();
+    cy.contains('elemental-operator').click()
+    cy.get('[data-testid="sortable-cell-0-2"] > .formatter-pod-images > span').invoke('text').then((version:string) => {
+      Cypress.env('elemental_operator_version', version);
+      cy.log(`Elemental operator version: ${version}`);
+    });
+  }
+
   installElementalOperator(upgrade_from_version: string): void {
     cy.contains('local').click();
     cy.get('.nav').contains('Apps').click();


### PR DESCRIPTION
- Fix the elemental version in the summary (because elemental is install by Cypress in UI tests).
- Add a function to get the elemental operator version to conditions features to test

## Verification run
https://github.com/rancher/elemental/actions/runs/10769841576 ✅ 