### PR TITLE
ci/ui: use rke2 as upstream cluster in rke2 tests

### DIFF
--- a/.github/workflows/ui-rke2-obs_dev.yaml
+++ b/.github/workflows/ui-rke2-obs_dev.yaml
@@ -16,6 +16,10 @@ on:
         description: Rancher cluster downstream version to use
         default: v1.30.4+rke2r1
         type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: v1.30.4+rke2r1
+        type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto

--- a/.github/workflows/ui-rke2-obs_staging.yaml
+++ b/.github/workflows/ui-rke2-obs_staging.yaml
@@ -16,6 +16,10 @@ on:
         description: Rancher cluster downstream version to use
         default: v1.30.4+rke2r1
         type: string
+      k8s_upstream_version:
+        description: Rancher cluster upstream version to use
+        default: v1.30.4+rke2r1
+        type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
         default: auto

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.28.13+k3s1"'
+        default: '"v1.28.13+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use


### PR DESCRIPTION
Some rke2 tests do not use rke2 cluster for the upstream cluster. Let's change it to be consistent.