### PR TITLE
Enable custom channel by default

### DIFF
--- a/tests/assets/osChannel.yaml
+++ b/tests/assets/osChannel.yaml
@@ -5,6 +5,7 @@ metadata:
   # namespace: fleet-default
 spec:
   deleteNoLongerInSyncVersions: true
+  enabled: true
   options:
     image: %OS_CHANNEL%
   syncInterval: 1h


### PR DESCRIPTION
Without the channel being enabled the synchronization does not happen and no managedosversions are created. This is relevant for testing specific OS versions in manual test workflows.