### PR TITLE
ci/ui: fix Stable OS channel addition

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -78,7 +78,7 @@ filterTests(['main', 'upgrade'], () => {
     );
     it('Add additional channel', () => {
       // Sometimes we want to test dev/staging operator version with stable OS version
-      if ( isOsVersion('stable') && isOperatorVersion('dev') || isOperatorVersion('staging')) {
+      if (isOsVersion('stable') && (isOperatorVersion('dev') || isOperatorVersion('staging'))) {
         cypressLib.accesMenu('OS Management');
         cy.addOsVersionChannel('stable');
       }});

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -140,7 +140,7 @@ Cypress.Commands.add('createMachReg', (
     } else if (utils.isOperatorVersion('registry.suse.com') || utils.isOperatorVersion('marketplace')) {
       cy.contains(Cypress.env('os_version_install')).click();
     // Sometimes we want to test dev/staging operator version with stable OS version
-    } else if (utils.isOsVersion('stable') && utils.isOperatorVersion('maintenance') || utils.isOperatorVersion('staging')) {
+    } else if (utils.isOsVersion('stable') && (utils.isOperatorVersion('maintenance') || utils.isOperatorVersion('staging'))) {
       cy.contains(new RegExp(osRegex)).click();
     } else {
       cy.contains('(unstable)').click();


### PR DESCRIPTION
Force addition of `stable` OS channel only if asked explicitly. According to the code it seems to be missing brackets only.

Verification run:
- [UI-OBS-Manual-Workflow with K3s+ISO](https://github.com/rancher/elemental/actions/runs/18107763283) :white_check_mark:
- [UI-OBS-Manual-Workflow with RKE2+RAW](https://github.com/rancher/elemental/actions/runs/18109457919)  :white_check_mark: