### PR TITLE
ci/cli: test operator upgrade after restore

### DIFF
--- a/tests/e2e/backup-restore_test.go
+++ b/tests/e2e/backup-restore_test.go
@@ -192,6 +192,11 @@ var _ = Describe("E2E - Test full Backup/Restore", Label("test-full-backup-resto
 			InstallRancher(k)
 		})
 
+		By("Upgrading/re-installing Elemental Operator", func() {
+			installOrder := []string{"elemental-operator-crds", "elemental-operator"}
+			InstallElementalOperator(k, installOrder, operatorRepo)
+		})
+
 		By("Checking cluster state after restore", func() {
 			WaitCluster(clusterNS, clusterName)
 		})


### PR DESCRIPTION
Should fix #1586.

Verification run:
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/11798543473)

Sounds good:
![Screenshot from 2024-11-12 15-22-00](https://github.com/user-attachments/assets/1a31429c-42e0-4b29-a034-2770baeb7d50)