### PR TITLE
Disable predictable interface names (bsc#1230904)

### DIFF
--- a/framework/files/etc/elemental/bootargs.cfg
+++ b/framework/files/etc/elemental/bootargs.cfg
@@ -15,12 +15,12 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} rd.neednet=0 elemental.oemlabel=${oem_label} selinux=0"
+  set kernelcmd="console=tty1 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} rd.neednet=0 elemental.oemlabel=${oem_label} selinux=0 net.ifnames=0"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"
   fi
-  set kernelcmd="console=tty1 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} panic=5 rd.neednet=0 elemental.oemlabel=${oem_label} fsck.mode=force fsck.repair=yes selinux=1 enforcing=0"
+  set kernelcmd="console=tty1 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} panic=5 rd.neednet=0 elemental.oemlabel=${oem_label} fsck.mode=force fsck.repair=yes selinux=1 enforcing=0 net.ifnames=0"
 fi
 
 set initramfs=/boot/initrd


### PR DESCRIPTION
This commit adds the net.ifnames=0 kernel parameter to the OS images to prevent interface rename. With the new Micro 6 image, the kernel uses predicable interface naming convention, which causes a network interface rename when upgrading from older OS versions.

This change disables this new kernel feature and keeps the old behavior.

Fixes bsc#1230904