### PR TITLE
[forwardport] Add policycoreutils-python-utils (bsc#1240623)

### DIFF
--- a/.obs/dockerfile/SL-Micro-baremetal-container/Dockerfile
+++ b/.obs/dockerfile/SL-Micro-baremetal-container/Dockerfile
@@ -23,7 +23,7 @@ RUN zypper in --no-recommends -y procps openssh openssh-server \
     container-selinux ethtool fuse-overlayfs hdparm hostname iptables \
     issue-generator jq keyutils lshw lsof lsscsi mdadm multipath-tools \
     netcat-openbsd net-tools nfs-client \
-    nss-mdns open-iscsi open-vm-tools pciutils pciutils-ids podman policycoreutils \
+    nss-mdns open-iscsi open-vm-tools pciutils pciutils-ids podman policycoreutils policycoreutils-python-utils \
     procmail psmisc rpcbind runc selinux-policy selinux-policy-targeted \
     selinux-tools slirp4netns strace sudo sysstat system-user-nobody \
     timezone traceroute xtables-plugins


### PR DESCRIPTION
Forwardport from downstream build service repository

Ported from branch v2.2
(cherry picked from commit 11a34eee954e3c18b9a295dee9f592120d93329a)