### PR TITLE
ci/cli: add full backup/restore test

### DIFF
--- a/.github/workflows/SCHEDULING.md
+++ b/.github/workflows/SCHEDULING.md
@@ -14,12 +14,13 @@ We try to spread the tests as best as we can to avoid SPOT issue as well as not 
 | CLI Multicluster | Sunday | 5am | us-central1-b |
 | CLI Regression | Saturday | 11am | us-central1-c |
 | CLI Rancher Manager Devel | Sunday | 8am | us-central1-c |
-| UI Rancher Manager Devel | Sunday | 12pm | us-central1-a |
 | CLI K3s Downgrade | Sunday | 2pm | us-central1-b |
+| CLI Full backup/restore (migration) | Sunday | 4pm | us-central1-c |
 | UI K3s | Monday to Saturday | 2am | us-central1-a |
 | UI K3s Upgrade | Monday to Saturday | 4am | us-central1-a |
 | UI RKE2 | Monday to Saturday | 2am | us-central1-b |
 | UI RKE2 Upgrade | Monday to Saturday | 4am | us-central1-b |
+| UI Rancher Manager Devel | Sunday | 12pm | us-central1-a |
 | Update tests description | All days | 11pm | us-central1 |
 
 **NOTE:** please note that the GitHub scheduler uses UTC and our GCP runners are deployed in `us-central1`, so UTC-5.

--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -1,0 +1,53 @@
+# This workflow calls the master E2E workflow with custom variables
+name: CLI-Full-Backup-Restore
+
+on:
+  workflow_dispatch:
+    inputs:
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      k8s_downstream_version:
+        description: Rancher cluster downstream version to use
+        default: '"v1.27.13+k3s1"'
+        type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: '"v1.27.13+k3s1"'
+        type: string
+      qase_run_id:
+        description: Qase run ID where the results will be reported
+        type: string
+      rancher_version:
+        description: Rancher Manager channel/version/head_version to use
+        default: '"stable/latest"'
+        type: string
+  schedule:
+    # Every Sunday at 4pm UTC (11am in us-central1)
+    - cron: '0 16 * * 0'
+
+jobs:
+  cli:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1","v1.30.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1","v1.30.4+rke2r1"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
+    uses: ./.github/workflows/master_e2e.yaml
+    secrets:
+      credentials: ${{ secrets.GCP_CREDENTIALS }}
+      pat_token: ${{ secrets.SELF_HOSTED_RUNNER_PAT_TOKEN }}
+      qase_api_token: ${{ secrets.QASE_API_TOKEN }}
+    with:
+      destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
+      full_backup_restore: true
+      k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
+      k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      node_number: 3
+      qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
+      rancher_version: ${{ matrix.rancher_version }}
+      test_type: cli
+      zone: us-central1-c

--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -45,6 +45,10 @@ on:
         description: Force OS downgrade
         default: false
         type: boolean
+      full_backup_restore:
+         description: Test migration-like backup/restore functionality
+         default: false
+         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
         type: string
