### PR TITLE
ci: add better pod status check

### DIFF
--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -231,9 +231,7 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 				"--namespace", "cattle-elemental-system",
 				"--create-namespace",
 			}
-
 			RunHelmCmdWithRetry(flags...)
-			time.Sleep(20 * time.Second)
 
 			// Set flags for Elemental Operator installation
 			elementalChart, err := exec.Command("bash", "-c", "ls "+airgapRepo+"/helm/elemental-operator-chart-*.tgz").Output()

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -670,11 +670,6 @@ Wait for K3s to start
   - @returns Nothing, the function will fail through Ginkgo in case of issue
 */
 func WaitForK3s(k *kubectl.Kubectl) {
-	// Delay before checking
-	// TODO: create and use a function that checks the real Status
-	//       of the pod as well as the Ready field
-	time.Sleep(1 * time.Minute)
-
 	checkList := [][]string{
 		{"kube-system", "app=local-path-provisioner"},
 		{"kube-system", "k8s-app=kube-dns"},
@@ -694,11 +689,6 @@ Wait for RKE2 to start
 func WaitForRKE2(k *kubectl.Kubectl) {
 	err := os.Setenv("KUBECONFIG", "/etc/rancher/rke2/rke2.yaml")
 	Expect(err).To(Not(HaveOccurred()))
-
-	// Delay before checking
-	// TODO: create and use a function that checks the real Status
-	//       of the pod as well as the Ready field
-	time.Sleep(1 * time.Minute)
 
 	checkList := [][]string{
 		{"kube-system", "k8s-app=kube-dns"},

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -138,9 +138,6 @@ var _ = Describe("E2E - Upgrading Rancher Manager", Label("upgrade-rancher-manag
 			return rancher.CheckPod(k, checkList)
 		}, tools.SetTimeout(3*time.Minute), 10*time.Second).Should(Not(HaveOccurred()))
 
-		// A bit dirty be better to wait a little here for all to be correctly started
-		time.Sleep(2 * time.Minute)
-
 		// Check that all pods are using the same version
 		Eventually(func() int {
 			out, _ := kubectl.RunWithoutErr(getImageVersion...)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,7 +9,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240911133917-d4312809d5eb
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240926104948-8ac88aebed21
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/mod v0.21.0
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/pprof v0.0.0-20240910150728-a0b0bb1d4134 // indirect
+	github.com/google/pprof v0.0.0-20240925223930-fa3061bff0bc // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -101,8 +101,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20240910150728-a0b0bb1d4134 h1:c5FlPPgxOn7kJz3VoPLkQYQXGBS3EklQ4Zfi57uOuqQ=
-github.com/google/pprof v0.0.0-20240910150728-a0b0bb1d4134/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20240925223930-fa3061bff0bc h1:7bf8bGo4akhLJrmttkYLjxIz0yQmBi5umb+Nj1qRPpE=
+github.com/google/pprof v0.0.0-20240925223930-fa3061bff0bc/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -127,8 +127,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240911133917-d4312809d5eb h1:Q4XjVA19KEX/EFHzbsN+A0bsSac70MvAYDF2qJddF1I=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240911133917-d4312809d5eb/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240926104948-8ac88aebed21 h1:HiCx5MUE8Y3o9K+YV8fMPPbzqSm7r6klDQ8erJbIw9E=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240926104948-8ac88aebed21/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Try to check the real status pods instead of having to rely on `Sleep` call. PR in [ele-testhelpers](https://github.com/rancher-sandbox/ele-testhelpers/pull/60) should be merged first.

Verification run:
- [CLI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11035828002)
- [CLI-K3s-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11048795745)
- [UI-RKE2-OBS_Dev](https://github.com/rancher/elemental/actions/runs/11051057195)