### PR TITLE
ci: bump K8s, Rancher Manager and backup/restore operator

### DIFF
--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1","v1.34.2+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1","v1.34.2+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1","v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1","v1.31.7+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1","v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1","v1.34.2+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.5+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.5+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -31,8 +31,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.34.2+k3s1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,8 +47,8 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.12"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '""')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.13"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/cli-k3s-scalability-matrix.yaml
+++ b/.github/workflows/cli-k3s-scalability-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.12"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
-        default: '"head/2.12"'
+        default: '"head/2.13"'
         type: string
   schedule:
     # Monday and Wednesday at 3am UTC (10pm in us-central1)
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.12"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-multicluster-matrix.yaml
+++ b/.github/workflows/cli-multicluster-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -29,7 +29,7 @@ on:
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version/head_version to upgrade to
-        default: head/2.12
+        default: head/2.13
         type: string
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.1+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.1+k3s1
+        default: v1.34.2+k3s1
         type: string
       operator_repo:
         description: Operator version to use for initial deployment

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -17,11 +17,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+k3s1
+        default: v1.34.2+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -29,8 +29,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.15+k3s1","v1.29.15+k3s1","v1.30.11+k3s1","v1.31.7+k3s1","v1.28.15+rke2r1","v1.29.15+rke2r1","v1.30.11+rke2r1","v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.28.15+k3s1","v1.29.15+k3s1","v1.30.11+k3s1","v1.34.2+k3s1","v1.28.15+rke2r1","v1.29.15+rke2r1","v1.30.11+rke2r1","v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -13,11 +13,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.31.7+rke2r1
+        default: v1.34.2+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.31.7+rke2r1
+        default: v1.34.2+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -18,11 +18,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -47,8 +47,8 @@ jobs:
       matrix:
         ca_type: ${{ fromJSON(format('[{0}]', inputs.ca_type || '"selfsigned","private"')) }}
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -49,7 +49,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
-        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.12"')) }}
+        rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
         reset: ${{ fromJSON(format('[{0}]', inputs.reset || 'false')) }}
         sequential: [ false ]
     uses: ./.github/workflows/master_e2e.yaml

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
-        default: '"head/2.12"'
+        default: '"head/2.13"'
         type: string
   schedule:
     # Monday and Wednesday at 5am UTC (12am in us-central1)
@@ -40,7 +40,7 @@ jobs:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
         k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
         k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
-        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.12"')) }}
+        rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:
       credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -14,11 +14,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.31.7+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported
@@ -38,8 +38,8 @@ jobs:
       max-parallel: 4
       matrix:
         cluster_type: ${{ fromJSON(format('[{0}]', inputs.cluster_type || '"", "hardened"')) }}
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.31.7+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.31.7+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
         rancher_upgrade: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"head/2.12"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.32.4+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.32.4+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.32.4+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.32.4+k3s1"'
+        default: '"v1.34.2+k3s1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+k3s1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+k3s1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+k3s1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+k3s1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"stable/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       os_version_install:
         description: OS version to install

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -19,11 +19,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -21,11 +21,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+k3s1
+        default: v1.34.2+k3s1
         type: string
       operator_repo:
         description: Elemental operator repository to use

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -14,11 +14,11 @@ on:
         type: string
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: v1.32.4+rke2r1
+        default: v1.34.2+rke2r1
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: v1.32.4+rke2r1
+        default: v1.34.2+rke2r1
         type: string
       qase_run_id:
         description: Qase run ID where the results will be reported

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.32.4+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.32.4+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -10,11 +10,11 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.32.4+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use
-        default: '"v1.32.4+rke2r1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       proxy:
         description: Deploy a proxy (none/rancher/elemental)
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.32.4+rke2r1"')) }}
-        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.32.4+rke2r1"')) }}
+        k8s_downstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_downstream_version || '"v1.34.2+rke2r1"')) }}
+        k8s_upstream_version: ${{ fromJSON(format('[{0}]', inputs.k8s_upstream_version || '"v1.34.2+rke2r1"')) }}
         rancher_version: ${{ fromJSON(format('[{0}]', inputs.rancher_version || '"prime/latest","head/2.13"')) }}
     uses: ./.github/workflows/master_e2e.yaml
     secrets:

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -306,12 +306,16 @@ func InstallBackupOperator(k *kubectl.Kubectl) {
 			"-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		Expect(err).To(Not(HaveOccurred()))
 
+		// backupRscSet should be used for newer versions
 		switch {
-		case strings.Contains(rancherVersion, ":v2.12") || strings.Contains(rancherVersion, ":v2.13"):
-			backupRestoreVersion = "v8.0.0"
-			backupRscSet = "rancher-resource-set-full" // Newer resources set should now be used
+		case strings.Contains(rancherVersion, ":v2.13"):
+			backupRestoreVersion = "v9.0.0"
+			backupRscSet = "rancher-resource-set-full"
+		case strings.Contains(rancherVersion, ":v2.12"):
+			backupRestoreVersion = "v8.1.1"
+			backupRscSet = "rancher-resource-set-full"
 		case strings.Contains(rancherVersion, ":v2.11"):
-			backupRestoreVersion = "v7.0.2"
+			backupRestoreVersion = "v7.0.4"
 		case strings.Contains(rancherVersion, ":v2.10"):
 			backupRestoreVersion = "v6.0.2"
 		case strings.Contains(rancherVersion, ":v2.9"):


### PR DESCRIPTION
This PR includes:
  - ci/cli: bump backup-restore-operator, also uses operator v9 for Rancher v2.13
  - ci/cli: replace Rancher 2.12-head with 2.13-head
  - ci: bump K3s and RKE2 versions to v1.34.3

Verification runs:
  - [CLI-K3s](https://github.com/rancher/elemental/actions/runs/20963826740) :white_check_mark:
  - [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/20995564394) (to validate RKE2, `UI-RKE2` has issue not related to RKE2 itself) :white_check_mark: 
  - [UI-K3s](https://github.com/rancher/elemental/actions/runs/20990687486)  :white_check_mark: