### PR TITLE
ci/airgap: fix test with Devel version of Rancher Manager

### DIFF
--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -156,6 +156,11 @@ if $(grep -iq 'not found' ${RANCHER_IMAGES_FILE}) || [[ ! -s ${RANCHER_IMAGES_FI
   error "ERROR: file ${RANCHER_IMAGES_FILE} is empty or not found!"
 fi
 
+# Fleet should be present in the file, otherwise no need to go further!
+if ! $(grep -iq 'fleet' ${RANCHER_IMAGES_FILE}); then
+  error "ERROR: fleet is not found in file ${RANCHER_IMAGES_FILE}!"
+fi
+
 # CertManager image list
 CERT_IMAGES_FILE=cert-manager-images.txt
 RunHelmCmdWithRetry template ${OPT_RANCHER}/helm/cert-manager-${CERT_MANAGER_VERSION}.tgz \

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -2,7 +2,13 @@
 
 # Build Airgap
 
-set -x
+set -vx
+
+# Error function
+function error() {
+  echo -e "$@" >&2
+  exit 1
+}
 
 # Retry helm command in case of sporadic issue
 function RunHelmCmdWithRetry() {
@@ -144,6 +150,11 @@ cd ${OPT_RANCHER}/images/
 RANCHER_REPO=https://github.com/rancher/rancher/releases/download/v${RANCHER_MANAGER_VERSION}
 RANCHER_IMAGES_FILE=rancher-images.txt
 curl -sOL ${RANCHER_REPO}/${RANCHER_IMAGES_FILE}
+
+# Rancher image file should not be empty
+if $(grep -iq 'not found' ${RANCHER_IMAGES_FILE}) || [[ ! -s ${RANCHER_IMAGES_FILE} ]]; then
+  error "ERROR: file ${RANCHER_IMAGES_FILE} is empty or not found!"
+fi
 
 # CertManager image list
 CERT_IMAGES_FILE=cert-manager-images.txt

--- a/tests/scripts/config-hardened
+++ b/tests/scripts/config-hardened
@@ -3,7 +3,7 @@
 # This script configures all we need to configure k3s / rke2 hardened cluster
 # Instructions from https://docs.k3s.io/security/hardening-guide and https://docs.rke2.io/security/hardening_guide
 
-set -e -x
+set -evx
 
 # Variables
 K3S_SERVER_DIR="/var/lib/rancher/k3s/server"

--- a/tests/scripts/config-private-ca
+++ b/tests/scripts/config-private-ca
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e -x
+set -evx
 
 # Variable(s)
 EMAIL=elemental@suse.de

--- a/tests/scripts/deploy-airgap
+++ b/tests/scripts/deploy-airgap
@@ -2,7 +2,7 @@
 
 # Deploy Airgap
 
-set -x
+set -vx
 
 # Retry skopeo command in case of sporadic issue
 function RunSkopeoCmdWithRetry() {

--- a/tests/scripts/deploy-chartmuseum
+++ b/tests/scripts/deploy-chartmuseum
@@ -3,7 +3,7 @@
 # This script deploys a local helm repo to host the dev operator chart
 # because it is not exported anywhere else.
 
-set -e -x
+set -evx
 
 # Add missing PATH, removed in recent distributions for security reasons...
 PATH+=:/usr/local/bin

--- a/tests/scripts/get-boot-files-for-pxe
+++ b/tests/scripts/get-boot-files-for-pxe
@@ -2,7 +2,7 @@
 
 # This script extracts the kernel and initrd files from an ISO image
 
-set -e -x
+set -evx
 
 # Cleaning function
 function clean_and_exit() {

--- a/tests/scripts/get-name-from-managedosversion
+++ b/tests/scripts/get-name-from-managedosversion
@@ -2,7 +2,7 @@
 
 # This script returns the OS version/channel name from ManagedOSVersion
 
-set -e -x
+set -evx
 
 # Variables
 typeset -l KIND_OF_OS=$1

--- a/tests/scripts/install-vm
+++ b/tests/scripts/install-vm
@@ -2,6 +2,12 @@
 
 set -evx
 
+# Error function
+function error() {
+  echo -e "$@" >&2
+  exit 1
+}
+
 # Variable(s) and default values
 ARCH=$(uname -m)
 EMULATED_TPM="none"
@@ -49,8 +55,7 @@ if [[ ${BOOT_TYPE} == "iso" ]]; then
 
   # Exit if ISO is not available
   [[ ! -f ${ISO} ]] \
-    && echo "File ${ISO} not found! Exiting!" >&2 \
-    && exit 1
+    && error "File ${ISO} not found! Exiting!"
 
   # Soft-link the ISO to avoid "Could not define storage pool" error
   ln -s ${ISO} ${VM_NAME}/
@@ -66,8 +71,7 @@ elif [[ ${BOOT_TYPE} == "raw" ]]; then
 
   # Exit if RAW is not available
   [[ ! -f ${RAW_IMAGE} ]] \
-    && echo "File ${RAW_IMAGE} not found! Exiting!" >&2 \
-    && exit 1  
+    && error "File ${RAW_IMAGE} not found! Exiting!"
   
   # Duplicate the raw image depending on nodes number
   cp ${RAW_IMAGE} ${VM_NAME}/${VM_NAME}.img
@@ -83,8 +87,7 @@ else
     # Exit if binary is not available
     IPXE_BIN=$(realpath ../assets/ipxe-${ARCH}.efi)
     [[ ! -f ${IPXE_BIN} ]] \
-      && echo "File ${IPXE_BIN} not found! Exiting!" >&2 \
-      && exit 1
+      && error "File ${IPXE_BIN} not found! Exiting!"
 
     # Force remove, to avoid issue with 'ln'
     # Only useful if an EFI file exists and it's not a symlink


### PR DESCRIPTION
Verification runs:
- [CLI-K3s-Airgap with Stable and Devel version of Rancher Manager](https://github.com/rancher/elemental/actions/runs/12238352554) :white_check_mark:

**NOTE:** the test on Rncher Manager Alpha version is failing as expected (some dependencies are missing in the `rancher-images.txt` file).