### PR TITLE
ci/ui: make code compatible with Rancher 2.11

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/advanced_filtering.spec.ts
@@ -68,7 +68,7 @@ filterTests(['main'], () => {
         cy.clickNavMenu(['Inventory of Machines']);
         cy.get('[width="30"] > .checkbox-outer-container > .checkbox-container > .checkbox-custom').click();
         cy.clickButton('Actions');
-        if (!isRancherManagerVersion('2.10')) {
+        if (isRancherManagerVersion('2.8') || isRancherManagerVersion('2.9')) {
           cy.get('.tooltip-inner > :nth-child(1) > .list-unstyled > :nth-child(3)').click();
         } else {
           cy.get('.v-popper__inner').contains('Delete').click();

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -31,6 +31,8 @@ filterTests(['main'], () => {
 
     qase(31,
       it('Deploy Alerting Drivers application', () => {
+        let myAppToInstall;
+        isRancherManagerVersion('2.11') ? myAppToInstall = 'Cerbos' : myAppToInstall = 'Alerting Drivers';
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         cypressLib.burgerMenuToggle();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -44,19 +46,25 @@ filterTests(['main'], () => {
         }
         cy.get('.nav').contains('Apps').click();
         cy.contains('Charts').click();
-        cy.contains('Alerting Drivers', { timeout: 30000 }).click();
-        cy.contains('.name-logo-install', 'Alerting Drivers', { timeout: 30000 });
+        cy.contains(myAppToInstall, { timeout: 30000 }).click();
+        cy.contains('.name-logo-install', myAppToInstall, { timeout: 30000 });
         cy.clickButton('Install');
-        cy.contains('.outer-container > .header', 'Alerting Drivers');
+        cy.contains('.outer-container > .header', myAppToInstall);
         cy.clickButton('Next');
         cy.clickButton('Install');
         cy.contains('SUCCESS: helm install', { timeout: 120000 });
         cy.reload();
-        cy.contains(new RegExp('Deployed.*rancher-alerting-drivers'))  
+        if (isRancherManagerVersion('2.11')) {
+          cy.contains(new RegExp('Deployed.*cerbos'));
+        } else { 
+          cy.contains(new RegExp('Deployed.*rancher-alerting-drivers'))  
+        }
       }));
 
     qase(32,
       it('Remove Alerting Drivers application', () => {
+        let myAppToInstall;
+        isRancherManagerVersion('2.11') ? myAppToInstall = 'cerbos' : myAppToInstall = 'rancher-alerting-drivers';
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         if (!isRancherManagerVersion('2.8')) {
           cy.get('.main-panel').contains(clusterName).click();
@@ -66,12 +74,12 @@ filterTests(['main'], () => {
         cy.get('.nav').contains('Apps').click();
         cy.contains('Installed Apps').click();
         cy.contains('.title', 'Installed Apps', { timeout: 20000 });
-        cy.contains('rancher-alerting-drivers');
+        cy.contains(myAppToInstall);
         cy.get('[width="30"] > .checkbox-outer-container').click();
         cy.get('.outlet').getBySel('sortable-table-promptRemove').click();
         cy.confirmDelete();
         cy.contains('SUCCESS: helm uninstall', { timeout: 60000 });
-        cy.contains('.apps', 'rancher-alerting-drivers').should('not.exist');
+        cy.contains('.apps', myAppToInstall).should('not.exist');
       }));
   });
 });

--- a/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import filterTests from '~/support/filterTests.js';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { isRancherManagerVersion } from '~/support/utils';
 
 filterTests(['main', 'upgrade'], () => {
   Cypress.config();
@@ -29,7 +30,12 @@ filterTests(['main', 'upgrade'], () => {
       cy.login();
       cy.visit('/');
       cy.getBySel('nav_header_showUserMenu').click();
-      cy.getBySel('user-menu-dropdown').contains('Preferences').click();
+      // HTML selector user-menu-dropdown is not in 2.11 anymore
+      if (isRancherManagerVersion('2.11')) {
+        cy.contains('Preferences').click();
+      } else {
+        cy.getBySel('user-menu-dropdown').contains('Preferences').click();
+      }
       cy.clickButton('Include Prerelease Versions');
       cypressLib.burgerMenuToggle();
       cy.getBySel('side-menu').contains('Home').click();

--- a/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/seed_image.spec.ts
@@ -51,7 +51,6 @@ filterTests(['main'], () => {
       }
       // The following line will replace the confition just above when we will remove 2.8 tests
       //cy.verifyDownload(isBootType('iso') ? '.iso' : '.raw', { contains: true, timeout: 300000, interval: 5000 });
-      // Check we can download the checksum file (only in dev UI for Rancher 2.9 / 2.10)
       if (!utils.isRancherManagerVersion('2.8') && utils.isUIVersion('dev')) {
         cy.getBySel('download-checksum-btn-list').click();
         cy.verifyDownload('.sh256', { contains: true, timeout: 60000, interval: 5000 });

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
@@ -31,10 +31,10 @@ describe('UI extension upgrade tests', () => {
 
   filterTests(['upgrade'], () => {
     // 1 - Enable only with K3S because still too much flaky with RKE2
-    // 2 - TODO: Remove rancher 2-10 condition later
-    // UI extension upgrade cannot be upgraded with rancher manager 2.10 yet
+    // 2 - TODO: Remove rancher 2-11 condition later
+    // UI extension upgrade cannot be upgraded with rancher manager 2.11 yet
     // because we have only one version so far
-    if (utils.isK8sVersion('k3s') && !utils.isRancherManagerVersion('2.10')) {
+    if (utils.isK8sVersion('k3s') && !utils.isRancherManagerVersion('2.11')) {
       it('Add elemental-ui dev repo', () => {
         cypressLib.addRepository('elemental-ui', 'https://github.com/rancher/elemental-ui.git', 'git', 'gh-pages');
       });

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -31,7 +31,7 @@ export class Elemental {
       expect($lis).to.have.length(7);
       // There is a bug with Dashboard entry in rancher 2.10
       // https://github.com/rancher/elemental-ui/issues/230
-      if (!isRancherManagerVersion('2.10')) {
+      if (isRancherManagerVersion('2.9')) {
         expect($lis.eq(0)).to.contain('Dashboard');
       }
       expect($lis.eq(1)).to.contain('Registration Endpoints');
@@ -93,7 +93,7 @@ export class Elemental {
     cy.clickButton('Install');
     cy.contains('SUCCESS: helm', { timeout: 120000 });
     cy.reload();
-    if (!isRancherManagerVersion('2.10')) {
+    if (isRancherManagerVersion('2.9')) {
       // eslint-disable-next-line cypress/unsafe-to-chain-command
       cy.contains('Only User Namespaces').click().type('cattle-elemental-system{enter}{esc}');
       cy.get('.outlet').contains('Deployed elemental-operator cattle-elemental-system', { timeout: 120000 });


### PR DESCRIPTION
Change code to work with Rancher 2.11.

Verification run:
[UI-K3s-Rancher_2.11.0-alpha5-v1.30.9+k3s1](https://github.com/rancher/elemental/actions/runs/13377197677/job/37364604210) ✅ 
[UI-K3s-Upgrade-Rancher_2.11.0-alpha5-v1.30.9+k3s1](https://github.com/rancher/elemental/actions/runs/13386425463) ✅ 
[UI-K3S-Rancher_2.10](https://github.com/rancher/elemental/actions/runs/13412625179/job/37466110507) ✅ 