### PR TITLE
ci/ui: fix rke2 upgrade test

### DIFF
--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -36,7 +36,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.9
+        default: stable/latest
         type: string
       upgrade_from_version:
         description: Elemental operator version to upgrade from

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -41,7 +41,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.9
+        default: stable/latest
         type: string
 
 jobs:

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/2.9","latest/devel/2.10"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/head"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
Verification run:
- [UI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/14731878999)

The upgrade test with Rancher Manager `latest/devel/head` version seems to be related to an issue with Racnher Manager itself. Anyway, the test goes further than before.