### PR TITLE
ci/ui: name changed for os version in rke2 test

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -55,7 +55,7 @@ describe('Upgrade tests', () => {
       qase(33,
         it('Check OS Versions', () => {
           cy.clickNavMenu(['Advanced', 'OS Versions']);
-          cy.contains(new RegExp('Active.*-iso-unstable'), { timeout: 120000 });
+          cy.contains(new RegExp('Active.*-unstable-iso'), { timeout: 120000 });
       }));
     }
 


### PR DESCRIPTION
Fix this issue:
![image](https://github.com/user-attachments/assets/2474b9e5-f0b7-4d62-9716-206c034cd3b5)
