### PR TITLE
Remove /etc/machine-id from base container

### DIFF
--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -103,3 +103,5 @@ RUN zypper clean --all && \
 
 # Rebuild initrd to setup dracut with the boot configurations
 RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
+
+RUN rm -f /etc/machine-id


### PR DESCRIPTION
Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
