### PR TITLE
ci/pxe: set SELinux in permissive mode by default

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,8 +14,9 @@ ifeq ($(TEST_TYPE),multi)
 endif
 
 # Define SELinux command line
+SELINUX_CMDLINE="security=selinux enforcing=0"
 ifeq ($(SELINUX),true)
-	SELINUX_CMDLINE?="security=selinux enforcing=0"
+	SELINUX_CMDLINE="security=selinux enforcing=1"
 endif
 
 extract_kernel_init_squash:


### PR DESCRIPTION
This will fix installation issues with SLMicro6.2 in PXE boot.

Verification run:
- [CLI-OBS-Manual-Workflow with K3s](https://github.com/rancher/elemental/actions/runs/18090626660)