### PR TITLE
ci/ui: Rename plugin to SUSE OS Management

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/elemental_plugin.spec.ts
@@ -51,7 +51,7 @@ filterTests(['main', 'upgrade'], () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(60000);
         cy.reload();
-        cy.contains('elemental');
+        cy.contains('SUSE OS Management');
         if (isRancherManagerVersion('2.13') || isRancherManagerVersion('2.14')) {
           cy.get('[data-testid="item-card-cluster/rancher-ui-plugin-charts/elemental"]').within(() => {
             cy.get('[data-testid="rc-item-card-action"]')
@@ -62,7 +62,7 @@ filterTests(['main', 'upgrade'], () => {
           });
 
         } else {
-          cy.contains('elemental');
+          cy.contains('SUSE OS Management');
           cy.get('.plugin')
             .contains('Install')
             .click();
@@ -78,7 +78,7 @@ filterTests(['main', 'upgrade'], () => {
         } else {
           cy.get('.plugins')
             .children()
-            .should('contain', 'elemental')
+            .should('contain', 'SUSE OS Management')
             .and('contain', 'Uninstall');
         }
       })


### PR DESCRIPTION
Elemental extension has been renamed to SUSE OS Management.

## Verification run:
Elemental plugin step is green:
https://github.com/rancher/elemental/actions/runs/27952073158/job/82711405701
<img width="1848" height="1120" alt="image" src="https://github.com/user-attachments/assets/9f6a937e-dbee-4265-8121-e7dc76fc2e8b" />
