### PR TITLE
ci/ui: use latest stable ISO for maintenance test

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -140,6 +140,9 @@ Cypress.Commands.add('createMachReg', (
     // Sometimes we want to test dev/staging operator version with stable OS version
     } else if ( utils.isOsVersion('stable') && utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
       cy.contains(Cypress.env('iso_stable_os_version')).click();
+    // For maintenance, we need to select the last -1 version, the last one is the unstable one.
+    } else if (utils.isOperatorVersion('maintenance')) {
+      cy.get('.vs__dropdown-option').last().prev().click();
     } else {
       cy.contains('(unstable)').click();
     }


### PR DESCRIPTION
When we build the ISO, we do not have a case for maintenance.
In maintenance, we want to use the latest stable ISO from the channel brought by the operator maintenance version.

## Verification run
https://github.com/rancher/elemental/actions/runs/13433833637/job/37536844034 ✅ 