### PR TITLE
ci: Fix gcloud instance create

### DIFF
--- a/.github/workflows/cli-full-backup-restore-matrix.yaml
+++ b/.github/workflows/cli-full-backup-restore-matrix.yaml
@@ -56,6 +56,6 @@ jobs:
       node_number: 3
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: cli
       zone: us-central1-a

--- a/.github/workflows/cli-k3s-airgap-matrix.yaml
+++ b/.github/workflows/cli-k3s-airgap-matrix.yaml
@@ -54,6 +54,6 @@ jobs:
       k8s_upstream_version: ${{ matrix.k8s_upstream_version }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: airgap
       zone: us-central1-b

--- a/.github/workflows/cli-k3s-matrix.yaml
+++ b/.github/workflows/cli-k3s-matrix.yaml
@@ -73,7 +73,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       sequential: ${{ matrix.sequential }}
       test_type: cli
       zone: us-central1-a

--- a/.github/workflows/cli-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/cli-k3s-upgrade-matrix.yaml
@@ -66,7 +66,7 @@ jobs:
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: stable/latest
       reset: true
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: cli
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/cli-regression-matrix.yaml
+++ b/.github/workflows/cli-regression-matrix.yaml
@@ -51,7 +51,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: prime/latest
       reset: true
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       sequential: false
       test_type: cli
       zone: us-central1-f

--- a/.github/workflows/cli-rke2-matrix.yaml
+++ b/.github/workflows/cli-rke2-matrix.yaml
@@ -73,7 +73,7 @@ jobs:
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
       reset: ${{ matrix.reset }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       sequential: ${{ matrix.sequential }}
       test_type: cli
       zone: us-central1-c

--- a/.github/workflows/cli-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/cli-rke2-upgrade-matrix.yaml
@@ -66,7 +66,7 @@ jobs:
       rancher_upgrade: ${{ matrix.rancher_upgrade }}
       rancher_version: prime/latest
       reset: true
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: cli
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/ui-k3s-matrix.yaml
+++ b/.github/workflows/ui-k3s-matrix.yaml
@@ -65,6 +65,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: ui
       zone: us-central1-a

--- a/.github/workflows/ui-k3s-upgrade-matrix.yaml
+++ b/.github/workflows/ui-k3s-upgrade-matrix.yaml
@@ -65,7 +65,7 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: ui
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest

--- a/.github/workflows/ui-rke2-matrix.yaml
+++ b/.github/workflows/ui-rke2-matrix.yaml
@@ -65,6 +65,6 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: ui
       zone: us-central1-c

--- a/.github/workflows/ui-rke2-upgrade-matrix.yaml
+++ b/.github/workflows/ui-rke2-upgrade-matrix.yaml
@@ -66,7 +66,7 @@ jobs:
       proxy: ${{ inputs.proxy || 'elemental' }}
       qase_run_id: ${{ github.event_name == 'schedule' && 'auto' || inputs.qase_run_id }}
       rancher_version: ${{ matrix.rancher_version }}
-      runner_template: ${{ inputs.runner_template }}
+      runner_template: ${{ github.event_name == 'schedule' && 'elemental-e2e-ci-runner-spot-x86-64-template-n2-standard-16-v5' || inputs.runner_template }}
       test_type: ui
       # Always use the IBS images upn the OBS ones
       upgrade_image: registry.suse.com/suse/sl-micro/6.2/baremetal-os-container:latest


### PR DESCRIPTION
The scheduled tests are failing with the following error:

```
ERROR: (gcloud.compute.instances.create) argument --source-instance-template: expected one argument'
```

The input for runner_template to the action also look empty:

```
 Inputs
    runner_template:
    zone: us-central1-a
```

Looking at [1] it seems the default value is not passed to scheduled
actions. This fix picks the default choice for runner_template for
scheduled actions.

[1] https://stackoverflow.com/questions/73404033/how-to-keep-default-action-input-if-parameter-passed-is-empty-in-github-action

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
