### PR TITLE
ci/cli: add support to test specific OS channel

### DIFF
--- a/.github/workflows/master_e2e.yaml
+++ b/.github/workflows/master_e2e.yaml
@@ -9,8 +9,8 @@ on:
         description: Version of backup-restore-operator to use
         type: string
       boot_type:
-        description: Choose booting type (pxe, iso, raw) 
-        default: pxe 
+        description: Choose booting type (pxe, iso, raw)
+        default: pxe
         type: string
       ca_type:
         description: CA type to use (selfsigned or private)

--- a/tests/assets/osChannel.yaml
+++ b/tests/assets/osChannel.yaml
@@ -1,0 +1,11 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: os-channel-to-test
+  # namespace: fleet-default
+spec:
+  deleteNoLongerInSyncVersions: true
+  options:
+    image: %OS_CHANNEL%
+  syncInterval: 1h
+  type: custom

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -49,6 +49,7 @@ const (
 	localStorageYaml      = "../assets/local-storage.yaml"
 	metallbRscYaml        = "../assets/metallb_rsc.yaml"
 	numberOfNodesMax      = 30
+	osChannelYaml         = "../assets/osChannel.yaml"
 	resetMachineInv       = "../assets/reset_machine_inventory.yaml"
 	restoreYaml           = "../assets/restore.yaml"
 	sshConfigFile         = "../assets/ssh_config"


### PR DESCRIPTION
Allows to test a specific OS channel.

Verification run:
- [CLI-OBS-Manual-Workflow](https://github.com/rancher/elemental/actions/runs/13237035037)