### PR TITLE
ci/cli: add Rancher v2.14 backup/restore support

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -309,7 +309,7 @@ func InstallBackupOperator(k *kubectl.Kubectl) {
 		// backupRscSet should be used for newer versions
 		switch {
 		case strings.Contains(rancherVersion, ":v2.14"):
-			backupRestoreVersion = "v9.0.1"
+			backupRestoreVersion = "v10.0.0-rc.1"
 			backupRscSet = "rancher-resource-set-full"
 		case strings.Contains(rancherVersion, ":v2.13"):
 			backupRestoreVersion = "v9.0.1"


### PR DESCRIPTION
Rancher v2.14 uses a newer version of CAPI provider, so we need to use the appropriate version of backup-restore operator.