### PR TITLE
ci: don't check app after operator uninstallation

### DIFF
--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -445,7 +445,7 @@ jobs:
           OPERATOR_REPO: ${{ inputs.operator_repo }}
         # Don't test Operator uninstall if we want to keep the runner for debugging purposes
         if: ${{ inputs.destroy_runner == true && inputs.full_backup_restore == false }}
-        run: cd tests && make e2e-uninstall-operator && make e2e-check-app
+        run: cd tests && make e2e-uninstall-operator
 
       # This step must be called in each worklow that wants a summary!
       - name: Get logs and add summary


### PR DESCRIPTION
This will not work as the downstream cluster has been deleted. This test has been added by error in a previous commit.

Verification run:
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11014420477)