### PR TITLE
Fix WaitForAllPods and bump backup-restore-operator

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -709,11 +709,20 @@ Wait for all pods to be Running/Succeeded in the current K8s cluster
   - @returns Nothing, the function will fail through Ginkgo in case of issue
 */
 func WaitForAllPods() {
+	// Log pods list, useful for debugging
+	podDetails, _ := kubectl.RunWithoutErr("get", "pod", "--all-namespaces")
+	GinkgoWriter.Printf("%s\n", podDetails)
+
 	okStatus := strings.NewReplacer("Running", "", "Succeeded", "", "Completed", "")
 	Eventually(func() string {
 		podStatus, _ := kubectl.RunWithoutErr("get", "pod", "--all-namespaces",
 			"-o", "jsonpath={.items[*].status.phase}")
-		return strings.TrimSpace(okStatus.Replace(podStatus))
+		s := strings.TrimSpace(okStatus.Replace(podStatus))
+
+		// Log pods status, useful for debugging
+		GinkgoWriter.Printf("Pods Status: %s\n", s)
+
+		return s
 	}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeEmpty())
 }
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -308,8 +308,11 @@ func InstallBackupOperator(k *kubectl.Kubectl) {
 
 		// backupRscSet should be used for newer versions
 		switch {
+		case strings.Contains(rancherVersion, ":v2.14"):
+			backupRestoreVersion = "v9.0.1"
+			backupRscSet = "rancher-resource-set-full"
 		case strings.Contains(rancherVersion, ":v2.13"):
-			backupRestoreVersion = "v9.0.0"
+			backupRestoreVersion = "v9.0.1"
 			backupRscSet = "rancher-resource-set-full"
 		case strings.Contains(rancherVersion, ":v2.12"):
 			backupRestoreVersion = "v8.1.1"

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -709,21 +709,12 @@ Wait for all pods to be Running/Succeeded in the current K8s cluster
   - @returns Nothing, the function will fail through Ginkgo in case of issue
 */
 func WaitForAllPods() {
-	// Extract list of pods
-	pods, _ := kubectl.RunWithoutErr("get", "pod", "--all-namespaces",
-		"-o", "jsonpath={.items[*].metadata.name}")
-
-	for _, p := range strings.Fields(pods) {
-		Eventually(func() string {
-			// We have to search for p in all namespaces as we don't know them in advance
-			status, _ := kubectl.RunWithoutErr("get", "pod", "--all-namespaces",
-				"-o", "jsonpath={.items[?(@.metadata.name==\""+p+"\")].status.phase}")
-			return status
-		}, tools.SetTimeout(8*time.Minute), 30*time.Second).Should(Or(
-			ContainSubstring("Running"),
-			ContainSubstring("Succeeded"),
-		))
-	}
+	okStatus := strings.NewReplacer("Running", "", "Succeeded", "", "Completed", "")
+	Eventually(func() string {
+		podStatus, _ := kubectl.RunWithoutErr("get", "pod", "--all-namespaces",
+			"-o", "jsonpath={.items[*].status.phase}")
+		return strings.TrimSpace(okStatus.Replace(podStatus))
+	}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeEmpty())
 }
 
 /*


### PR DESCRIPTION
The recently  added `WaitForAllPods` function sporadically fails: this is because the list of pods list is created and then the status checked but meanwhile some pod changed.

This PR fix this by checking pods/ status at once. The PR also outputted pods' status to allow better debugging.

Backup-restore operator is also bumped to v9.0.1 and this version is also used for Rancher Manager v2.14.