### PR TITLE
ci/ui: checksum test only for rancher 2.10

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import '~/support/commands';
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import { isBootType, isRancherManagerVersion, isUIVersion } from '~/support/utils';
+import * as utils from "~/support/utils";
 
 filterTests(['main'], () => {
   Cypress.config();
@@ -41,18 +41,18 @@ filterTests(['main'], () => {
       cy.exec('rm -f cypress/downloads/*', { failOnNonZeroExit: false });
       cy.clickNavMenu(["Advanced", "Seed Images"]);
       cy.getBySel(selectors.sortableTableRow).contains('Download').click();
-      if (isBootType('iso')) {
+      if (utils.isBootType('iso')) {
         cy.verifyDownload('.iso', { contains: true, timeout: 300000, interval: 5000 });
       } else {
-        // .img will be removed in next elemental UI, only .raw will be available
+        // .img still needed for rancher 2.8
         let extension = 'img';
-        isRancherManagerVersion('2.10') ? extension = 'raw' : null;
+        !utils.isRancherManagerVersion('2.8') ? extension = 'raw' : null;
         cy.verifyDownload('.'+extension, { contains: true, timeout: 300000, interval: 5000 });
       }
-      // The following line will replace the confition just above very soon
+      // The following line will replace the confition just above when we will remove 2.8 tests
       //cy.verifyDownload(isBootType('iso') ? '.iso' : '.raw', { contains: true, timeout: 300000, interval: 5000 });
-          // Check we can download the checksum file (only in dev UI for now)
-      if (isUIVersion('dev')) {
+      // Check we can download the checksum file (only in dev UI for Rancher 2.9 / 2.10)
+      if (!utils.isRancherManagerVersion('2.8') && utils.isUIVersion('dev')) {
         cy.getBySel('download-checksum-btn-list').click();
         cy.verifyDownload('.sh256', { contains: true, timeout: 60000, interval: 5000 });
       }

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -152,20 +152,17 @@ Cypress.Commands.add('createMachReg', (
     cy.getBySel(selectors.downloadMediaBtn, { timeout: 600000 }).should('not.have.attr', 'disabled');
     cy.getBySel(selectors.downloadMediaBtn).click();
 
-    // RAW image not available in upgrade scenario because we start from stable
-    // and RAW feature is not already available in stable
-    // upgrade condition will be removed in next elemental stable version
-    if (utils.isBootType('raw') && !utils.isCypressTag('upgrade')) {
+    if (utils.isBootType('raw')) {
       // .img will be removed in next elemental UI, only .raw will be available
       let extension = 'img';
-      utils.isRancherManagerVersion('2.10') ? extension = 'raw' : null;
+      !utils.isRancherManagerVersion('2.8') ? extension = 'raw' : null;
       cy.verifyDownload('.'+extension, { contains: true, timeout: 300000, interval: 5000 });
     } else {
       cy.verifyDownload('.iso', { contains: true, timeout: 300000, interval: 5000 });
     }
 
-    // Check we can download the checksum file (only in dev UI for now)
-    if (utils.isUIVersion('dev')) {
+    // Check we can download the checksum file (only in dev UI for Rancher 2.9 / 2.10)
+    if (!utils.isRancherManagerVersion('2.8') && utils.isUIVersion('dev')) {
       cy.getBySel('download-checksum-btn').click();
       cy.verifyDownload('.sh256', { contains: true, timeout: 60000, interval: 5000 });
     }


### PR DESCRIPTION
Checksum feature only in elemental UI 3.0.1-rc, waiting for a backport in the previous versions.

Fix CI issue https://github.com/rancher/elemental/actions/runs/12288687097/job/34292956776

## Verification run
[RKE2-UI-2.9.4](https://github.com/rancher/elemental/actions/runs/12297313143) ✅ 
[RKE2-Upgrade-2.9.4](https://github.com/rancher/elemental/actions/runs/12297317681/job/34318299875) ✅ 