### PR TITLE
ci/ui: seed image can be iso or image

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import { isBootType } from '~/support/utils';
 
 filterTests(['main'], () => {
   Cypress.config();
@@ -40,7 +41,7 @@ filterTests(['main'], () => {
       cy.exec('rm -f cypress/downloads/*', { failOnNonZeroExit: false });
       cy.clickNavMenu(["Advanced", "Seed Images"]);
       cy.getBySel(selectors.sortableTableRow).contains('Download').click();
-      cy.verifyDownload('.iso', { contains: true, timeout: 300000, interval: 5000 });
+      cy.verifyDownload(isBootType('iso') ? '.iso' : '.img', { contains: true, timeout: 300000, interval: 5000 });
     });
   });
 });


### PR DESCRIPTION
Fix this [issue](https://github.com/rancher/elemental/actions/runs/11136927954/job/30949559740)

Format of the downloaded media depends of `boot_type` variable, it can be iso or img.

## Verification run
[UI-RKE2-Raw](https://github.com/rancher/elemental/actions/runs/11139676054) `seed_image.spec.ts`  is green ✅ 
[UI-K3S-Iso](https://github.com/rancher/elemental/actions/runs/11139680669) `seed_image.spec.ts`  is green ✅ 