### PR TITLE
ci/airgap: allow to use specific version of Rancher

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.30.4+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.30.4+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","alpha"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/tests/e2e/airgap_test.go
+++ b/tests/e2e/airgap_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,10 +34,13 @@ var _ = Describe("E2E - Build the airgap archive", Label("prepare-archive"), fun
 		if certManagerVersion == "" {
 			certManagerVersion = "latest"
 		}
+		if rancherVersion == "" {
+			rancherVersion = "latest"
+		}
 
 		// Could be useful for manual debugging!
-		GinkgoWriter.Printf("Executed command: %s %s %s %s %s %s\n", airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sDownstreamVersion, operatorRepo)
-		out, err := exec.Command(airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, k8sDownstreamVersion, operatorRepo).CombinedOutput()
+		GinkgoWriter.Printf("Executed command: %s %s %s %s %s %s %s\n", airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, rancherVersion, k8sDownstreamVersion, operatorRepo)
+		out, err := exec.Command(airgapBuildScript, k8sUpstreamVersion, certManagerVersion, rancherChannel, rancherVersion, k8sDownstreamVersion, operatorRepo).CombinedOutput()
 		Expect(err).To(Not(HaveOccurred()), string(out))
 	})
 })
@@ -194,7 +198,7 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 
 			// Set flags for Rancher Manager installation
 			flags := []string{
-				"upgrade", "--install", "rancher", string(rancherManagerChart),
+				"upgrade", "--install", "rancher", strings.TrimSpace(string(rancherManagerChart)),
 				"--namespace", "cattle-system",
 				"--create-namespace",
 				"--set", "hostname=" + rancherManager,

--- a/tests/e2e/seedImage_test.go
+++ b/tests/e2e/seedImage_test.go
@@ -57,11 +57,10 @@ var _ = Describe("E2E - Creating ISO image", Label("iso-image"), func() {
 				WaitForOSVersion(clusterNS)
 
 				// Get OSVersion name
-				Eventually(func() error {
-					OSVersion, err = exec.Command(getOSScript, os2Test, "true").Output()
-					return err
-				}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(BeNil())
-				Expect(OSVersion).To(Not(BeEmpty()))
+				Eventually(func() string {
+					OSVersion, _ = exec.Command(getOSScript, os2Test, "true").Output()
+					return string(OSVersion)
+				}, tools.SetTimeout(2*time.Minute), 30*time.Second).Should(Not(BeEmpty()))
 
 				// Extract container image URL
 				baseImageURL, err = elemental.GetImageURI(clusterNS, string(OSVersion))

--- a/tests/scripts/build-airgap
+++ b/tests/scripts/build-airgap
@@ -56,8 +56,9 @@ function RunSkopeoCmdWithRetry() {
 K3S_UPSTREAM_VERSION=$1
 CERT_MANAGER_VERSION=$2
 RANCHER_CHANNEL=$3
-K3S_DOWNSTREAM_VERSION=$4
-ELEMENTAL_REPO=$5
+RANCHER_VERSION=$4
+K3S_DOWNSTREAM_VERSION=$5
+ELEMENTAL_REPO=$6
 DEPLOY_AIRGAP_SCRIPT=$(realpath ../scripts/deploy-airgap)
 OPT_RANCHER="${HOME}/airgap_rancher"
 REPO_SERVER="rancher-manager.test:5000"
@@ -107,14 +108,37 @@ done
 # Get Helm Charts
 cd ${OPT_RANCHER}/helm/
 
+# Define Rancher Manager repos depending of the needed version
+case ${RANCHER_CHANNEL} in
+  prime)
+    RANCHER_CHART_REPO="https://charts.rancher.com/server-charts/prime"
+    ;;
+  prime-optimus)
+    RANCHER_CHART_REPO="https://charts.optimus.rancher.io/server-charts/latest"
+    ;;
+  prime-optimus-alpha)
+    RANCHER_CHART_REPO="https://charts.optimus.rancher.io/server-charts/alpha"
+    RANCHER_IMAGES_REPO="stgregistry.suse.com"
+    ;;
+  alpha|latest|stable)
+    RANCHER_CHART_REPO="https://releases.rancher.com/server-charts/${RANCHER_CHANNEL}"
+    RANCHER_IMAGES_REPO="stgregistry.suse.com"
+    ;;
+  *)
+    error "Rancher channel '${RANCHER_CHANNEL}' unknown!"
+    ;;
+esac
+
 # Add repos
 RunHelmCmdWithRetry repo add jetstack https://charts.jetstack.io > /dev/null 2>&1
-RunHelmCmdWithRetry repo add rancher-${RANCHER_CHANNEL} https://releases.rancher.com/server-charts/${RANCHER_CHANNEL} > /dev/null 2>&1
+RunHelmCmdWithRetry repo add rancher-${RANCHER_CHANNEL} ${RANCHER_CHART_REPO} > /dev/null 2>&1
 RunHelmCmdWithRetry repo update > /dev/null 2>&1
 
 # Get CertManager charts
