### PR TITLE
Checkbox to choose normal or spot runner template

### DIFF
--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -23,6 +23,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Every Friday at 2am UTC (9pm in us-central1)
     - cron: '0 2 * * 5'
@@ -49,5 +56,6 @@ jobs:
       node_number: 3
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli
       zone: us-central1-a

--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -23,6 +23,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Every Friday at 3am UTC (10pm in us-central1)
     - cron: '0 3 * * 5'
@@ -47,5 +54,6 @@ jobs:
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: airgap
       zone: us-central1-b

--- a/.github/workflows/cli-k3s-downgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-downgrade-matrix.yaml
@@ -23,6 +23,13 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   cli:
@@ -47,6 +54,7 @@ jobs:
       node_number: 3
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: stable/latest
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli
       # Use the version just below the stable one
       upgrade_image: registry.suse.com/suse/sl-micro/6.1/baremetal-os-container:latest

--- a/.github/workflows/cli-k3s-ibs_stable.yaml
+++ b/.github/workflows/cli-k3s-ibs_stable.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   cli:
@@ -45,4 +52,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -35,6 +35,13 @@ on:
         description: Allow reset test (mainly used on CLI tests)
         default: false
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Monday and Wednesday at 2am UTC (9pm in us-central1)
     - cron: '0 2 * * 1,3'
@@ -66,6 +73,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
+      runner_template: ${{ inputs.runner_template }}
       sequential: ${{ matrix.sequential }}
       test_type: cli
       zone: us-central1-a

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version to upgrade to
         default: '"head/2.13"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Monday and Wednesday at 3am UTC (10pm in us-central1)
     - cron: '0 3 * * 1,3'
@@ -59,6 +66,7 @@ jobs:
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-upgrade-workflow.yaml
@@ -35,6 +35,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
       upgrade_image:
         description: OS image to use during the upgrade
         default: registry.opensuse.org/isv/rancher/elemental/maintenance/6.2/containers/suse/sl-micro/6.2/baremetal-os-container:latest
