### PR TITLE
ci/airgap: fix test with Dev operator

### DIFF
--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,7 +43,11 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 		testCaseID = 38
 
 		By("Adding SeedImage", func() {
-			var baseImageURL string
+			var (
+				baseImageURL string
+				err          error
+				OSVersion    []byte
+			)
 
 			if selinux {
 				// For now SELinux images are only for testing purposes and not added to any channel, so we should force the value here
@@ -52,8 +57,10 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 				WaitForOSVersion(clusterNS)
 
 				// Get OSVersion name
-				OSVersion, err := exec.Command(getOSScript, os2Test, "true").Output()
-				Expect(err).To(Not(HaveOccurred()))
+				Eventually(func() error {
+					OSVersion, err = exec.Command(getOSScript, os2Test, "true").Output()
+					return err
+				}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(BeNil())
 				Expect(OSVersion).To(Not(BeEmpty()))
 
 				// Extract container image URL

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -386,10 +386,8 @@ func InstallElementalOperator(k *kubectl.Kubectl, order []string, repo string) {
 			"--wait", "--wait-for-jobs",
 		}
 
-		// TODO: maybe adding a dedicated variable for operator version instead?
-		// of using os2Test (this one should be kept for the OS image version)
-		// Variable operator_repo exists but does not exactly reflect operator's version
-		if strings.Contains(repo, "dev") {
+		// Dev and Staging versions need a specific treatment
+		if strings.Contains(repo, "/dev/") || strings.Contains(repo, "/staging/") {
 			flags = append(flags, "--devel")
 		}
 

--- a/tests/e2e/uninstall-operator_test.go
+++ b/tests/e2e/uninstall-operator_test.go
@@ -94,10 +94,8 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 				"--wait", "--wait-for-jobs",
 			}
 
-			// TODO: maybe adding a dedicated variable for operator version instead?
-			// of using os2Test (this one should be kept for the OS image version)
-			// Variable operator_repo exists but does not exactly reflect operator's version
-			if strings.Contains(os2Test, "dev") {
+			// Dev and Staging versions need a specific treatment
+			if strings.Contains(os2Test, "dev") || strings.Contains(os2Test, "staging") {
 				flags = append(flags, "--devel")
 			}
 
@@ -195,10 +193,8 @@ var _ = Describe("E2E - Uninstall Elemental Operator", Label("uninstall-operator
 					"--wait", "--wait-for-jobs",
 				}
 
-				// TODO: maybe adding a dedicated variable for operator version instead?
-				// of using os2Test (this one should be kept for the OS image version)
-				// Variable operator_repo exists but does not exactly reflect operator's version
-				if strings.Contains(os2Test, "dev") {
+				// Dev and Staging versions need a specific treatment
+				if strings.Contains(os2Test, "dev") || strings.Contains(os2Test, "staging") {
 					flags = append(flags, "--devel")
 				}
 

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -116,10 +116,13 @@ CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION#cert-manager-*}
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION%.*}
 
 # Get Rancher charts
-[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] && DEVEL="--devel"
-RunHelmCmdWithRetry pull rancher-${RANCHER_CHANNEL}/rancher ${DEVEL} > /dev/null 2>&1
+[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] && DEVEL="--devel" || unset DEVEL
+RunHelmCmdWithRetry pull ${DEVEL} rancher-${RANCHER_CHANNEL}/rancher > /dev/null 2>&1
+
+# Get Elemental charts
+[[ "${ELEMENTAL_REPO}" =~ (/dev/|/staging/) ]] && DEVEL="--devel" || unset DEVEL
 for i in elemental-operator-chart elemental-operator-crds-chart ; do
-  RunHelmCmdWithRetry pull ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1
+  RunHelmCmdWithRetry pull ${DEVEL} ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1
 done
 
 # Get Rancher Manager version

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -47,7 +47,7 @@ helm plugin install https://github.com/chartmuseum/helm-push.git
 helm repo add chartmuseum http://localhost:8080
 
 # Check if we want to use Development version of Elemental
-[[ "${OS2TEST}" =~ dev ]] && DEVEL="--devel"
+[[ "${OS2TEST}" =~ (dev|staging) ]] && DEVEL="--devel"
 
 # Download needed helm charts
 helm pull ${DEVEL} ${REPO}/elemental-operator-crds-chart


### PR DESCRIPTION
Should fix #1583. PR in operator repository should be merged first: https://github.com/rancher/elemental-operator/pull/853.

Verification run:
- [CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/11053175665)

**NOTE:** the test failed due to a SPOT on the GCP runner, but the VR is validated as the nodes were bootstrapped as expected.