### PR TITLE
Include an empty /etc/machine-id file (bsc#1239623)

### DIFF
--- a/.obs/dockerfile/micro-base-os/Dockerfile
+++ b/.obs/dockerfile/micro-base-os/Dockerfile
@@ -104,4 +104,6 @@ RUN zypper clean --all && \
 # Rebuild initrd to setup dracut with the boot configurations
 RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
 
-RUN rm -f /etc/machine-id
+# Empty machine-id is not considered a firstboot by systemd
+# https://www.freedesktop.org/software/systemd/man/latest/machine-id.html#First%20Boot%20Semantics
+RUN > /etc/machine-id


### PR DESCRIPTION
Systemd considers a first boot any system without an /etc/machine-id, so removing it caused an interactive firstboot process we don't want.