### PR TITLE
ci/ui: use os_to_test in UI manual workflows

### DIFF
--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -56,6 +56,7 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
+      operator_install_type: ui
       operator_repo: ${{ inputs.operator_repo }}
       os_to_test: ${{ inputs.os_to_test }}
       qase_run_id: ${{ inputs.qase_run_id }}

--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -209,6 +209,7 @@ jobs:
           K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           OS_VERSION_INSTALL: ${{ inputs.os_version_install }}
+          OS_VERSION_TO_TEST: ${{ inputs.os_to_test }}
           RANCHER_CHANNEL: ${{ inputs.rancher_version }}
           RANCHER_GIT_CHART: ${{ inputs.rancher_git_chart }}
           RANCHER_VERSION: ${{ steps.component.outputs.rancher_image_version }}

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -50,6 +50,7 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
+      operator_install_type: ui
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -31,12 +31,13 @@ on:
         description: Elemental operator repository to use
         default: oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher
         type: string
+      os_to_test:
+        description: OS repository to test (dev/staging/stable)
+        type: string
+        default: dev
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
         default: elemental
-        type: string
-      qase_run_id:
-        description: Qase run ID where the results will be reported
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
@@ -57,8 +58,10 @@ jobs:
       elemental_ui_version: ${{ inputs.elemental_ui_version }}
       k8s_downstream_version: ${{ inputs.k8s_downstream_version }}
       k8s_upstream_version: ${{ inputs.k8s_upstream_version }}
+      operator_install_type: ui
       operator_repo: ${{ inputs.operator_repo }}
+      os_to_test: ${{ inputs.os_to_test }}
       proxy: ${{ inputs.proxy }}
-      qase_run_id: ${{ inputs.qase_run_id }}
+      qase_run_id: auto
       rancher_version: ${{ inputs.rancher_version }}
       test_type: ui

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -80,7 +80,7 @@ e2e-install-backup-restore: deps
 	ginkgo --label-filter install-backup-restore -r -v ./e2e
 
 e2e-install-chartmuseum:
-	sudo ./scripts/deploy-chartmuseum $(OPERATOR_REPO) $(OS_TO_TEST)
+	sudo ./scripts/deploy-chartmuseum $(OPERATOR_REPO)
 
 e2e-install-rancher: deps
 	ginkgo --label-filter install -r -v ./e2e

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
-import { isRancherManagerVersion, isUIVersion } from '../../support/utils';
+import { isRancherManagerVersion, isUIVersion , isOsVersion, isOperatorVersion} from '../../support/utils';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
@@ -72,5 +72,11 @@ filterTests(['main', 'upgrade'], () => {
           .and('contain', 'Uninstall');
       })
     );
+    it('Add additional channel', () => {
+      // Sometimes we want to test dev/staging operator version with stable OS version
+      if ( isOsVersion('stable') && isOperatorVersion('dev') || isOperatorVersion('staging')) {
+        cypressLib.accesMenu('OS Management');
+        cy.addOsVersionChannel('stable');
+      }});
   });
 });

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -42,6 +42,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.operator_repo = process.env.OPERATOR_REPO;
   config.env.os_version_install = process.env.OS_VERSION_INSTALL;
   config.env.os_version_target = process.env.OS_VERSION_TARGET;
+  config.env.os_version_to_test = process.env.OS_VERSION_TO_TEST;
   config.env.password = process.env.RANCHER_PASSWORD;
   config.env.proxy_ip = process.env.PROXY_IP;
   config.env.proxy = process.env.PROXY;

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -137,6 +137,9 @@ Cypress.Commands.add('createMachReg', (
       }
     } else if (utils.isOperatorVersion('registry.suse.com') || utils.isOperatorVersion('marketplace')) {
       cy.contains(Cypress.env('os_version_install')).click();
+    // Sometimes we want to test dev/staging operator version with stable OS version
+    } else if ( utils.isOsVersion('stable') && utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
+      cy.contains(Cypress.env('iso_stable_os_version')).click();
     } else {
       cy.contains('(unstable)').click();
     }
@@ -367,7 +370,7 @@ Cypress.Commands.add('addOsVersionChannel', (channelVersion: string) => {
 
   switch (channelVersion) {
     case "stable":
-      channelRepo = 'registry.suse.com/rancher/elemental-channel:latest';
+      channelRepo = 'registry.suse.com/rancher/elemental-channel/sl-micro:6.0-baremetal';
       break;
     case "dev":
       channelRepo = 'registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-unstable-channel:latest';

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -36,6 +36,11 @@ export const isOperatorVersion = (version: string) => {
   return (new RegExp(version)).test(Cypress.env("operator_repo"));
 }
 
+// Check OS version to test
+export const isOsVersion = (version: string) => {
+  return (new RegExp(version)).test(Cypress.env("os_version_to_test"));
+}
+
 // Check rancher manager version
 export const isRancherManagerVersion = (version: string) => {
   return (new RegExp(version)).test(Cypress.env("rancher_version"));

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -10,8 +10,6 @@ PATH+=:/usr/local/bin
 
 # Variables
 typeset REPO=$1
-shift
-typeset -l OS2TEST=$1
 
 # Create a systemctl file for chartmuseum
 cat > /etc/systemd/system/chartmuseum.service << EOF
@@ -47,7 +45,7 @@ helm plugin install https://github.com/chartmuseum/helm-push.git
 helm repo add chartmuseum http://localhost:8080
 
 # Check if we want to use Development version of Elemental
-[[ "${OS2TEST}" =~ (dev|staging) ]] && DEVEL="--devel"
+[[ "${REPO}" =~ (dev|staging) ]] && DEVEL="--devel"
 
 # Download needed helm charts
 helm pull ${DEVEL} ${REPO}/elemental-operator-crds-chart

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -54,6 +54,7 @@ docker run -v $PWD:/workdir -w /workdir                         \
     -e OPERATOR_REPO=$OPERATOR_REPO                             \
     -e OS_VERSION_INSTALL=$OS_VERSION_INSTALL                   \
     -e OS_VERSION_TARGET=$OS_VERSION_TARGET                     \
+    -e OS_VERSION_TO_TEST=$OS_VERSION_TO_TEST                   \
     -e PROXY=$PROXY                                             \
     -e QASE_API_TOKEN=$QASE_API_TOKEN                           \
     -e QASE_REPORT=$QASE_REPORT                                 \


### PR DESCRIPTION
Fix #1526 

With this PR, we can use stable OS version with dev/staging operator.

[UI-OBS-Manual_Workflow dev operator + stable OS](https://github.com/rancher/elemental/actions/runs/11177981321/job/31074729328) ✅ 
[UI-OBS-Manual_Workflow dev operator + dev OS](https://github.com/rancher/elemental/actions/runs/11180584044) ✅ 
[UI-K3S](https://github.com/rancher/elemental/actions/runs/11179944362) ✅ 
[UI-K3S-Upgrade](https://github.com/rancher/elemental/actions/runs/11231005935) ✅ 