### PR TITLE
ci/airgap: fix K3s downstream version

### DIFF
--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.31.5+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.5+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml


### PR DESCRIPTION
The latest version available is v1.31.5, so we have to use this one.

Verification run:
- [CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/runs/14441163776)