### PR TITLE
ci/cli: fix 2.8-head test

### DIFF
--- a/.github/workflows/cli-rm-head-2.8-matrix.yaml
+++ b/.github/workflows/cli-rm-head-2.8-matrix.yaml
@@ -57,7 +57,7 @@ jobs:
             cluster_type: ""
             k8s_downstream_version: v1.28.13+k3s1
             k8s_upstream_version: v1.28.13+k3s1
-            rancher_version: latest/devel/2.7
+            rancher_version: latest/devel/2.8
             reset: true
             sequential: true
           - ca_type: private


### PR DESCRIPTION
An wrong version of Rancher Manager was set, e.g. 2.7 instead of 2.8.