### PR TITLE
ci/cli: fix backup-restore issue

### DIFF
--- a/.github/workflows/sub_cli.yaml
+++ b/.github/workflows/sub_cli.yaml
@@ -205,6 +205,7 @@ jobs:
 
           # Export values
           echo "backup_operator_version=${BACKUP_OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "backup_restore_version=${BACKUP_OPERATOR_VERSION##*:}" >> ${GITHUB_OUTPUT}
           echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
           echo "operator_version=${OPERATOR_VERSION}" >> ${GITHUB_OUTPUT}
           echo "rancher_image_version=${RANCHER_VERSION}" >> ${GITHUB_OUTPUT}
@@ -362,6 +363,7 @@ jobs:
       - name: Test Backup/Restore Rancher Manager/Elemental resources
         id: test_backup_restore
         env:
+          BACKUP_RESTORE_VERSION: ${{ steps.component.outputs.backup_restore_version }}
           CA_TYPE: ${{ inputs.ca_type }}
           OPERATOR_REPO: ${{ inputs.operator_repo }}
           PUBLIC_FQDN: ${{ inputs.public_fqdn }}


### PR DESCRIPTION
Use a hardcoded map to match Rancher Manager version with the backup-restore operator one. This should avoid weird (and sporadic!) issues because of versions mismatch.

It is not an elegant solution, but it is easy to update and should be enough for now.

Verification runs:
- [CLI-K3s](https://github.com/rancher/elemental/actions/runs/17245852061) :white_check_mark:
- [CLI-K3s-Upgrade](https://github.com/rancher/elemental/actions/runs/17249919060) :white_check_mark:
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/17231831427) :white_check_mark:
- [CLI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/17245876422) :white_check_mark:
- [CLI-Full-Backup-Restore](https://github.com/rancher/elemental/actions/runs/17244259807) :white_check_mark: