### PR TITLE
ci/cli: add tests on Rancher Manager v2.10

### DIFF
--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1","v1.30.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1","v1.30.4+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.9","latest/devel/2.10"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/2.9","latest/devel/2.10"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+k3s1"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.10"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.9"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.9","latest/devel/2.10"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
         include:

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.13+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.28.13+rke2r1"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.8"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"latest/devel/2.10"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,7 +9,7 @@ replace go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-2023111420
 require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240930072321-44f66a46e109
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241112093046-812bbbbdb8e3
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/mod v0.21.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -129,6 +129,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240930072321-44f66a46e109 h1:Czoy0MxvKD12RfXQdyZukHWHedUP1l1EGm1ZU2xgpac=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240930072321-44f66a46e109/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241112093046-812bbbbdb8e3 h1:wB7yRkOqvwtNpn3em1hz+/S/Y4c1m++GoicsROj5CY0=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241112093046-812bbbbdb8e3/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Verification runs:
- [CLI-K3s](https://github.com/rancher/elemental/actions/runs/11814129914)
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/11814148710)
- [CLI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/11813060696)
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/11813181898)
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/11812893888)

**NOTE:** the `CLI-RKE2-Upgrade` VR failed for a sporadic issue not related to that PR, the upgrade to Rancher Manager v2.10 was done as expected.