### PR TITLE
ci/ui: add git repo input in marketplace tests

### DIFF
--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -79,6 +79,10 @@ on:
         description: Case run ID where the results will be reported
         default: auto
         type: string
+      rancher_git_chart:
+        description: Point to github or rancher git for chart installation
+        default: rancher
+        type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
         type: string
@@ -236,6 +240,7 @@ jobs:
       public_fqdn: ${{ needs.create-runner.outputs.public_fqdn }}
       qase_project_code: ELEMENTAL
       qase_run_id: ${{ needs.pre-qase.outputs.qase_run_id }}
+      rancher_git_chart: ${{ inputs.rancher_git_chart }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: ${{ inputs.reset }}

--- a/.github/workflows/sub_test_choice.yaml
+++ b/.github/workflows/sub_test_choice.yaml
@@ -80,6 +80,9 @@ on:
       qase_run_id:
         required: true
         type: string
+      rancher_git_chart:
+        required: true
+        type: string
       rancher_upgrade:
         required: true
         type: string
@@ -239,6 +242,7 @@ jobs:
       public_fqdn: ${{ inputs.public_fqdn }}
       qase_project_code: ${{ inputs.qase_project_code }}
       qase_run_id: ${{ inputs.qase_run_id }}
+      rancher_git_chart: ${{ inputs.rancher_git_chart }}
       rancher_version: ${{ inputs.rancher_version }}
       runner_label: ${{ inputs.runner_label }}
       ui_account: ${{ inputs.ui_account }}

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -59,6 +59,9 @@ on:
       qase_run_id:
         required: true
         type: string
+      rancher_git_chart:
+        required: true
+        type: string
       rancher_version:
         required: true
         type: string
@@ -199,6 +202,7 @@ jobs:
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           OS_VERSION_INSTALL: ${{ inputs.os_version_install }}
           RANCHER_CHANNEL: ${{ inputs.rancher_version }}
+          RANCHER_GIT_CHART: ${{ inputs.rancher_git_chart }}
           RANCHER_VERSION: ${{ steps.component.outputs.rancher_image_version }}
           RANCHER_PASSWORD: rancherpassword
           RANCHER_URL: https://${{ inputs.public_fqdn }}/dashboard

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -32,12 +32,12 @@ on:
       os_version_install:
         description: OS version to install
         type: string
-      proxy:
-        description: Deploy a proxy (none/rancher/elemental)
-        default: elemental
-        type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
+        type: string
+      rancher_git_chart:
+        description: Point to github or rancher git for chart installation
+        default: rancher
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
@@ -61,7 +61,8 @@ jobs:
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
       operator_repo: ${{ inputs.operator_repo }}
       os_version_install: ${{ inputs.os_version_install }}
-      proxy: ${{ inputs.proxy }}
+      proxy: elemental
       qase_run_id: ${{ inputs.qase_run_id }}
+      rancher_git_chart: ${{ inputs.rancher_git_chart }}
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_operator.spec.ts
@@ -16,7 +16,7 @@ import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { isCypressTag, isOperatorVersion, isRancherManagerVersion } from '~/support/utils';
+import { isCypressTag, isGitRepo, isOperatorVersion, isRancherManagerVersion } from '~/support/utils';
 import { Elemental } from '~/support/elemental';
 
 filterTests(['main', 'upgrade'], () => {
@@ -26,11 +26,17 @@ filterTests(['main', 'upgrade'], () => {
     const chartmuseumRepo = Cypress.env('chartmuseum_repo') + ':8080';
 
     beforeEach(() => {
+      cy.viewport(1920, 1080);
       cy.login();
       cy.visit('/');
       cypressLib.burgerMenuToggle();
     });
 
+    if (isOperatorVersion('marketplace') && isGitRepo('github')) {
+      it('Configure from which git repo charts are pulled from', () => {
+        cypressLib.addRepository('rancher-dev', 'https://github.com/rancher/charts.git', 'git', isRancherManagerVersion('2.9') ? 'dev-v2.9' : 'dev-v2.8');
+      });
+    }
     // Add dev repo for main test or if the test runs on Rancher 2.7 (because operator is not in the 2.7 marketplace)
     if ((!isOperatorVersion('marketplace') && isCypressTag('main')) || isRancherManagerVersion('2.7')) {
       it('Add local chartmuseum repo', () => {

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -43,6 +43,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.password = process.env.RANCHER_PASSWORD;
   config.env.proxy_ip = process.env.PROXY_IP;
   config.env.proxy = process.env.PROXY;
+  config.env.rancher_git_chart = process.env.RANCHER_GIT_CHART;
   config.env.rancher_channel = process.env.RANCHER_CHANNEL;
   config.env.rancher_version = process.env.RANCHER_VERSION;
   config.env.stable_os_version = process.env.STABLE_OS_VERSION;

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -170,15 +170,7 @@ Cypress.Commands.add('createMachReg', (
       'type: btrfs', 'reset:', 'reboot: true', 'reset-oem: true', 'reset-persistent: true'
     ];
 
-    if (utils.isUIVersion('dev')) {
-      cloudConfigChecks.forEach(text => cy.getBySel(selectors.yamlEditor).should('include.text', text));
-    } else {
-      const stableConfigChecks = [
-        'config:', 'cloud-config:', 'users:', '- name: root', 'passwd: root',
-        'elemental:', 'install:', 'device: /dev/nvme0n1', 'poweroff: true'
-      ];
-      stableConfigChecks.forEach(text => cy.getBySel(selectors.yamlEditor).should('include.text', text));
-    }
+    cloudConfigChecks.forEach(text => cy.getBySel(selectors.yamlEditor).should('include.text', text));
   }
 
   // Check label and annotation in YAML

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -10,7 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { isCypressTag, isOperatorVersion, isRancherPrime } from '~/support/utils';
+import { isCypressTag, isGitRepo, isOperatorVersion, isRancherPrime } from '~/support/utils';
 
 export class Elemental {
   // Go into the cluster creation menu
@@ -58,6 +58,11 @@ export class Elemental {
     if (isCypressTag('main') && !isOperatorVersion('marketplace')) {
       cy.contains('.item.has-description.color1', 'Elemental', { timeout: 30000 }).click();
     } else {
+        // Uncheck Rancher (rancher.io) repo if it's checked
+        if (isGitRepo('github')) {
+          cy.get('#vs1__combobox > .vs__selected-options').click();
+          cy.get('#vs1__option-1 > .checkbox-outer-container > .checkbox-container').click();
+        }
       cy.contains('Elemental', { timeout: 30000 }).click();
     }
 
@@ -71,6 +76,7 @@ export class Elemental {
     cy.contains('.outer-container > .header', 'Elemental');
 
     if (isRancherPrime() && isCypressTag('main')) {
+      cy.contains('Container Registry').click();
       const registryLabel = 'Container Registry';
       cy.byLabel(registryLabel).clear();
       if (isOperatorVersion('staging')) {

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -10,6 +10,11 @@ export const isCypressTag = (tag: string) => {
   return (new RegExp(tag)).test(Cypress.env("cypress_tags"));
 }
 
+// Check the Git repo to pull charts from
+export const isGitRepo = (repo: string) => {
+  return (new RegExp(repo)).test(Cypress.env("rancher_git_chart"));
+}
+
 // Check the K8s version
 export const isK8sVersion = (version: string) => {
   version = version.toLowerCase();

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -52,6 +52,7 @@ docker run -v $PWD:/workdir -w /workdir               \
     -e QASE_REPORT=$QASE_REPORT                       \
     -e QASE_RUN_ID=$QASE_RUN_ID                       \
     -e RANCHER_CHANNEL=$RANCHER_CHANNEL               \
+    -e RANCHER_GIT_CHART=$RANCHER_GIT_CHART           \
     -e RANCHER_VERSION=$RANCHER_VERSION               \
     -e RANCHER_PASSWORD=$RANCHER_PASSWORD             \
     -e RANCHER_URL=$RANCHER_URL                       \


### PR DESCRIPTION
Fix #1570 

Additionally to this feature, I also removed the older default cloud-config which is not needed anymore with 1.6.4.

## Verification run
[UI-Marketplace with github repo and v2.9.2-alpha6](https://github.com/rancher/elemental/actions/runs/10928421663) ✅ 
[UI-Marketplace with github repo and v2.8.8-alpha2-prime](https://github.com/rancher/elemental/actions/runs/10924063273) ✅ 