-[[ "${CERT_MANAGER_VERSION}" != "latest" ]] && VER_OPT="--version ${CERT_MANAGER_VERSION}"
-RunHelmCmdWithRetry pull jetstack/cert-manager ${VER_OPT} > /dev/null 2>&1
+[[ "${CERT_MANAGER_VERSION}" == "latest" ]] \
+  && unset VER_OPT \
+  || VER_OPT="--version ${CERT_MANAGER_VERSION}"
+RunHelmCmdWithRetry pull ${VER_OPT} jetstack/cert-manager > /dev/null 2>&1
 
 # Get CertManager version
 CERT_MANAGER_VERSION=$(ls cert-manager-*.tgz 2>/dev/null)
@@ -122,19 +146,28 @@ CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION#cert-manager-*}
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION%.*}
 
 # Get Rancher charts
-[[ "${RANCHER_CHANNEL}" =~ (latest|alpha) ]] && DEVEL="--devel" || unset DEVEL
-RunHelmCmdWithRetry pull ${DEVEL} rancher-${RANCHER_CHANNEL}/rancher > /dev/null 2>&1
+[[ "${RANCHER_CHANNEL}" =~ (alpha|latest|optimus) ]] \
+  && DEVEL="--devel" \
+  || unset DEVEL
+[[ "${RANCHER_VERSION}" == "latest" ]] \
+  && unset VER_OPT \
+  || VER_OPT="--version ${RANCHER_VERSION}"
+RunHelmCmdWithRetry pull ${DEVEL} ${VER_OPT} rancher-${RANCHER_CHANNEL}/rancher > /dev/null 2>&1
 
 # Get Elemental charts
-[[ "${ELEMENTAL_REPO}" =~ (/dev/|/staging/) ]] && DEVEL="--devel" || unset DEVEL
+[[ "${ELEMENTAL_REPO}" =~ (/dev/|/staging/) ]] \
+  && DEVEL="--devel" \
+  || unset DEVEL
 for i in elemental-operator-chart elemental-operator-crds-chart ; do
   RunHelmCmdWithRetry pull ${DEVEL} ${ELEMENTAL_REPO}/${i} > /dev/null 2>&1
 done
 
-# Get Rancher Manager version
-RANCHER_MANAGER_VERSION=$(ls rancher-*.tgz 2>/dev/null)
-RANCHER_MANAGER_VERSION=${RANCHER_MANAGER_VERSION#rancher-*}
-RANCHER_MANAGER_VERSION=${RANCHER_MANAGER_VERSION%.*}
+# Get Rancher Manager version if not already set
+if [[ -z "${RANCHER_VERSION}" || "${RANCHER_VERSION}" == "latest" ]]; then
+  RANCHER_VERSION=$(ls rancher-*.tgz 2>/dev/null)
+  RANCHER_VERSION=${RANCHER_VERSION#rancher-*}
+  RANCHER_VERSION=${RANCHER_VERSION%.*}
+fi
 
 # Get the Elemental repositories
 ELEMENTAL_AIRGAP_REPO=https://raw.githubusercontent.com/rancher/elemental-operator/main/scripts
@@ -147,7 +180,9 @@ rm -f ${ELEMENTAL_AIRGAP_SCRIPT}
 cd ${OPT_RANCHER}/images/
 
 # Rancher image list
-RANCHER_REPO=https://github.com/rancher/rancher/releases/download/v${RANCHER_MANAGER_VERSION}
+[[ "${RANCHER_CHANNEL}" =~ prime ]] \
+  && RANCHER_REPO=https://prime.ribs.rancher.io/rancher/v${RANCHER_VERSION} \
+  || RANCHER_REPO=https://github.com/rancher/rancher/releases/download/v${RANCHER_VERSION}
 RANCHER_IMAGES_FILE=rancher-images.txt
 curl -sOL ${RANCHER_REPO}/${RANCHER_IMAGES_FILE}
 
@@ -175,7 +210,14 @@ mv -f ${OPT_RANCHER}/helm/${ELEMENTAL_IMAGES_FILE} .
 loop=0
 for i in $(< ${CERT_IMAGES_FILE}) $(< ${ELEMENTAL_IMAGES_FILE}) $(< ${RANCHER_IMAGES_FILE}); do
   mkdir -p ${i%/*}
-  RunSkopeoCmdWithRetry copy docker://${i} docker-archive:${i/:/_}.tar:${i} &
+
+  # Devel/Staging versions of Rancher are hosted in a specific registry
+  [[ "${i}" =~ (rancher/rancher-agent:|rancher/rancher:) && -n "${RANCHER_IMAGES_REPO}" ]] \
+    && j="${RANCHER_IMAGES_REPO}/${i}" \
+    || j="${i}"
+
+  # Copy images
+  RunSkopeoCmdWithRetry copy docker://${j} docker-archive:${i/:/_}.tar:${i} &
 
   # Wait for skopeo jobs to finish if we already have too much jobs in parallel
   # This is to avoid the "too many requests to registry" error!


### PR DESCRIPTION
This is can be useful to validate specific versions of Rancher Manager in Airgap environment.

Verification run:
- [CLI-K3s-Airgap with `prime-optimus-alpha/2.9.5-alpha1`](https://github.com/rancher/elemental/actions/runs/12353731558) :white_check_mark:
- [CLI-K3s-Airgap with `prime-optimus-alpha/2.8.11-alpha1`](https://github.com/rancher/elemental/actions/runs/12359586873) :white_check_mark:
- [CLI-K3s-Airgap with `alpha/2.10.1-alpha1`](https://github.com/rancher/elemental/actions/runs/12294856794) :white_check_mark:
- [CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/12297817131) :white_check_mark: