### PR TITLE
Remove DynamicSchemas workaround

### DIFF
--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -170,16 +170,6 @@ jobs:
           PUBLIC_DOMAIN: ${{ inputs.public_domain }}
         run: cd tests && make e2e-install-rancher
 
-      - name: Workaround for DynamicSchemas for operator uninstallation (if needed)
-        id: workaround_for_dynamicschemas
-        run: |
-          # Check if DynamicSchemas for MachineInventorySelectorTemplate exists
-          if ! kubectl get dynamicschema machineinventoryselectortemplate >/dev/null 2>&1; then
-            # If not we have to add it to avoid weird issues!
-            echo "WORKAROUND: DynamicSchemas for MachineInventorySelectorTemplate is missing!"
-            kubectl apply -f tests/assets/add_missing_dynamicschemas.yaml
-          fi
-
       - name: Install backup-restore components
         id: install_backup_restore
         env:

--- a/tests/assets/add_missing_dynamicschemas.yaml
+++ b/tests/assets/add_missing_dynamicschemas.yaml
@@ -1,6 +1,0 @@
-apiVersion: management.cattle.io/v3
-kind: DynamicSchema
-metadata:
-  labels:
-    cattle.io/creator: norman
-  name: machineinventoryselectortemplate


### PR DESCRIPTION
Not needed anymore and it fails with Rancher Manager v2.12.

Verification runs:
- [CLI-K3s with Rancher Manager `head/2.12`](https://github.com/rancher/elemental/actions/runs/16351556765) :white_check_mark:
- [CLI-RKE2 with Rancher Manager `prime/latest`](https://github.com/rancher/elemental/actions/runs/16351664304) :white_check_mark:
- [CLI-K3s-Downgrade](https://github.com/rancher/elemental/actions/runs/16351713230) :white_check_mark:
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/16351716641) :x:, this test fails for a reason not related to this PR.