@@ -63,6 +70,7 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_upgrade: ${{ inputs.rancher_upgrade }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli
       upgrade_image: ${{ inputs.upgrade_image }}
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/cli-obs-manual-workflow.yaml
+++ b/.github/workflows/cli-obs-manual-workflow.yaml
@@ -38,6 +38,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
       sequential:
         description: Defines if bootstrapping is done sequentially (true) or in parallel (false)
         default: false
@@ -61,5 +68,6 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       sequential: ${{ inputs.sequential }}
       test_type: cli

--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -19,6 +19,13 @@ on:
       qase_run_id:
         description: Qase run ID where the results will be reported
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Every Friday at 4am UTC (11pm in us-central1)
     - cron: '0 4 * * 5'
@@ -44,6 +51,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: prime/latest
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       sequential: false
       test_type: cli
       zone: us-central1-f

--- a/.github/workflows/cli-rke2-ibs_stable.yaml
+++ b/.github/workflows/cli-rke2-ibs_stable.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: prime/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   cli:
@@ -46,5 +53,6 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       snap_type: loopdevice
       test_type: cli

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -35,6 +35,13 @@ on:
         description: Allow reset test (mainly used on CLI tests)
         default: false
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Monday and Wednesday at 4am UTC (11pm in us-central1)
     - cron: '0 4 * * 1,3'
@@ -66,6 +73,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
+      runner_template: ${{ inputs.runner_template }}
       sequential: ${{ matrix.sequential }}
       test_type: cli
       zone: us-central1-c

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version to upgrade to
         default: '"head/2.13"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Monday and Wednesday at 5am UTC (12am in us-central1)
     - cron: '0 5 * * 1,3'
@@ -59,6 +66,7 @@ jobs:
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: prime/latest
       reset: true
+      runner_template: ${{ inputs.runner_template }}
       test_type: cli
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/sub_create-runner.yaml
+++ b/.github/workflows/sub_create-runner.yaml
@@ -92,8 +92,9 @@ jobs:
           typeset -i i=0
           while true; do
             # Get public IP
-            PUBLIC_IP=$(gcloud compute instances list 2> /dev/null \
-                        | awk '/${{ steps.generator.outputs.runner_hostname }}/ {print $6}')
+            PUBLIC_IP=$(gcloud compute instances describe ${{ steps.generator.outputs.runner_hostname }} \
+                        --zone ${{ inputs.zone }} \
+                        --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
 
             # Exit if we reach the timeout or if IP is set
             if (( ++i > 10 )) || [[ -n "${PUBLIC_IP}" ]]; then

--- a/.github/workflows/ui-k3s-ibs_stable.yaml
+++ b/.github/workflows/ui-k3s-ibs_stable.yaml
@@ -32,6 +32,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   ui:
@@ -52,4 +59,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Tuesday and Thursday at 2am UTC (9pm in us-central1)
     - cron: '0 2 * * 2,4'
@@ -58,5 +65,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       zone: us-central1-a

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"stable/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Tuesday and Thursday at 3am UTC (10pm in us-central1)
     - cron: '0 3 * * 2,4'
@@ -58,6 +65,7 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/ui-marketplace-upgrade-workflow.yaml
+++ b/.github/workflows/ui-marketplace-upgrade-workflow.yaml
@@ -38,6 +38,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
       upgrade_from_version:
         description: Elemental operator version to upgrade from
         type: string
@@ -64,5 +71,6 @@ jobs:
       proxy: none
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       upgrade_from_version: ${{ inputs.upgrade_from_version }}

--- a/.github/workflows/ui-marketplace-workflow.yaml
+++ b/.github/workflows/ui-marketplace-workflow.yaml
@@ -43,6 +43,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   ui:
@@ -66,4 +73,5 @@ jobs:
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_git_chart: ${{ inputs.rancher_git_chart }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui

--- a/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-upgrade-workflow.yaml
@@ -35,6 +35,13 @@ on:
         description: Channel to use for the Elemental OS upgrade
         default: maintenance/6.2
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   ui:
@@ -54,6 +61,7 @@ jobs:
       proxy: ${{ inputs.proxy }}
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       ui_account: user
       upgrade_os_channel: ${{ inputs.upgrade_os_channel }}

--- a/.github/workflows/ui-obs-manual-workflow.yaml
+++ b/.github/workflows/ui-obs-manual-workflow.yaml
@@ -43,6 +43,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   ui:
@@ -64,4 +71,5 @@ jobs:
       proxy: ${{ inputs.proxy }}
       qase_run_id: auto
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui

--- a/.github/workflows/ui-rke2-ibs_stable.yaml
+++ b/.github/workflows/ui-rke2-ibs_stable.yaml
@@ -28,6 +28,13 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
 
 jobs:
   ui:
@@ -48,4 +55,5 @@ jobs:
       operator_repo: oci://registry.suse.com/rancher
       qase_run_id: ${{ inputs.qase_run_id }}
       rancher_version: ${{ inputs.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"prime/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Tuesday and Thursday at 4am UTC (11pm in us-central1)
     - cron: '0 4 * * 2,4'
@@ -58,5 +65,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       zone: us-central1-c

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -27,6 +27,13 @@ on:
         description: Rancher Manager channel/version/head_version to use
         default: '"prime/latest"'
         type: string
+      runner_template:
+        description: Runner template to use
+        default: elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+        type: choice
+        options:
+          - elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5
+          - elemental-e2e-ci-runner-x86-64-template-n2-standard-16-v5
   schedule:
     # Tuesday and Thursday at 5am UTC (12am in us-central1)
     - cron: '0 5 * * 2,4'
@@ -59,6 +66,7 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
+      runner_template: ${{ inputs.runner_template }}
       test_type: ui
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest


### PR DESCRIPTION
Sometimes we need to use normal instances to avoid GCP to reclaim the VMs and killed the job.

## Verification run
Standard VM [UI-Marketplace](https://github.com/rancher/elemental/actions/runs/24880936010) ✅ 
Standard VM [UI-K3S](https://github.com/rancher/elemental/actions/runs/24880371157) ✅ 
Spot VM [UI-K3S](https://github.com/rancher/elemental/actions/runs/24890081728)