### PR TITLE
ci/ui: Update tests for compat with Rancher 2.14

### DIFF
--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -50,7 +50,7 @@ jobs:
       ca_type: selfsigned
       cypress_tags: main
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       operator_install_type: ui

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -50,7 +50,7 @@ jobs:
       ca_type: private
       cypress_tags: main
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      elemental_ui_version: dev
+      elemental_ui_version: stable
       k8s_downstream_version: ${{ matrix.k8s_downstream_version }}
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       operator_install_type: ui

--- a/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/deploy_app.spec.ts
@@ -51,7 +51,7 @@ filterTests(['main'], () => {
         cy.get('.nav').contains('Apps').click();
         cy.contains('Charts').click();
         cy.contains(myAppToInstall, { timeout: 30000 }).click();
-        if (isRancherManagerVersion('2.13')) {
+        if (isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
           cy.getBySel('chart-header-title').should('contain.text', myAppToInstall);
           cy.getBySel('btn-chart-install').click();
         } else {

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -49,7 +49,7 @@ filterTests(['main', 'upgrade'], () => {
         cy.contains('Extensions')
           .click();
         cy.contains('elemental');
-        if (isRancherManagerVersion('2.13')) {
+        if (isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
           cy.get('[data-testid="item-card-cluster/rancher-ui-plugin-charts/elemental"]').within(() => {
             cy.get('[data-testid="rc-item-card-action"]')
             //.getBySel('rc-item-card-action')
@@ -68,7 +68,7 @@ filterTests(['main', 'upgrade'], () => {
         cy.contains('Installing');
         cy.contains('Extensions changed - reload required', { timeout: 40000 });
         cy.clickButton('Reload');
-        if (isRancherManagerVersion('2.13')) {
+        if (isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
           cy.getBySel('btn-installed')
             .click();
           cy.getBySel('item-card-header-title')

--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -48,6 +48,9 @@ filterTests(['main', 'upgrade'], () => {
         // TODO: create a function to install any plugin and not elemental only
         cy.contains('Extensions')
           .click();
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(60000);
+        cy.reload();
         cy.contains('elemental');
         if (isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
           cy.get('[data-testid="item-card-cluster/rancher-ui-plugin-charts/elemental"]').within(() => {

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-operator.spec.ts
@@ -41,7 +41,7 @@ describe('Elemental operator upgrade tests', () => {
         it('Upgrade Elemental operator', () => {
           cy.contains('local').click();
           cy.get('.nav').contains('Apps').click();
-          if (utils.isRancherManagerVersion('2.12')|| (utils.isRancherManagerVersion('2.13'))) {
+          if (utils.isRancherManagerVersion('2.12')|| (utils.isRancherManagerVersion('2.13') || (utils.isRancherManagerVersion('2.14')))) {
             cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click()
           } else {
             cy.get('.color1').contains('Elemental').click()

--- a/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade-ui-extension.spec.ts
@@ -39,7 +39,7 @@ describe('UI extension upgrade tests', () => {
 
       qase(56,
         it('Upgrade Elemental UI extension', () => {
-          if (utils.isRancherManagerVersion('v2.13')) {
+          if (utils.isRancherManagerVersion('v2.13') || utils.isRancherManagerVersion('v2.14')) {
             cy.visit('c/local/uiplugins#installed');
             cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
             cy.get('[data-testid="item-card-cluster/elemental-ui/elemental"]').click();

--- a/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/upgrade.spec.ts
@@ -110,7 +110,7 @@ describe('Upgrade tests', () => {
         cy.getBySel('cluster-target').click();
         // As there is already an upgrade group targeting the cluster,
         // the cluster should not be available in the dropdown
-        if (utils.isRancherManagerVersion('v2.13')) {
+        if (utils.isRancherManagerVersion('v2.13') || utils.isRancherManagerVersion('v2.14')) {
           cy.get('.no-options-slot').should('contain', 'No options');
         } else {
           cy.get('#vs4__listbox').should('not.contain', clusterName);

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -29,7 +29,7 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-qase-reporter": "1.4.1",
-    "cypress-slow-down": "^1.3.1",
+    "cypress-slow-down": "1.3.1",
     "dotenv": "^10.0.0",
     "typescript": "^4.5.2"
   },

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@rancher-ecp-qa/cypress-library": "2.1.0",
     "cy-verify-downloads": "^0.3.0",
-    "cypress": "^15.9.0",
+    "cypress": "15.9.0",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-plugin-tab": "^1.0.5",

--- a/tests/cypress/latest/support/elemental.ts
+++ b/tests/cypress/latest/support/elemental.ts
@@ -24,7 +24,7 @@ export class Elemental {
   // Make sure we get all menus
   checkElementalNav(): void {
     // Open advanced accordion
-    if (isRancherManagerVersion('2.12') || isRancherManagerVersion('2.13')) {
+    if (isRancherManagerVersion('2.12') || isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
       cy.get('.accordion-item > .icon').eq(0).click();
     } else {
       cy.get('div.header > i').eq(0).click();
@@ -59,7 +59,10 @@ export class Elemental {
     cy.get('.nav').contains('Apps').click();
 
     if (isCypressTag('main') && !isOperatorVersion('marketplace')) {
-      if (isRancherManagerVersion('2.12')|| (isRancherManagerVersion('2.13'))) {
+      if (isRancherManagerVersion('2.14')) {
+        cy.getBySel("filter-panel-filter-group").contains('elemental-operator').click();
+      }
+      if (isRancherManagerVersion('2.12') || (isRancherManagerVersion('2.13') || (isRancherManagerVersion('2.14')))) {
         cy.get('[data-testid="item-card-cluster/elemental-operator/elemental-operator"]').click()
       } else {
         cy.get('.color1').contains('Elemental').click()


### PR DESCRIPTION
Add Rancher 2.14 conditions and other small fixes

## Verification run
[UI-K3S-2.13.3](https://github.com/rancher/elemental/actions/runs/23442065266/job/68195690980) ✅ 
2.14 cannot be totally tested due to this issue https://github.com/rancher/elemental-operator/issues/972