### PR TITLE
ci: fix elemental-operator installation

### DIFF
--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -232,6 +232,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: ${{ inputs.os_to_test }}
       os_version_install: ${{ inputs.os_version_install }}
       os_version_target: ${{ inputs.os_version_target }}
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -38,6 +38,9 @@ on:
       operator_repo:
         required: true
         type: string
+      os_to_test:
+        required: true
+        type: string
       os_version_install:
         required: true
         type: string
@@ -175,10 +178,11 @@ jobs:
         if: ${{ inputs.operator_repo != 'marketplace' }}
         env: 
           OPERATOR_REPO: ${{ inputs.operator_repo }}
+          OS_TO_TEST: ${{ inputs.os_to_test }}
         run: |
           cd tests && make e2e-install-chartmuseum
           # Extract latest dev operator version
-          OPERATOR_CHART=$(ls elemental-operator-chart*)
+          OPERATOR_CHART=$(ls elemental-operator-chart* 2>/dev/null)
           i=${OPERATOR_CHART##*-}
           OPERATOR_VERSION=${i%.tgz}
 

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -373,6 +373,7 @@ jobs:
           rancher_image_version: ${{ steps.component.outputs.rancher_image_version }}
           rancher_version: ${{ inputs.rancher_version }}
           sequential: ${{ inputs.sequential }}
+          steps_status: ${{ join(steps.*.conclusion, ' ') }}
           test_type: ${{ inputs.test_type }}
           ui_account: ${{ inputs.ui_account }}
           upgrade_image: ${{ inputs.upgrade_image }}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -80,7 +80,7 @@ e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
 
 e2e-install-chartmuseum:
-	sudo ./scripts/deploy-chartmuseum $(OPERATOR_REPO)
+	sudo ./scripts/deploy-chartmuseum $(OPERATOR_REPO) $(OS_TO_TEST)
 
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -355,15 +355,22 @@ var _ = Describe("E2E - Install Rancher Manager", Label("install"), func() {
 				testCaseID = 62
 
 				for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
-					RunHelmCmdWithRetry("upgrade", "--install", chart,
-						operatorRepo+"/"+chart+"-chart",
+					// Set flags for installation
+					flags := []string{"upgrade", "--install", chart,
+						operatorRepo + "/" + chart + "-chart",
 						"--namespace", "cattle-elemental-system",
 						"--create-namespace",
 						"--wait", "--wait-for-jobs",
-					)
+					}
 
-					// Delay few seconds for all to be installed
-					time.Sleep(tools.SetTimeout(20 * time.Second))
+					// TODO: maybe adding a dedicated variable for operator version instead
+					// of using os2Test (this one should be kept for the OS image version)
+					// Variable operator_repo extists but does not exactly reflect operator's version
+					if strings.Contains(os2Test, "dev") {
+						flags = append(flags, "--devel")
+					}
+
+					RunHelmCmdWithRetry(flags...)
 				}
 
 				// Wait for pod to be started

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -85,13 +85,23 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 		// NOTE: the operator cannot be reinstall now because there are still CRDs pending to be removed
 		By("Checking that Elemental operator CRDs cannot be reinstalled", func() {
+			// Set flags for installation
 			chart := "elemental-operator-crds"
-			out, err := kubectl.RunHelmBinaryWithOutput("upgrade", "--install", chart,
-				operatorRepo+"/"+chart+"-chart",
+			flags := []string{"upgrade", "--install", chart,
+				operatorRepo + "/" + chart + "-chart",
 				"--namespace", "cattle-elemental-system",
 				"--create-namespace",
 				"--wait", "--wait-for-jobs",
-			)
+			}
+
+			// TODO: maybe adding a dedicated variable for operator version instead
+			// of using os2Test (this one should be kept for the OS image version)
+			// Variable operator_repo extists but does not exactly reflect operator's version
+			if strings.Contains(os2Test, "dev") {
+				flags = append(flags, "--devel")
+			}
+
+			out, err := kubectl.RunHelmBinaryWithOutput(flags...)
 			Expect(err).To(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("CRDs from previous installations are pending to be removed"))
 		})
@@ -171,12 +181,22 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 
 		By("Installing Operator via Helm", func() {
 			for _, chart := range []string{"elemental-operator-crds", "elemental-operator"} {
-				RunHelmCmdWithRetry("upgrade", "--install", chart,
-					operatorRepo+"/"+chart+"-chart",
+				// Set flags for installation
+				flags := []string{"upgrade", "--install", chart,
+					operatorRepo + "/" + chart + "-chart",
 					"--namespace", "cattle-elemental-system",
 					"--create-namespace",
 					"--wait", "--wait-for-jobs",
-				)
+				}
+
+				// TODO: maybe adding a dedicated variable for operator version instead
+				// of using os2Test (this one should be kept for the OS image version)
+				// Variable operator_repo extists but does not exactly reflect operator's version
+				if strings.Contains(os2Test, "dev") {
+					flags = append(flags, "--devel")
+				}
+
+				RunHelmCmdWithRetry(flags...)
 			}
 
 			// Wait for pod to be started

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -9,7 +9,9 @@ set -e -x
 PATH+=:/usr/local/bin
 
 # Variables
-REPO=$1
+typeset REPO=$1
+shift
+typeset -l OS2TEST=$1
 
 # Create a systemctl file for chartmuseum
 cat > /etc/systemd/system/chartmuseum.service << EOF
@@ -44,9 +46,12 @@ helm plugin install https://github.com/chartmuseum/helm-push.git
 # Create a local helm repo
 helm repo add chartmuseum http://localhost:8080
 
+# Check if we want to use Development version of Elemental
+[[ "${OS2TEST}" =~ dev ]] && DEVEL="--devel"
+
 # Download needed helm charts
-helm pull $REPO/elemental-operator-crds-chart
-helm pull $REPO/elemental-operator-chart
+helm pull ${DEVEL} ${REPO}/elemental-operator-crds-chart
+helm pull ${DEVEL} ${REPO}/elemental-operator-chart
 
 # Extract helm charts
 tar -xvzf elemental-operator-crds-*


### PR DESCRIPTION
Now we have to explicitly define that we want to install a development version.
This is due to changes made for https://github.com/rancher/elemental-obs/issues/18.

Verification runs:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/10918676723)
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/10917054527) - It fails for another issue with the chart, will be investigated/fixed in another PR.