### PR TITLE
ci/cli: fix simple app deployment

### DIFF
--- a/tests/e2e/app_test.go
+++ b/tests/e2e/app_test.go
@@ -141,6 +141,10 @@ var _ = Describe("E2E - Install a simple application", Label("install-app"), fun
 			err := kubectl.Apply("default", appYaml)
 			Expect(err).To(Not(HaveOccurred()))
 		})
+
+		By("Waiting for all pods", func() {
+			WaitForAllPods()
+		})
 	})
 })
 
@@ -156,6 +160,10 @@ var _ = Describe("E2E - Checking a simple application", Label("check-app"), func
 		defer os.Remove(kubeConfig)
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(kubeConfig).To(Not(BeEmpty()))
+
+		By("Waiting for all pods", func() {
+			WaitForAllPods()
+		})
 
 		By("Scaling the deployment to the number of nodes", func() {
 			var nodeList string

--- a/tests/e2e/reset_test.go
+++ b/tests/e2e/reset_test.go
@@ -30,6 +30,14 @@ var _ = Describe("E2E - Test the reset feature", Label("reset"), func() {
 		// Report to Qase
 		testCaseID = 54
 
+		By("Waiting for all pods", func() {
+			WaitForAllPods()
+		})
+
+		By("Checking cluster state", func() {
+			WaitCluster(clusterNS, clusterName)
+		})
+
 		// Get the machine inventory name list
 		machineInventory, err := kubectl.RunWithoutErr("get", "MachineInventory",
 			"--namespace", clusterNS,


### PR DESCRIPTION
Check that the cluster/app deployment is in a good state before starting the next test. It should also reduce the number of sporadic failure during `reset` test.

Verification run:
- [CLI-K3s](https://github.com/rancher/elemental/actions/runs/21897553818) :white_check_mark:
- [CLI-K3s-upgrade](https://github.com/rancher/elemental/actions/runs/21874535716) :white_check_mark:
- [CLI-RKE2](https://github.com/rancher/elemental/actions/runs/21897565756) :white_check_mark:
- [CLI-RKE2-upgrade](https://github.com/rancher/elemental/actions/runs/21899029832) :x:

**NOTE**: multiple sporadic failures in the `CLI-RKE2-upgrade` test but not always in the same steps and doesn't seem related to this PR.