### PR TITLE
ci/cli: Add etcd snapshot for downstream clusters

### DIFF
--- a/tests/assets/cluster.yaml
+++ b/tests/assets/cluster.yaml
@@ -6,7 +6,9 @@ metadata:
 spec:
   rkeConfig:
     etcd:
-      disableSnapshots: true
+      disableSnapshots: false
+      snapshotRetention: 5
+      snapshotScheduleCron: 0 */5 * * *
     machineGlobalConfig:
       cni: canal
       disable:

--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -163,7 +163,7 @@ var _ = Describe("E2E - Test full Backup/Restore", Label("test-full-backup-resto
 			err := tools.Sed("%BACKUP_FILE%", backupFile, restoreYaml)
 			Expect(err).To(Not(HaveOccurred()))
 
-			// "prune" option should be set to true here
+			// "prune" option should be set to false in case of migration test
 			err = tools.Sed("%PRUNE%", "false", restoreYaml)
 			Expect(err).To(Not(HaveOccurred()))
 


### PR DESCRIPTION
This is needed to be able to run a migration test.

Verification run:
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/11404867262)