### PR TITLE
ci/ui: add checksum file check to cypress tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import { isBootType } from '~/support/utils';
+import { isBootType, isRancherManagerVersion, isUIVersion } from '~/support/utils';
 
 filterTests(['main'], () => {
   Cypress.config();
@@ -41,7 +41,21 @@ filterTests(['main'], () => {
       cy.exec('rm -f cypress/downloads/*', { failOnNonZeroExit: false });
       cy.clickNavMenu(["Advanced", "Seed Images"]);
       cy.getBySel(selectors.sortableTableRow).contains('Download').click();
-      cy.verifyDownload(isBootType('iso') ? '.iso' : '.img', { contains: true, timeout: 300000, interval: 5000 });
+      if (isBootType('iso')) {
+        cy.verifyDownload('.iso', { contains: true, timeout: 300000, interval: 5000 });
+      } else {
+        // .img will be removed in next elemental UI, only .raw will be available
+        let extension = 'img';
+        isRancherManagerVersion('2.10') ? extension = 'raw' : null;
+        cy.verifyDownload('.'+extension, { contains: true, timeout: 300000, interval: 5000 });
+      }
+      // The following line will replace the confition just above very soon
+      //cy.verifyDownload(isBootType('iso') ? '.iso' : '.raw', { contains: true, timeout: 300000, interval: 5000 });
+          // Check we can download the checksum file (only in dev UI for now)
+      if (isUIVersion('dev')) {
+        cy.getBySel('download-checksum-btn-list').click();
+        cy.verifyDownload('.sh256', { contains: true, timeout: 60000, interval: 5000 });
+      }
     });
   });
 });

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -156,9 +156,18 @@ Cypress.Commands.add('createMachReg', (
     // and RAW feature is not already available in stable
     // upgrade condition will be removed in next elemental stable version
     if (utils.isBootType('raw') && !utils.isCypressTag('upgrade')) {
-      cy.verifyDownload('.img', { contains: true, timeout: 300000, interval: 5000 });
+      // .img will be removed in next elemental UI, only .raw will be available
+      let extension = 'img';
+      utils.isRancherManagerVersion('2.10') ? extension = 'raw' : null;
+      cy.verifyDownload('.'+extension, { contains: true, timeout: 300000, interval: 5000 });
     } else {
       cy.verifyDownload('.iso', { contains: true, timeout: 300000, interval: 5000 });
+    }
+
+    // Check we can download the checksum file (only in dev UI for now)
+    if (utils.isUIVersion('dev')) {
+      cy.getBySel('download-checksum-btn').click();
+      cy.verifyDownload('.sh256', { contains: true, timeout: 60000, interval: 5000 });
     }
   }
 

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -79,7 +79,7 @@ docker run -v $PWD:/workdir -w /workdir                         \
 
 if [[ ! -f ${ELEMENTAL_MEDIA_PATH} ]]; then
   # Move elemental image into the expected folder
-  for EXT in iso img; do
+  for EXT in iso img raw; do
     mv downloads/*.${EXT} ${ELEMENTAL_MEDIA_PATH} 2>/dev/null || true
   done
 fi


### PR DESCRIPTION
Fix #1661 

Add download checksum test only for ui 3.0 because we are waiting on some backport to 2.0 and 1.3
And for the raw image media, the extension is now `.raw` instead of  `.img`

## Verification run
https://github.com/rancher/elemental/actions/runs/12278594352 ✅ 