### PR TITLE
ci/ui: fix 2.8 UI weekly test

### DIFF
--- a/.github/workflows/ui-rm-head-2.8-matrix.yaml
+++ b/.github/workflows/ui-rm-head-2.8-matrix.yaml
@@ -58,6 +58,7 @@ jobs:
       elemental_ui_version: dev
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
+      operator_install_type: ui
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -62,6 +62,12 @@ filterTests(['main', 'upgrade'], () => {
         cy.get('.plugin')
           .contains('Install')
           .click();
+        if (isRancherManagerVersion('2.8')) {
+          cy.getBySel('install-ext-modal-select-version')
+            .click();
+          cy.contains('1.3.1')
+            .click();
+        }
         cy.clickButton('Install');
         cy.contains('Installing');
         cy.contains('Extensions changed - reload required', { timeout: 40000 });


### PR DESCRIPTION
There is also an issue with Elemental UI version, we have to force 1.3 version because otherwise, it installs 2.0 and it will not work.

## Verification run
[UI-Rancher-Manager-Head-2.8](https://github.com/rancher/elemental/actions/runs/12156212343) ✅ 