### PR TITLE
ci/ui: add operator_install_type in rancher 2.7

### DIFF
--- a/.github/workflows/ui-rm-head-2.7-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.7-matrix.yaml
@@ -58,6 +58,7 @@ jobs:
       elemental_ui_version: dev
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      operator_install_type: ui
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}


### PR DESCRIPTION
Rancher is installed twice, we have to disable cli installation using `operator_install_type: ui`

## Verification run
https://github.com/rancher/elemental/actions/runs/11269006412