@@ -228,6 +232,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       force_downgrade: ${{ inputs.force_downgrade }}
+      full_backup_restore: ${{ inputs.full_backup_restore }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -32,6 +32,9 @@ on:
       force_downgrade:
         required: true
         type: boolean
+      full_backup_restore:
+        required: true
+        type: boolean
       k8s_downstream_version:
         required: true
         type: string
@@ -350,10 +353,25 @@ jobs:
         run: |
           cd tests && make e2e-upgrade-node && make e2e-check-app
 
-      - name: Test Backup/Restore Elemental resources with Rancher Manager
+      - name: Test Backup/Restore Rancher Manager/Elemental resources
         id: test_backup_restore
+        env:
+          CA_TYPE: ${{ inputs.ca_type }}
+          OPERATOR_REPO: ${{ inputs.operator_repo }}
+          PUBLIC_FQDN: ${{ inputs.public_fqdn }}
+          PUBLIC_DOMAIN: ${{ inputs.public_domain }}
         run: |
-          cd tests && make e2e-backup-restore && make e2e-check-app
+          cd tests
+
+          # Run simple or full backup/restore test
+          if ${{ inputs.full_backup_restore == true }}; then
+            make e2e-full-backup-restore
+          else
+            make e2e-simple-backup-restore
+          fi
+
+          # Check the installed application
+          make e2e-check-app
 
       - name: Extract ISO version
         id: iso_version
@@ -426,8 +444,8 @@ jobs:
         env:
           OPERATOR_REPO: ${{ inputs.operator_repo }}
         # Don't test Operator uninstall if we want to keep the runner for debugging purposes
-        if: ${{ inputs.destroy_runner == true }}
-        run: cd tests && make e2e-uninstall-operator
+        if: ${{ inputs.destroy_runner == true && inputs.full_backup_restore == false }}
+        run: cd tests && make e2e-uninstall-operator && make e2e-check-app
 
       # This step must be called in each worklow that wants a summary!
       - name: Get logs and add summary

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -41,6 +41,9 @@ on:
       force_downgrade:
         required: true
         type: boolean
+      full_backup_restore:
+        required: true
+        type: boolean
       k8s_downstream_version:
         required: true
         type: string
@@ -171,6 +174,7 @@ jobs:
       cluster_type: ${{ inputs.cluster_type }}
       destroy_runner: ${{ inputs.destroy_runner }}
       force_downgrade: ${{ inputs.force_downgrade }}
+      full_backup_restore: ${{ inputs.full_backup_restore }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       node_number: ${{ inputs.node_number }}
       operator_repo: ${{ inputs.operator_repo }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 [![CLI-K3s-Downgrade](https://github.com/rancher/elemental/actions/workflows/cli-k3s-downgrade-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-downgrade-matrix.yaml)
 [![CLI-K3s-Scalability](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-scalability-matrix.yaml)
 [![CLI-K3s-SELinux](https://github.com/rancher/elemental/actions/workflows/cli-k3s-selinux-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-selinux-matrix.yaml)
+[![CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml)
 [![CLI-Multicluster](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml)
 [![CLI-Rancher-Manager-Head-2.7](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.7-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.7-matrix.yaml)
 [![CLI-Regression](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -61,14 +61,14 @@ e2e-airgap-rancher: deps
 e2e-bootstrap-node: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter bootstrap -r -v ./e2e
 
-e2e-backup-restore: deps
-	ginkgo --label-filter test-backup-restore -r -v ./e2e
-
 e2e-check-app: deps
 	ginkgo --label-filter check-app -r -v ./e2e
 
 e2e-configure-rancher: deps
 	ginkgo --label-filter configure -r -v ./e2e
+
+e2e-full-backup-restore: deps
+	ginkgo --label-filter test-full-backup-restore -r -v ./e2e
 
 e2e-get-logs: deps
 	ginkgo --label-filter logs -r -v ./e2e
@@ -91,11 +91,14 @@ e2e-iso-image: deps
 e2e-multi-cluster: deps
 	ginkgo --timeout $(GINKGO_TIMEOUT)s --label-filter multi-cluster -r -v ./e2e
 
+e2e-prepare-archive: deps
+	ginkgo --label-filter prepare-archive -r -v ./e2e
+
 e2e-reset: deps
 	ginkgo --label-filter reset -r -v ./e2e
 
-e2e-prepare-archive: deps
-	ginkgo --label-filter prepare-archive -r -v ./e2e
+e2e-simple-backup-restore: deps
+	ginkgo --label-filter test-simple-backup-restore -r -v ./e2e
 	
 e2e-ui-rancher: deps
 	ginkgo --label-filter ui -r -v ./e2e

--- a/tests/assets/restore.yaml
+++ b/tests/assets/restore.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   backupFilename: %BACKUP_FILE%
   deleteTimeoutSeconds: 10
-  prune: true
+  prune: %PRUNE%

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -15,14 +15,20 @@ limitations under the License.
 package e2e_test
 
 import (
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
-	"github.com/rancher-sandbox/ele-testhelpers/rancher"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+)
+
+const (
+	backupResourceName  = "elemental-backup"
+	restoreResourceName = "elemental-restore"
 )
 
 var _ = Describe("E2E - Install Backup/Restore Operator", Label("install-backup-restore"), func() {
@@ -38,64 +44,161 @@ var _ = Describe("E2E - Install Backup/Restore Operator", Label("install-backup-
 		// Report to Qase
 		testCaseID = 64
 
-		// Default chart
-		chartRepo := "rancher-chart"
-
-		By("Configuring Chart repository", func() {
-			// Set specific operator version if defined
-			if backupRestoreVersion != "" {
-				chartRepo = "https://github.com/rancher/backup-restore-operator/releases/download/" + backupRestoreVersion
-			} else {
-				RunHelmCmdWithRetry("repo", "add", chartRepo, "https://charts.rancher.io")
-				RunHelmCmdWithRetry("repo", "update")
-			}
-		})
-
 		By("Installing rancher-backup-operator", func() {
-			for _, chart := range []string{"rancher-backup-crd", "rancher-backup"} {
-				// Set the filename in chart if a custom version is defined
-				chartName := chart
-				if backupRestoreVersion != "" {
-					chartName = chart + "-" + strings.Trim(backupRestoreVersion, "v") + ".tgz"
-				}
-
-				// Global installation flags
-				flags := []string{
-					"upgrade", "--install", chart, chartRepo + "/" + chartName,
-					"--namespace", "cattle-resources-system",
-					"--create-namespace",
-					"--wait", "--wait-for-jobs",
-				}
-
-				// Add specific options for the rancher-backup chart
-				if chart == "rancher-backup" {
-					flags = append(flags,
-						"--set", "persistence.enabled=true",
-						"--set", "persistence.storageClass=local-path",
-					)
-				}
-
-				// Install through Helm
-				RunHelmCmdWithRetry(flags...)
-
-				// Delay few seconds for all to be installed
-				time.Sleep(tools.SetTimeout(20 * time.Second))
-			}
-		})
-
-		By("Waiting for rancher-backup-operator pod", func() {
-			// Wait for pod to be started
-			Eventually(func() error {
-				return rancher.CheckPod(k, [][]string{{"cattle-resources-system", "app.kubernetes.io/name=rancher-backup"}})
-			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+			InstallBackupOperator(k)
 		})
 	})
 })
 
-var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func() {
-	backupResourceName := "elemental-backup"
-	restoreResourceName := "elemental-restore"
+var _ = Describe("E2E - Test full Backup/Restore", Label("test-full-backup-restore"), func() {
+	// Create kubectl context
+	// Default timeout is too small, so New() cannot be used
+	k := &kubectl.Kubectl{
+		Namespace:    "",
+		PollTimeout:  tools.SetTimeout(300 * time.Second),
+		PollInterval: 500 * time.Millisecond,
+	}
 
+	var backupFile string
+
+	It("Do a full backup/restore test", func() {
+		// TODO: use another case id for full backup/restore test
+		// Report to Qase
+		// testCaseID = 65
+
+		By("Adding a backup resource", func() {
+			err := kubectl.Apply(clusterNS, backupYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Checking that the backup has been done", func() {
+			out, err := kubectl.RunWithoutErr("get", "backup", backupResourceName,
+				"-o", "jsonpath={.metadata.name}")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(out).To(ContainSubstring(backupResourceName))
+
+			// Wait for backup to be done
+			CheckBackupRestore("Done with backup")
+		})
+
+		By("Copying the backup file", func() {
+			// Get local storage path
+			localPath := GetBackupDir()
+
+			// Get the backup file from the previous backup
+			file, err := kubectl.RunWithoutErr("get", "backup", backupResourceName, "-o", "jsonpath={.status.filename}")
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Share the filename across other functions
+			backupFile = file
+
+			// Copy backup file
+			err = exec.Command("sudo", "cp", localPath+"/"+backupFile, ".").Run()
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Uninstalling K8s", func() {
+			if strings.Contains(k8sUpstreamVersion, "rke2") {
+				out, err := exec.Command("sudo", "/usr/local/bin/rke2-uninstall.sh").CombinedOutput()
+				Expect(err).To(Not(HaveOccurred()), out)
+			} else {
+				out, err := exec.Command("k3s-uninstall.sh").CombinedOutput()
+				Expect(err).To(Not(HaveOccurred()), out)
+			}
+		})
+
+		if strings.Contains(k8sUpstreamVersion, "rke2") {
+			By("Installing RKE2", func() {
+				InstallRKE2()
+			})
+
+			// Use the new Kube config
+			err := os.Setenv("KUBECONFIG", "/etc/rancher/rke2/rke2.yaml")
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Starting RKE2", func() {
+				StartRKE2()
+			})
+
+			By("Waiting for RKE2 to be started", func() {
+				WaitForRKE2(k)
+			})
+
+			By("Installing local-path-provisionner", func() {
+				InstallLocalStorage(k)
+			})
+		} else {
+			By("Installing K3s", func() {
+				InstallK3s()
+			})
+
+			// Use the new Kube config
+			err := os.Setenv("KUBECONFIG", "/etc/rancher/k3s/k3s.yaml")
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Starting K3s", func() {
+				StartK3s()
+			})
+
+			By("Waiting for K3s to be started", func() {
+				WaitForK3s(k)
+			})
+		}
+
+		By("Installing rancher-backup-operator", func() {
+			InstallBackupOperator(k)
+		})
+
+		By("Copying backup file to restore", func() {
+			// Get new local storage path
+			localPath := GetBackupDir()
+
+			// Copy backup file
+			err := exec.Command("sudo", "cp", backupFile, localPath).Run()
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Adding a restore resource", func() {
+			// Set the backup file in the restore resource
+			err := tools.Sed("%BACKUP_FILE%", backupFile, restoreYaml)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// "prune" option should be set to true here
+			err = tools.Sed("%PRUNE%", "false", restoreYaml)
+			Expect(err).To(Not(HaveOccurred()))
+
+			// And apply
+			err = kubectl.Apply(clusterNS, restoreYaml)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Checking that the restore has been done", func() {
+			// Wait until resources are available again
+			Eventually(func() string {
+				out, _ := kubectl.RunWithoutErr("get", "restore", restoreResourceName,
+					"-o", "jsonpath={.metadata.name}")
+				return out
+			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(ContainSubstring(restoreResourceName))
+
+			// Wait for restore to be done
+			CheckBackupRestore("Done restoring")
+		})
+
+		By("Installing CertManager", func() {
+			InstallCertManager(k)
+		})
+
+		By("Installing Rancher Manager", func() {
+			InstallRancher(k)
+		})
+
+		By("Checking cluster state after restore", func() {
+			WaitCluster(clusterNS, clusterName)
+		})
+	})
+})
+
+var _ = Describe("E2E - Test simple Backup/Restore", Label("test-simple-backup-restore"), func() {
 	It("Do a backup", func() {
 		// Report to Qase
 		testCaseID = 65
@@ -111,13 +214,8 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(out).To(ContainSubstring(backupResourceName))
 
-			// Check operator logs
-			Eventually(func() string {
-				out, _ := kubectl.RunWithoutErr("logs", "-l app.kubernetes.io/name=rancher-backup",
-					"--tail=-1", "--since=5m",
-					"--namespace", "cattle-resources-system")
-				return out
-			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(ContainSubstring("Done with backup"))
+			// Wait for backup to be done
+			CheckBackupRestore("Done with backup")
 		})
 	})
 
@@ -150,6 +248,10 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 			err = tools.Sed("%BACKUP_FILE%", backupFile, restoreYaml)
 			Expect(err).To(Not(HaveOccurred()))
 
+			// "prune" option should be set to true here
+			err = tools.Sed("%PRUNE%", "true", restoreYaml)
+			Expect(err).To(Not(HaveOccurred()))
+
 			// And apply
 			err = kubectl.Apply(clusterNS, restoreYaml)
 			Expect(err).To(Not(HaveOccurred()))
@@ -163,13 +265,8 @@ var _ = Describe("E2E - Test Backup/Restore", Label("test-backup-restore"), func
 				return out
 			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(ContainSubstring(restoreResourceName))
 
-			// Check operator logs
-			Eventually(func() string {
-				out, _ := kubectl.RunWithoutErr("logs", "-l app.kubernetes.io/name=rancher-backup",
-					"--tail=-1", "--since=5m",
-					"--namespace", "cattle-resources-system")
-				return out
-			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(ContainSubstring("Done restoring"))
+			// Wait for restore to be done
+			CheckBackupRestore("Done restoring")
 		})
 
 		By("Checking cluster state after restore", func() {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -78,27 +78,7 @@ var _ = Describe("E2E - Upgrading Elemental Operator", Label("upgrade-operator")
 			upgradeOrder = []string{"elemental-operator", "elemental-operator-crds"}
 		}
 
-		for _, chart := range upgradeOrder {
-			// Set flags for installation
-			flags := []string{"upgrade", "--install", chart,
-				operatorUpgrade + "/" + chart + "-chart",
-				"--namespace", "cattle-elemental-system",
-				"--create-namespace",
-				"--wait", "--wait-for-jobs",
-			}
-
-			// TODO: maybe adding a dedicated variable for operator version instead?
-			if strings.Contains(operatorUpgrade, "dev") {
-				flags = append(flags, "--devel")
-			}
-
-			RunHelmCmdWithRetry(flags...)
-		}
-
-		// Wait for all pods to be started
-		Eventually(func() error {
-			return rancher.CheckPod(k, [][]string{{"cattle-elemental-system", "app=elemental-operator"}})
-		}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		InstallElementalOperator(k, upgradeOrder, operatorUpgrade)
 	})
 })
 


### PR DESCRIPTION
This test simulates migration of a Rancher Manager server. This PR will fix #1212.

**Note:** this version doesn't install worker nodes because there is an issue as we need to do a separate etcd backup/restore to be able to deploy new nodes. This will be done in another PR (etcd backup/restore and provisioning of worker nodes). The operator uninstallation test is also not working because the operator is not installed by helm after a restore, something to investigate further if it's expected or not.

Verification runs:
- [CLI-K3s-Full-Backup](https://github.com/rancher/elemental/actions/runs/10959853850)
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/10989821754)