### PR TITLE
ci/ui Bump k3s and rke2 versions to v1.32.4

### DIFF
--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.32.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.32.4+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/head"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.32.4+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.32.4+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","latest/devel/head"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       os_version_install:
         description: OS version to install

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -21,11 +21,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.32.4+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+rke2r1
+        default: v1.32.4+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+rke2r1
+        default: v1.32.4+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.32.4+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.32.4+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/head"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.32.4+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.32.4+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","latest/devel/head"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:


### PR DESCRIPTION
Bump K3S and RKE2 versions to fix the CI

## Verification run
[UI-K3S](https://github.com/rancher/elemental/actions/runs/15302659130) ✅ 
[UI-RKE2](https://github.com/rancher/elemental/actions/runs/15302678069) ✅ 