### PR TITLE
ci/ui: increase timeout when checking machine inv

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/reset.spec.ts
@@ -62,7 +62,7 @@ filterTests(['main'], () => {
         cypressLib.burgerMenuToggle();
         cypressLib.accesMenu('OS Management');
         cy.clickNavMenu(['Inventory of Machines']);
-        cy.contains('There are no rows to show.');
+        cy.contains('There are no rows to show.', { timeout: 30000 });
         for (let i = 0; i < vmNumber; i++) {
           cy.getBySel(`sortable-table-${i}-row`, { timeout: 180000 }).contains('Active', { timeout: 180000 });
         }


### PR DESCRIPTION
Fix this issue:
![image](https://github.com/user-attachments/assets/ec396239-6de9-4cf2-89cd-d0a39edaea1e)

Looks like it can takes some times to delete machine inventories after the reset

## Verification run
https://github.com/rancher/elemental/actions/runs/10955901424