### PR TITLE
ci/cli: install Traefik v3.6.6 on RKE2 cluster

### DIFF
--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -18,7 +18,7 @@ on:
         type: boolean
       k8s_downstream_version:
         description: Rancher cluster downstream version to use
-        default: '"v1.34.2+k3s1"'
+        default: '"v1.34.2+rke2r1"'
         type: string
       k8s_upstream_version:
         description: Rancher cluster upstream version to use

--- a/tests/e2e/app_test.go
+++ b/tests/e2e/app_test.go
@@ -95,8 +95,13 @@ var _ = Describe("E2E - Install a simple application", Label("install-app"), fun
 				RunHelmCmdWithRetry("repo", "add", "traefik", "https://traefik.github.io/charts")
 				RunHelmCmdWithRetry("repo", "update")
 
+				// Latest version of Traefik (>3.6.6) cannot be installed (changes in variables)
+				// As this is just a simple application test, it is easier to force the correct
+				// version to use, eg. 3.6.6 but the app version is different from the chart version!
+				// App v3.6.6 => chart v38.0.2
 				flags := []string{
 					"upgrade", "--install", "traefik", "traefik/traefik",
+					"--version", "38.0.2",
 					"--namespace", traefikNS,
 					"--create-namespace",
 					"--set", "ports.web.redirections.entryPoint.to=websecure",


### PR DESCRIPTION
Latest version of Traefik cannot be installed (changes in variables). As this is just a simple application test, it is easier to force the correct version to use.

It should fix this kind of issue: https://github.com/rancher/elemental/actions/runs/21519113515/job/62005256945.

Verification run:
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/21523258277) :white_check_mark: