### PR TITLE
ci/cli: fix regression test

### DIFF
--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.25.16+k3s4"'
+        default: '"v1.27.14+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.16+k3s1","v1.28.13+k3s1","v1.29.8+k3s1","v1.30.4+k3s1","v1.27.16+rke2r2","v1.28.13+rke2r1","v1.29.8+rke2r1","v1.30.4+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.27.14+k3s1","v1.28.13+k3s1","v1.29.8+k3s1","v1.30.4+k3s1","v1.27.16+rke2r2","v1.28.13+rke2r1","v1.29.8+rke2r1","v1.30.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:


### PR DESCRIPTION
Use v1.27.14+k3s1 instead of v1.27.16+k3s1 because of an issue with IPv6 forwarding.

Verification run:
- [CLI-Regression with 1.27.14](https://github.com/rancher/elemental/actions/runs/11455853410)