### PR TITLE
ci/cli: fix active_mode check in upgrade test

### DIFF
--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -51,5 +51,5 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: stable/latest
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/staging/containers/suse/sl-micro/6.0/baremetal-os-container:latest
+      upgrade_image: registry.suse.com/suse/sl-micro/6.0/baremetal-os-container:latest
       zone: us-central1-b

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -350,7 +350,7 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 						// This remove the version and keep only the repo, as in the file
 						// we have the exact version and we don't know it before the upgrade
 						return tools.TrimStringFromChar(strings.Trim(out, "\n"), ":")
-					}, tools.SetTimeout(5*time.Minute), 30*time.Second).Should(Equal(valueToCheck))
+					}, tools.SetTimeout(10*time.Minute), 30*time.Second).Should(Equal(valueToCheck))
 				})
 
 				By("Getting annotations for "+h+" after upgrade", func() {

--- a/tests/e2e/upgrade_test.go
+++ b/tests/e2e/upgrade_test.go
@@ -378,14 +378,14 @@ var _ = Describe("E2E - Upgrading node", Label("upgrade-node"), func() {
 						_ = RunSSHWithRetry(cl, "setsid -f reboot")
 
 						// Check the mode after reboot
-						out = RunSSHWithRetry(cl, "cat /run/cos/recovery_mode")
+						out = RunSSHWithRetry(cl, "cat /run/elemental/recovery_mode")
 						Expect(out).To(Not(BeEmpty()))
 
 						// Final reboot, in active mode as recovery mode is not persistent
 						_ = RunSSHWithRetry(cl, "setsid -f reboot")
 
 						// Check the mode after fnal reboot
-						out = RunSSHWithRetry(cl, "cat /run/cos/active_mode")
+						out = RunSSHWithRetry(cl, "cat /run/elemental/active_mode")
 						Expect(out).To(Not(BeEmpty()))
 					})
 				}


### PR DESCRIPTION
This should fix this kind of issue: https://github.com/rancher/elemental/actions/runs/11426988378/job/31790635597.

Verification run:
- [CLI-K3s-Downgrade](https://github.com/rancher/elemental/actions/runs/11459283225)