### PR TITLE
ci/ui: remove config file download btn workaround

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -163,13 +163,9 @@ Cypress.Commands.add('createMachReg', (
   }
 
   // Try to download the registration file and check it
-  // The button is broken in rancher 2.10, bug opened here
-  // https://github.com/rancher/elemental-ui/issues/229
-  if (!utils.isRancherManagerVersion('2.10')) {
-    cy.getBySel(selectors.downloadBtn).click();
-    cy.verifyDownload(`${machRegName}_registrationURL.yaml`);
-    cy.contains('Saving').should('not.exist');
-  }
+  cy.getBySel(selectors.downloadBtn).click();
+  cy.verifyDownload(`${machRegName}_registrationURL.yaml`);
+  cy.contains('Saving').should('not.exist');
 
   // Check Cloud configuration
   if (checkDefaultCloudConfig) {


### PR DESCRIPTION
As my bug got fixed (https://github.com/rancher/elemental-ui/issues/229), this workaround can be safely removed from the code.
Tested manually with rancher `2.10` and elemental-ui `3.0.0-rc3`.

## Verification run
[UI-K3S-Rancher_2.10](https://github.com/rancher/elemental/actions/runs/12032443065) ✅ 