### PR TITLE
ci/ui: bump cypress from 13 to 15

### DIFF
--- a/.github/workflows/sub_ui.yaml
+++ b/.github/workflows/sub_ui.yaml
@@ -207,7 +207,7 @@ jobs:
           BOOT_TYPE: ${{ inputs.boot_type }}
           BROWSER: chrome
           CHARTMUSEUM_REPO: http://${{ inputs.public_fqdn }}
-          CYPRESS_DOCKER: 'cypress/included:13.9.0'
+          CYPRESS_DOCKER: 'cypress/included:15.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}
           K8S_UPSTREAM_VERSION: ${{ inputs.k8s_upstream_version }}
@@ -296,7 +296,7 @@ jobs:
           BOOT_TYPE: ${{ inputs.boot_type }}
           BROWSER: firefox
           CHARTMUSEUM_REPO: http://${{ inputs.public_fqdn }}
-          CYPRESS_DOCKER: 'cypress/included:13.9.0'
+          CYPRESS_DOCKER: 'cypress/included:15.9.0'
           CYPRESS_TAGS: ${{ inputs.cypress_tags }}
           ELEMENTAL_DEV_VERSION: ${{ steps.install_chartmuseum.outputs.operator_dev_version }}
           ELEMENTAL_UI_VERSION: ${{ inputs.elemental_ui_version }}

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -23,8 +23,8 @@
   "homepage": "https://github.com/rancher/elemental#readme",
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "1.2.1",
-    "cy-verify-downloads": "^0.1.8",
-    "cypress": "^13.7.3",
+    "cy-verify-downloads": "^0.3.0",
+    "cypress": "^15.9.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",


### PR DESCRIPTION
Bump Cypress version from 13.9 to 15.9

## Verification run
[UI-K3S](https://github.com/rancher/elemental/actions/runs/21282875014) ✅ 