### PR TITLE
ci/cli: fix upgrade tests (use Staging)

### DIFF
--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -59,6 +59,5 @@ jobs:
       rancher_version: stable/latest
       reset: true
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/maintenance/6.0/containers/suse/sl-micro/6.0/baremetal-os-container:latest
-      upgrade_os_channel: dev
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/staging/containers/suse/sl-micro/6.1/baremetal-os-container:latest
       zone: us-central1-b

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -59,6 +59,5 @@ jobs:
       rancher_version: prime/latest
       reset: true
       test_type: cli
-      upgrade_image: registry.opensuse.org/isv/rancher/elemental/maintenance/6.0/containers/suse/sl-micro/6.0/baremetal-os-container:latest
-      upgrade_os_channel: dev
+      upgrade_image: registry.opensuse.org/isv/rancher/elemental/staging/containers/suse/sl-micro/6.1/baremetal-os-container:latest
       zone: us-central1-f

--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -335,8 +335,20 @@ jobs:
         run: |
           cd tests && make e2e-upgrade-node && make e2e-check-app
 
+      - name: Upgrade other nodes to specified OS version with osImage
+        id: upgrade_other_nodes_osimage
+        if: ${{ inputs.upgrade_image != '' && inputs.upgrade_os_channel == ''}}
+        env:
+          FORCE_DOWNGRADE: ${{ inputs.force_downgrade }}
+          UPGRADE_IMAGE: ${{ inputs.upgrade_image }}
+          UPGRADE_TYPE: osImage
+          VM_INDEX: 2
+          VM_NUMBERS: 3
+        run: |
+          cd tests && make e2e-upgrade-node && make e2e-check-app
+
       - name: Upgrade other nodes to specified OS version with managedOSVersionName
-        id: upgrade_other_nodes
+        id: upgrade_other_nodes_managedosversionname
         if: ${{ inputs.upgrade_os_channel != '' }}
         env:
           FORCE_DOWNGRADE: ${{ inputs.force_downgrade }}


### PR DESCRIPTION
Use Staging for now, as Maintenance have older versions.

Verification runs:
- [CLI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/16494365694/job/46636559259) :white_check_mark:
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/16494558799) :white_check_mark: