### PR TITLE
ci: no need to run clean-delete if we want to keep the runner

### DIFF
--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -268,15 +268,12 @@ jobs:
 
   clean-and-delete-runner:
     needs: [create-runner, e2e]
-    if: ${{ always() }}
+    if: ${{ always() && needs.create-runner.result == 'success' && inputs.destroy_runner == true }}
     uses: ./.github/workflows/sub_clean-and-delete-runner.yaml
     secrets:
       credentials: ${{ secrets.credentials }}
     with:
-      create_runner_result: ${{ needs.create-runner.result }}
-      destroy_runner: ${{ inputs.destroy_runner }}
       runner_hostname: ${{ needs.create-runner.outputs.runner_hostname }}
-      runner_label: ${{ needs.create-runner.outputs.runner_label }}
       zone: ${{ inputs.zone }}
 
   post-qase:

--- a/.github/workflows/sub_clean-and-delete-runner.yaml
+++ b/.github/workflows/sub_clean-and-delete-runner.yaml
@@ -5,17 +5,7 @@ on:
   workflow_call:
     # Variables to set when calling this reusable workflow
     inputs:
-      create_runner_result:
-        description: Status of the create-runner job
-        required: true
-        type: string
-      destroy_runner:
-        required: true
-        type: boolean
       runner_hostname:
-        required: true
-        type: string
-      runner_label:
         required: true
         type: string
       zone:
@@ -43,7 +33,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Delete runner
-        if: ${{ inputs.create_runner_result == 'success' && inputs.destroy_runner == true }}
         run: |
           # Disable failure on first error, needed for the "delete" check
           set +e


### PR DESCRIPTION
Following PR #1615 it's not needed to run `clean-delete` if we want to keep the runner. This will save times and may reduce some cost at the same time.

Verification runs:
- [CLI-K3s-OBS_Dev with runner delete (default)](https://github.com/rancher/elemental/actions/runs/11406418231)
- [CLI-K3s-OBS_Dev with runner kept](https://github.com/rancher/elemental/actions/runs/11407647914)