### PR TITLE
ci: bump versions of K3s/RKE2

### DIFF
--- a/.github/workflows/SCHEDULING.md
+++ b/.github/workflows/SCHEDULING.md
@@ -13,7 +13,8 @@ We try to spread the tests as best as we can to avoid SPOT issue as well as not 
 | CLI K3s SELinux | Sunday | 2am | us-central1-c |
 | CLI Multicluster | Sunday | 5am | us-central1-b |
 | CLI Regression | Saturday | 11am | us-central1-c |
-| CLI Rancher Manager Devel | Sunday | 8am | us-central1-c |
+| CLI Rancher Manager 2.7-head | Saturday | 4pm | us-central1-c |
+| CLI Rancher Manager 2.8-head | Sunday | 8am | us-central1-c |
 | CLI K3s Downgrade | Sunday | 2pm | us-central1-b |
 | CLI Full backup/restore (migration) | Sunday | 4pm | us-central1-c |
 | UI K3s | Monday to Saturday | 2am | us-central1-a |

--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","alpha"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -34,8 +34,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,23 +47,23 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8","latest/devel/2.9"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.13+k3s1
-            k8s_upstream_version: v1.27.13+k3s1
+            k8s_downstream_version: v1.30.4+k3s1
+            k8s_upstream_version: v1.30.4+k3s1
             rancher_version: stable/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.13+k3s1
-            k8s_upstream_version: v1.27.13+k3s1
+            k8s_downstream_version: v1.30.4+k3s1
+            k8s_upstream_version: v1.30.4+k3s1
             rancher_version: stable/latest
             reset: true
             sequential: false

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.9"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-k3s-obs_dev.yaml
+++ b/.github/workflows/cli-k3s-obs_dev.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-obs_staging.yaml
+++ b/.github/workflows/cli-k3s-obs_staging.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-selinux-matrix.yaml
+++ b/.github/workflows/cli-k3s-selinux-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,8 +47,8 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"","hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'true')) }}
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+k3s1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       operator_repo:
         description: Operator version to use for initial deployment

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,11 +17,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.28.11+k3s2"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -29,8 +29,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.25.16+k3s4","v1.26.15+k3s1","v1.27.14+k3s1","v1.28.10+k3s1","v1.25.16+rke2r1","v1.26.15+rke2r1","v1.27.14+rke2r1","v1.28.10+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.11+k3s2"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.16+k3s1","v1.28.13+k3s1","v1.29.8+k3s1","v1.30.4+k3s1","v1.27.16+rke2r2","v1.28.13+rke2r1","v1.29.8+rke2r1","v1.30.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.8","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.9"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.30.4+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,23 +47,23 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.8","latest/devel/2.9"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.13+rke2r1
-            k8s_upstream_version: v1.27.13+rke2r1
+            k8s_downstream_version: v1.30.4+rke2r1
+            k8s_upstream_version: v1.30.4+rke2r1
             rancher_version: prime/latest
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.13+rke2r1
-            k8s_upstream_version: v1.27.13+rke2r1
+            k8s_downstream_version: v1.30.4+rke2r1
+            k8s_upstream_version: v1.30.4+rke2r1
             rancher_version: prime/latest
             reset: true
             sequential: false

--- a/.github/workflows/cli-rke2-obs_dev.yaml
+++ b/.github/workflows/cli-rke2-obs_dev.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-obs_staging.yaml
+++ b/.github/workflows/cli-rke2-obs_staging.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+rke2r1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-rm-head-2.7-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.7-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.27.16+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.27.16+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,23 +47,23 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.16+k3s1","v1.27.16+rke2r2"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.16+k3s1","v1.27.16+rke2r2"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.13+k3s1
-            k8s_upstream_version: v1.27.13+k3s1
+            k8s_downstream_version: v1.27.16+k3s1
+            k8s_upstream_version: v1.27.16+k3s1
             rancher_version: latest/devel/2.7
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.13+k3s1
-            k8s_upstream_version: v1.27.13+k3s1
+            k8s_downstream_version: v1.27.16+k3s1
+            k8s_upstream_version: v1.27.16+k3s1
             rancher_version: latest/devel/2.7
             reset: true
             sequential: false

--- a/.github/workflows/cli-rm-head-2.8-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.8-matrix.yaml
@@ -1,5 +1,5 @@
 # This workflow calls the master E2E workflow with custom variables
-name: CLI-Rancher-Manager-Head-2.7
+name: CLI-Rancher-Manager-Head-2.8
 
 on:
   workflow_dispatch:
@@ -18,26 +18,26 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.16+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.16+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use
-        default: '"latest/devel/2.7"'
+        default: '"latest/devel/2.8"'
         type: string
       reset:
         description: Allow reset test (mainly used on CLI tests)
         default: false
         type: boolean
   schedule:
-    # Every Saturday at 4pm UTC (11am in us-central1)
-    - cron: '0 16 * * 0'
+    # Every Sunday at 8am UTC (3am in us-central1)
+    - cron: '0 8 * * 0'
 
 jobs:
   cli:
@@ -47,24 +47,24 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.16+k3s1","v1.27.16+rke2r2"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.16+k3s1","v1.27.16+rke2r2"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+k3s1","v1.28.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+k3s1","v1.28.13+rke2r1"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:
           - ca_type: selfsigned
             cluster_type: ""
-            k8s_downstream_version: v1.27.16+k3s1
-            k8s_upstream_version: v1.27.16+k3s1
+            k8s_downstream_version: v1.28.13+k3s1
+            k8s_upstream_version: v1.28.13+k3s1
             rancher_version: latest/devel/2.7
             reset: true
             sequential: true
           - ca_type: private
             cluster_type: hardened
-            k8s_downstream_version: v1.27.16+k3s1
-            k8s_upstream_version: v1.27.16+k3s1
-            rancher_version: latest/devel/2.7
+            k8s_downstream_version: v1.28.13+k3s1
+            k8s_upstream_version: v1.28.13+k3s1
+            rancher_version: latest/devel/2.8
             reset: true
             sequential: false
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8","latest/devel/2.9"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-obs_dev.yaml
+++ b/.github/workflows/ui-k3s-obs_dev.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-obs_staging.yaml
+++ b/.github/workflows/ui-k3s-obs_staging.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.8","latest/devel/2.9"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       os_version_install:
         description: OS version to install

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -21,11 +21,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+k3s1
+        default: v1.30.4+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.8","latest/devel/2.9"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.27.13+rke2r1
+        default: v1.30.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.28.13+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+rke2r1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.8","latest/devel/2.9"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-rm-head-2.7-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.7-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.27.16+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.27.16+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -42,8 +42,8 @@ jobs:
       max-parallel: 4
       matrix:
         boot_type: ${{ fromJSON(format('[{0}]', inputs.boot_type || '"iso","raw"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.13+k3s1","v1.27.13+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.13+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.16+k3s1","v1.27.16+rke2r2"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.27.16+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.7"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [![CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml)
 [![CLI-Multicluster](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-multicluster-matrix.yaml)
 [![CLI-Rancher-Manager-Head-2.7](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.7-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.7-matrix.yaml)
+[![CLI-Rancher-Manager-Head-2.8](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.8-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-rm-head-2.8-matrix.yaml)
 [![CLI-Regression](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml)
 [![UI-Rancher-Manager-Head-2.7](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.7-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/ui-rm-head-2.7-matrix.yaml)
 


### PR DESCRIPTION
According to [Rancher support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-9-1/) we should use K3s/RKE2 version 1.27 to 1.30.

Verification run:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11028861895)
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11031322789)
- [UI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11028869269)
- [UI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11033333078)