### PR TITLE
ci/ui: fix RKE2 ui test with raw boot

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -140,15 +140,8 @@ Cypress.Commands.add('createMachReg', (
     } else if (utils.isOperatorVersion('registry.suse.com') || utils.isOperatorVersion('marketplace')) {
       cy.contains(Cypress.env('os_version_install')).click();
     // Sometimes we want to test dev/staging operator version with stable OS version
-    } else if (utils.isOsVersion('stable') && utils.isOperatorVersion('dev') || utils.isOperatorVersion('staging')) {
+    } else if (utils.isOsVersion('stable') && utils.isOperatorVersion('maintenance') || utils.isOperatorVersion('staging')) {
       cy.contains(new RegExp(osRegex)).click();
-    // For maintenance, we need to select the last -1 version, the last one is the unstable one.
-    } else if (utils.isOperatorVersion('maintenance')) {
-      if (osVersion === "") {
-        cy.get('.vs__dropdown-option').last().prev().click();
-      } else {
-        cy.contains(new RegExp(osRegex)).click();
-      }
     } else {
       cy.contains('(unstable)').click();
     }


### PR DESCRIPTION
RKE2 UI tests are failing since Elemental switched from `dev` to `maintenance` in tests.

## Verification runs
[UI-RKE2-Rancher_Prime](https://github.com/rancher/elemental/actions/runs/17466974269) ✅ 
[UI-RKE-Upgrade](https://github.com/rancher/elemental/actions/runs/17470425835) ✅ 