### PR TITLE
ci/cli: fix migration test with RKE2

### DIFF
--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.27.13+k3s1"'
+        default: '"v1.30.4+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -541,6 +541,11 @@ func StartRKE2() {
 	err = exec.Command("sudo", "systemctl", "enable", "--now", "rke2-server.service").Run()
 	Expect(err).To(Not(HaveOccurred()))
 
+	// Be sure that any previous kubectl command has been removed before linking the new one
+	err = exec.Command("sudo", "rm", "-f", "/usr/local/bin/kubectl").Run()
+	Expect(err).To(Not(HaveOccurred()))
+
+	// Create kubectl link
 	err = exec.Command("sudo", "ln", "-s", "/var/lib/rancher/rke2/bin/kubectl", "/usr/local/bin/kubectl").Run()
 	Expect(err).To(Not(HaveOccurred()))
 }


### PR DESCRIPTION
Should fix this issue: https://github.com/rancher/elemental/actions/runs/11203348112/job/31140513736.

Verification run:
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/11250174849) with RKE2