### PR TITLE
ci: add time to live for GCP secrets

### DIFF
--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -272,7 +272,6 @@ jobs:
     uses: ./.github/workflows/sub_clean-and-delete-runner.yaml
     secrets:
       credentials: ${{ secrets.credentials }}
-      pat_token: ${{ secrets.pat_token }}
     with:
       create_runner_result: ${{ needs.create-runner.result }}
       destroy_runner: ${{ inputs.destroy_runner }}

--- a/.github/workflows/sub_clean-and-delete-runner.yaml
+++ b/.github/workflows/sub_clean-and-delete-runner.yaml
@@ -26,8 +26,6 @@ on:
     secrets:
       credentials:
         required: true
-      pat_token:
-        required: true
 
 jobs:
   clean-delete:
@@ -43,12 +41,6 @@ jobs:
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
-
-      - name: Delete GCP secrets
-        run: |
-          for SECRET in PAT_TOKEN GH_REPO; do
-            gcloud --quiet secrets delete ${SECRET}_${{ inputs.runner_label }} || true
-          done
 
       - name: Delete runner
         if: ${{ inputs.create_runner_result == 'success' && inputs.destroy_runner == true }}

--- a/.github/workflows/sub_create-runner.yaml
+++ b/.github/workflows/sub_create-runner.yaml
@@ -73,9 +73,9 @@ jobs:
       - name: Create GCP secrets
         run: |
           echo -n ${{ secrets.pat_token }} \
-            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.runner_label }} --data-file=-
+            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.runner_label }} --data-file=- --ttl="18000s" --quiet
           echo -n ${{ github.repository }} \
-            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.runner_label }} --data-file=-
+            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.runner_label }} --data-file=- --ttl="18000s" --quiet
 
       - name: Get public FQDN and DOMAIN
         id: dns


### PR DESCRIPTION
Sometimes GCP Secrets are not removed and it cost money. By adding a ttl to the secret, it is automatically deleted once expired.

![image](https://github.com/user-attachments/assets/17d2fedf-a981-42f6-91d9-827055a86328)

## Verification run
https://github.com/rancher/elemental/actions/runs/11177265348 ✅ 

