### PR TITLE
ci/ui: remove useless dash in check_os_version

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -55,7 +55,7 @@ describe('Upgrade tests', () => {
       qase(33,
         it('Check OS Versions', () => {
           cy.clickNavMenu(['Advanced', 'OS Versions']);
-          cy.contains(new RegExp('Active.*-unstable-iso'), { timeout: 120000 });
+          cy.contains(new RegExp('Active.*unstable-iso'), { timeout: 120000 });
       }));
     }
 


### PR DESCRIPTION
Fix issue introduced by this PR https://github.com/rancher/elemental/pull/1599

## Verification run
https://github.com/rancher/elemental/actions/runs/11120278955