### PR TITLE
ci/cli: remove downgrade test

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,8 +11,7 @@ Tests that are scheduled (can be manually triggered as well):
 | CLI RKE2 Upgrade | Monday/Wednesday | 5am | us-central1-f |
 | CLI Full backup/restore (migration) | Friday | 2am | us-central1-a |
 | CLI K3s Airgap | Friday | 3am | us-central1-b |
-| CLI K3s Downgrade | Friday | 4am | us-central1-c |
-| CLI Regression | Friday | 5am | us-central1-f |
+| CLI Regression | Friday | 4am | us-central1-f |
 | UI K3s | Tuesday/Thursday | 2am | us-central1-a |
 | UI K3s Upgrade | Tuesday/Thursday | 3am | us-central1-b |
 | UI RKE2 | Tuesday/Thursday | 4am | us-central1-c |
@@ -22,6 +21,7 @@ Tests that are scheduled (can be manually triggered as well):
 Tests that are not scheduled (but can be manually triggered):
 | Test type | Zones |
 |:---:|:---:|
+| CLI K3s Downgrade | us-central1-c |
 | CLI K3s IBS Stable | us-central1-f |
 | CLI K3s OBS Dev | us-central1-f |
 | CLI K3s OBS Staging | us-central1-f |

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -23,9 +23,6 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         type: string
-  schedule:
-    # Every Friday at 4am UTC (11pm in us-central1)
-    - cron: '0 4 * * 5'
 
 jobs:
   cli:

--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -20,8 +20,8 @@ on:
         description: Qase run ID where the results will be reported
         type: string
   schedule:
-    # Every Friday at 5am UTC (12am in us-central1)
-    - cron: '0 5 * * 5'
+    # Every Friday at 4am UTC (11pm in us-central1)
+    - cron: '0 4 * * 5'
 
 jobs:
   cli:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ See [here](.github/workflows/README.md) for a detailed view of the tests schedul
 
 [![CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-full-backup-restore-matrix.yaml)
 [![CLI-K3s-Airgap](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-airgap-matrix.yaml)
-[![CLI-K3s-Downgrade](https://github.com/rancher/elemental/actions/workflows/cli-k3s-downgrade-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-k3s-downgrade-matrix.yaml)
 [![CLI-Regression](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml/badge.svg)](https://github.com/rancher/elemental/actions/workflows/cli-regression-matrix.yaml)
 
 ## Goal


### PR DESCRIPTION
After discussion with the Devs we decided that this test doesn't need to be scheduled every day or week. It can still be manually triggerred if needed.