### PR TITLE
Add support to define CATTLE_AGENT_STRICT_VERIFY

### DIFF
--- a/framework/files/usr/lib/systemd/system/elemental-system-agent.service
+++ b/framework/files/usr/lib/systemd/system/elemental-system-agent.service
@@ -7,6 +7,7 @@ After=time-sync.target
 ConditionPathExists=!/run/elemental/live_mode
 
 [Service]
+EnvironmentFile=-/etc/rancher/elemental/agent/envs
 EnvironmentFile=-/etc/default/elemental
 EnvironmentFile=-/etc/sysconfig/proxy
 Type=simple


### PR DESCRIPTION
The strict verify setting can only be changed through the CATTLE_AGENT_STRICT_VERIFY environment variable.
For this reason I added a new "/etc/rancher/elemental/agent/envs" file for the purpose of configuring the `elemental-system-agent` only.