### PR TITLE
Bump google-github-actions

### DIFF
--- a/.github/workflows/sub_airgap.yaml
+++ b/.github/workflows/sub_airgap.yaml
@@ -86,13 +86,13 @@ jobs:
 
       - name: Authenticate to GCP
         id: authenticate
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.credentials }}
 
       - name: Setup gcloud
         id: setup_gcloud
-        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Download QCOW2 VM image
         id: download_qcow2

--- a/.github/workflows/sub_clean-and-delete-runner.yaml
+++ b/.github/workflows/sub_clean-and-delete-runner.yaml
@@ -25,12 +25,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.credentials }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Delete runner
         run: |

--- a/.github/workflows/sub_create-runner.yaml
+++ b/.github/workflows/sub_create-runner.yaml
@@ -57,12 +57,12 @@ jobs:
           echo "runner_label=${UUID//-}" >> ${GITHUB_OUTPUT}
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.credentials }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Create runner
         run: |


### PR DESCRIPTION
This solves the following error in github:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed, google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f.
```

Bumps the following actions:
* google-github-actions/auth to v3.0.0
* google-github-actions/setup-gcloud to v3.0.1