### PR TITLE
ci/ui: Fix RKE2 upgrade channel to maintenance

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -34,7 +34,7 @@ describe('Upgrade tests', () => {
   });
 
   filterTests(['upgrade'], () => {
-    // Add dev OS Version Channel if stable operator is installed
+    // Add maintenance (new dev) OS Version Channel if stable operator is installed
     // because we do not update the operator in RKE2 UI test so far
     // Only RKE2 tests use os version channel
     if (utils.isK8sVersion('rke2')) {
@@ -43,8 +43,8 @@ describe('Upgrade tests', () => {
         cy.deleteAllResources();
       });
 
-      it('Add staging channel for RKE2 upgrade', () => {
-        cy.addOsVersionChannel('staging');
+      it('Add maintenance channel for RKE2 upgrade', () => {
+        cy.addOsVersionChannel('maintenance');
       });
     }
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -378,10 +378,10 @@ Cypress.Commands.add('addOsVersionChannel', (channelVersion: string) => {
 
   switch (channelVersion) {
     case "stable":
-      channelRepo = 'registry.suse.com/rancher/elemental-channel/sl-micro:6.0-baremetal';
+      channelRepo = 'registry.suse.com/rancher/elemental-channel/sl-micro:6.2-baremetal'
       break;
-    case "staging":
-      channelRepo = 'registry.opensuse.org/isv/rancher/elemental/staging/containers/rancher/elemental-unstable-channel:latest';
+    case "maintenance":
+      channelRepo ='registry.opensuse.org/isv/rancher/elemental/maintenance/6.2/containers/rancher/elemental-unstable-channel:latest';
       break;
     default:
       cy.log("Channel not found");


### PR DESCRIPTION
Dev does not exist anymore, we have to use `maintenance`.

## Verification run
[UI-RKE2-Upgrade](https://github.com/rancher/elemental/actions/runs/21279916871/job/61247307183)
Test failed due to issue with [SUC](https://github.com/rancher/elemental/actions/runs/21279916871/job/61247307183)