### PR TITLE
Fix UI CI for 1.6.4 stable

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
@@ -24,5 +24,15 @@ filterTests(['main', 'upgrade'], () => {
         cypressLib.firstLogin();
       })
     );
+    // We need to enable prerelease versions to install the elemental dev operator
+    it('Enable Helm Chart Prerelease versions', () => {
+      cy.login();
+      cy.visit('/');
+      cy.getBySel('nav_header_showUserMenu').click();
+      cy.getBySel('user-menu-dropdown').contains('Preferences').click();
+      cy.clickButton('Include Prerelease Versions');
+      cypressLib.burgerMenuToggle();
+      cy.getBySel('side-menu').contains('Home').click();
+    });
   })
 });


### PR DESCRIPTION
Fix partially #1566 for the standard tests
- Enable helm prerelease in user settings
![image](https://github.com/user-attachments/assets/6fde4ef5-b400-4d47-a267-7fb492f3b508)

## Verification run
[UI-K3S-Rancher-2.9](https://github.com/rancher/elemental/actions/runs/10938095883) ✅ 
[UI-K3S-Rancher-2.8](https://github.com/rancher/elemental/actions/runs/10938281925) ✅ 