### PR TITLE
ci: replace rancher 2.12-head with 2.13-head

### DIFF
--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -32,10 +32,10 @@ filterTests(['main'], () => {
     qase(31,
       it('Deploy Alerting Drivers application', () => {
         let myAppToInstall;
-        if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-          myAppToInstall = 'Cerbos'
-        } else {
+        if (isRancherManagerVersion('2.10')) {
           myAppToInstall = 'Alerting Drivers';
+        } else {
+          myAppToInstall = 'Cerbos'
         }
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         cypressLib.burgerMenuToggle();
@@ -51,31 +51,36 @@ filterTests(['main'], () => {
         cy.get('.nav').contains('Apps').click();
         cy.contains('Charts').click();
         cy.contains(myAppToInstall, { timeout: 30000 }).click();
-        cy.contains('.name-logo-install', myAppToInstall, { timeout: 30000 });
-        cy.clickButton('Install');
-        if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-          cy.contains('.top > .title', myAppToInstall)
+        if (isRancherManagerVersion('2.13')) {
+          cy.getBySel('chart-header-title').should('contain.text', myAppToInstall);
+          cy.getBySel('btn-chart-install').click();
         } else {
+          cy.contains('.name-logo-install', myAppToInstall, { timeout: 30000 });
+          cy.clickButton('Install');
+        }
+        if (isRancherManagerVersion('2.10')) {
           cy.contains('.outer-container > .header', myAppToInstall);
+        } else {
+          cy.contains('.top > .title', myAppToInstall)
         }
         cy.clickButton('Next');
         cy.clickButton('Install');
         cy.contains('SUCCESS: helm install', { timeout: 120000 });
         cy.reload();
-        if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-          cy.contains(new RegExp('Deployed.*cerbos'));
-        } else { 
+        if (isRancherManagerVersion('2.10')) {
           cy.contains(new RegExp('Deployed.*rancher-alerting-drivers'))  
+        } else { 
+          cy.contains(new RegExp('Deployed.*cerbos'));
         }
       }));
 
     qase(32,
       it('Remove Alerting Drivers application', () => {
         let myAppToInstall;
-        if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-          myAppToInstall = 'cerbos'
-        } else {
+        if (isRancherManagerVersion('2.10')) {
           myAppToInstall = 'rancher-alerting-drivers';
+        } else {
+          myAppToInstall = 'cerbos'
         }
         cypressLib.checkClusterStatus(clusterName, 'Active', 600000);
         if (!isRancherManagerVersion('2.8')) {

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -38,18 +38,10 @@ filterTests(['main', 'upgrade'], () => {
       })
     );
 
-    // Add rancher-ui-plugin-charts repo except for rancher manager 2.7
+    // Add rancher-ui-plugin-charts repo
     it('Add rancher-ui-plugin-charts repo', () => {
-      !isRancherManagerVersion('2.7') ? cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main') : null;
+      cypressLib.addRepository('rancher-ui-plugin-charts', 'https://github.com/rancher/ui-plugin-charts.git', 'git', 'main');
     });
-
-    qase(12,
-      it('Enable extension support', () => {
-        if (isRancherManagerVersion('2.8')) {
-          isUIVersion('stable') ? cypressLib.enableExtensionSupport(true) : cypressLib.enableExtensionSupport(false);
-        }
-      })
-    );
 
     qase(13,
       it('Install Elemental plugin', () => {
@@ -57,23 +49,35 @@ filterTests(['main', 'upgrade'], () => {
         cy.contains('Extensions')
           .click();
         cy.contains('elemental');
-        cy.get('.plugin')
-          .contains('Install')
-          .click();
-        if (isRancherManagerVersion('2.8')) {
-          cy.getBySel('install-ext-modal-select-version')
+        if (isRancherManagerVersion('2.13')) {
+          cy.get('[data-testid="item-card-cluster/rancher-ui-plugin-charts/elemental"]').within(() => {
+            cy.get('[data-testid="rc-item-card-action"]')
+            //.getBySel('rc-item-card-action')
             .click();
-          cy.contains('1.3.1')
+            cy.contains('Install')
+            .click();
+          });
+
+        } else {
+          cy.contains('elemental');
+          cy.get('.plugin')
+            .contains('Install')
             .click();
         }
         cy.clickButton('Install');
         cy.contains('Installing');
         cy.contains('Extensions changed - reload required', { timeout: 40000 });
         cy.clickButton('Reload');
-        cy.get('.plugins')
-          .children()
-          .should('contain', 'elemental')
-          .and('contain', 'Uninstall');
+        if (isRancherManagerVersion('2.13')) {
+          cy.getBySel('btn-installed')
+            .click();
+          cy.getBySel('item-card-header-title')
+        } else {
+          cy.get('.plugins')
+            .children()
+            .should('contain', 'elemental')
+            .and('contain', 'Uninstall');
+        }
       })
     );
     it('Add additional channel', () => {

--- a/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
@@ -30,11 +30,10 @@ filterTests(['main', 'upgrade'], () => {
       cy.login();
       cy.visit('/');
       cy.getBySel('nav_header_showUserMenu').click();
-      // HTML selector user-menu-dropdown is not in 2.11 or 2.12 anymore
-      if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-        cy.contains('Preferences').click();
-      } else {
+      if (isRancherManagerVersion('2.10')) {
         cy.getBySel('user-menu-dropdown').contains('Preferences').click();
+      } else {
+        cy.contains('Preferences').click();
       }
       cy.clickButton('Include Prerelease Versions');
       cypressLib.burgerMenuToggle();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -41,7 +41,11 @@ describe('Elemental operator upgrade tests', () => {
         it('Upgrade Elemental operator', () => {
           cy.contains('local').click();
           cy.get('.nav').contains('Apps').click();
-          utils.isRancherManagerVersion('2.12') ? cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click() : cy.get('.color1').contains('Elemental').click();
+          if (utils.isRancherManagerVersion('2.12')|| (utils.isRancherManagerVersion('2.13'))) {
+            cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click()
+          } else {
+            cy.get('.color1').contains('Elemental').click()
+          }
           cy.contains('Charts: Elemental', { timeout: 30000 });
           cy.getBySel('btn-chart-install').click();
           //cy.clickButton('Upgrade');

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -24,7 +24,7 @@ export class Elemental {
   // Make sure we get all menus
   checkElementalNav(): void {
     // Open advanced accordion
-    if (isRancherManagerVersion('2.12') || isRancherManagerVersion('2.12')) {
+    if (isRancherManagerVersion('2.12') || isRancherManagerVersion('2.13')) {
       cy.get('.accordion-item > .icon').eq(0).click();
     } else {
       cy.get('div.header > i').eq(0).click();
@@ -33,11 +33,6 @@ export class Elemental {
     // Check all listed options once accordion is opened
     cy.get('li.child.nav-type').should(($lis) => {
       expect($lis).to.have.length(7);
-      // There is a bug with Dashboard entry in rancher 2.10
-      // https://github.com/rancher/elemental-ui/issues/230
-      if (isRancherManagerVersion('2.9')) {
-        expect($lis.eq(0)).to.contain('Dashboard');
-      }
       expect($lis.eq(1)).to.contain('Registration Endpoints');
       expect($lis.eq(2)).to.contain('Inventory of Machines');
       expect($lis.eq(3)).to.contain('Update Groups');
@@ -64,7 +59,11 @@ export class Elemental {
     cy.get('.nav').contains('Apps').click();
 
     if (isCypressTag('main') && !isOperatorVersion('marketplace')) {
-      isRancherManagerVersion('2.12') ? cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click() : cy.contains('.item.has-description.color1', 'Elemental', { timeout: 30000 }).click();
+      if (isRancherManagerVersion('2.12')|| (isRancherManagerVersion('2.13'))) {
+        cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click()
+      } else {
+        cy.get('.color1').contains('Elemental').click()
+      }  
     } else {
         // Uncheck Rancher (rancher.io) repo if it's checked
         if (isGitRepo('github')) {
@@ -81,10 +80,10 @@ export class Elemental {
     }
 
     cy.clickButton('Install');
-    if (isRancherManagerVersion('2.11') || isRancherManagerVersion('2.12')) {
-      cy.contains('.top > .title', 'Elemental') 
-    } else {
+    if (isRancherManagerVersion('2.10')) {
       cy.contains('.outer-container > .header', 'Elemental');
+    } else {
+      cy.contains('.top > .title', 'Elemental') 
     }
     if (isRancherPrime() && isCypressTag('main') && !isOperatorVersion('marketplace')) {
       const registryLabel = 'Container Registry';
@@ -100,15 +99,9 @@ export class Elemental {
     cy.clickButton('Install');
     cy.contains('SUCCESS: helm', { timeout: 120000 });
     cy.reload();
-    if (isRancherManagerVersion('2\.9') || isRancherManagerVersion('2\.8')) {
-      // eslint-disable-next-line cypress/unsafe-to-chain-command
-      cy.contains('Only User Namespaces').click().type('cattle-elemental-system{enter}{esc}');
-      cy.get('.outlet').contains('Deployed elemental-operator cattle-elemental-system', { timeout: 120000 });
-    } else {
-      cy.contains('Only User Namespaces').click()
-      // Select All Namespaces entry
-      cy.getBySel('namespaces-option-0').click();
-      cy.get('.outlet').contains(new RegExp('Deployed.*elemental-operator'), { timeout: 120000 });
-    }
+    cy.contains('Only User Namespaces').click()
+    // Select All Namespaces entry
+    cy.getBySel('namespaces-option-0').click();
+    cy.get('.outlet').contains(new RegExp('Deployed.*elemental-operator'), { timeout: 120000 });
   }
 }

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -307,7 +307,7 @@ func InstallBackupOperator(k *kubectl.Kubectl) {
 		Expect(err).To(Not(HaveOccurred()))
 
 		switch {
-		case strings.Contains(rancherVersion, ":v2.12"):
+		case strings.Contains(rancherVersion, ":v2.12") || strings.Contains(rancherVersion, ":v2.13"):
 			backupRestoreVersion = "v8.0.0"
 			backupRscSet = "rancher-resource-set-full" // Newer resources set should now be used
 		case strings.Contains(rancherVersion, ":v2.11"):


### PR DESCRIPTION
Update the CI and code to use rancher 2.13-head

## Verification run
[UI-K3S-Rancher_2.13-head](https://github.com/rancher/elemental/actions/runs/18343647915) ✅ 
[UI-K3S-Rancher_latest_stable](https://github.com/rancher/elemental/actions/runs/18346305499) ✅ 