### PR TITLE
ci/cli: re-add operator uninstallation in full backup test

### DIFF
--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -448,7 +448,7 @@ jobs:
         env:
           OPERATOR_REPO: ${{ inputs.operator_repo }}
         # Don't test Operator uninstall if we want to keep the runner for debugging purposes
-        if: ${{ inputs.destroy_runner == true && inputs.full_backup_restore == false }}
+        if: ${{ inputs.destroy_runner == true }}
         run: cd tests && make e2e-uninstall-operator
 
       # This step must be called in each worklow that wants a summary!


### PR DESCRIPTION
As rancher/elemental-operator#881 as been fixed, the test can be re-added.

Verification run:
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/12275038625)