### PR TITLE
ci/ui: fix upgrade cloud-config file

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -113,7 +113,7 @@ describe('Upgrade tests', () => {
         cy.getBySel('cluster-target').click();
         // As there is already an upgrade group targeting the cluster,
         // the cluster should not be available in the dropdown
-        cy.get('#vs3__listbox').should('not.contain', clusterName);
+        cy.get('#vs4__listbox').should('not.contain', clusterName);
     }));
 
     qase(37,

--- a/tests/cypress/latest/fixtures/custom_cloud-config_upgrade.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_upgrade.yaml
@@ -3,9 +3,34 @@ config:
     users:
     - name: root
       passwd: r0s@pwd1
+    write_files:
+      - path: /etc/ssh/sshd_config.d/root_access.conf
+        append: true
+        content: |
+          PermitRootLogin yes
+        owner: root:root
+        permissions: 644
   elemental:
     install:
       poweroff: true
-      device: /dev/sda
       debug: true
+      device-selector:
+      - key: Name
+        operator: In
+        values:
+          - /dev/sda
+          - /dev/vda
+          - /dev/nvme0n1
+      - key: Size
+        operator: Gt
+        values:
+          - 25Gi
+      snapshotter:
+        type: btrfs
+    reset:
+      debug: true
+      enabled: true
+      reset-persistent: true
+      reset-oem: true
+      power-off: true
 machineName: my-machine

--- a/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
+++ b/tests/cypress/latest/fixtures/custom_cloud-config_with_reset.yaml
@@ -4,7 +4,7 @@ config:
     - name: root
       passwd: r0s@pwd1
     write_files:
-      - path: /etc/ssh/sshd_config
+      - path: /etc/ssh/sshd_config.d/root_access.conf
         append: true
         content: |
           PermitRootLogin yes


### PR DESCRIPTION
Fix #1566 

As 1.6.4 is the new stable, cloud-config file has to be updated to match SLE Micro 6.

## Verification runs
[UI-K3S-Upgrade](https://github.com/rancher/elemental/actions/runs/11067332822/job/30750705560) ✅ 